### PR TITLE
Scaffold repository layout, Helm chart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04	
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Provision CI environment
+        run: |
+          ansible-galaxy install geerlingguy.docker
+          ansible-galaxy install andrewrothstein.k3d
+          ansible-galaxy install andrewrothstein.kubectl
+          ansible-galaxy install andrewrothstein.kubernetes-helm
+
+          # Delete files which may cause conflicts
+          sudo rm /usr/local/bin/kubectl
+
+          ansible-playbook --version
+          ansible-playbook --connection=local --inventory "127.0.0.1," -e 'ansible_python_interpreter=/usr/bin/python3' ci/playbook.yml
+
+      - name: Create Helm chart
+        run: |
+          set -e
+          helm lint .
+          helm package . -d ${{ github.workspace }}/bin 
+        working-directory: src/chart
+
+      - name: Upload Helm chart
+        uses: actions/upload-artifact@v2
+        with:
+          name: chart
+          path: |
+            ${{ github.workspace }}/bin/

--- a/ci/playbook.yml
+++ b/ci/playbook.yml
@@ -1,0 +1,16 @@
+- hosts: all
+  become: yes
+
+  roles:
+    # Install rootless Docker
+    - role: geerlingguy.docker
+      vars:
+        docker_install_compose: false
+        docker_users:
+          - "vagrant"
+
+    # Install the k3d binary
+    - role: andrewrothstein.k3d
+
+    # Install kubectl
+    - role: andrewrothstein.kubectl

--- a/src/chart/Chart.yaml
+++ b/src/chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: kaponata
+description: Kaponata manages your mobile device test farm for you, so you can run Appium tests at scale on iOS and Android devices.
+
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/src/chart/templates/_helpers.tpl
+++ b/src/chart/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kaponata.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kaponata.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kaponata.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/src/version.json
+++ b/src/version.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1",
+    "publicReleaseRefSpec": [
+        "^refs/heads/master$",
+        "^refs/heads/releases/*"
+    ]
+}


### PR DESCRIPTION
This PR scaffolds the repository layout.

It adds an (empty) Helm chart, and a GitHub action which will build and publish the Helm chart as an artifact.
It also adds an Ansible workflow which can be used to make sure all dependencies (such as k3d, kubectl, docker or helm) are installed.