### PR TITLE
Deploy Helm chart during CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,13 @@ jobs:
     runs-on: ubuntu-20.04	
     steps:
       - uses: actions/checkout@v2
-      
+        with:
+          fetch-depth: 0
+
       - uses: dotnet/nbgv@v0.4.0
         id: nbgv
-        working-directory: src
+        with:
+          path: src
 
       - name: Provision CI environment
         run: |
@@ -46,3 +49,21 @@ jobs:
           name: chart
           path: |
             ${{ github.workspace }}/bin/
+
+      - name: Create k3d cluster
+        run: |
+          set -e
+
+          k3d cluster create --api-port 6433 -p "80:80@loadbalancer"
+
+      - name: Deploy Helm chart
+        run: |
+          set -e
+
+          helm install kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
+
+      - name: Delete k3d cluster
+        run: |
+          set -e
+
+          k3d cluster delete

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-20.04	
     steps:
       - uses: actions/checkout@v2
+      
+      - uses: dotnet/nbgv@v0.4.0
+        id: nbgv
+        working-directory: src
 
       - name: Provision CI environment
         run: |
@@ -17,6 +21,7 @@ jobs:
           ansible-galaxy install andrewrothstein.k3d
           ansible-galaxy install andrewrothstein.kubectl
           ansible-galaxy install andrewrothstein.kubernetes-helm
+          ansible-galaxy install andrewrothstein.yq
 
           # Delete files which may cause conflicts
           sudo rm /usr/local/bin/kubectl
@@ -27,8 +32,12 @@ jobs:
       - name: Create Helm chart
         run: |
           set -e
+
+          yq e '.version="${{ steps.nbgv.outputs.SemVer2 }}"' -i Chart.yaml
+          yq e '.appVersion="${{ steps.nbgv.outputs.SemVer2 }}"' -i Chart.yaml
+
           helm lint .
-          helm package . -d ${{ github.workspace }}/bin 
+          helm package . -d ${{ github.workspace }}/bin
         working-directory: src/chart
 
       - name: Upload Helm chart

--- a/ci/playbook.yml
+++ b/ci/playbook.yml
@@ -14,3 +14,6 @@
 
     # Install kubectl
     - role: andrewrothstein.kubectl
+
+    # Install jq
+    - role: andrewrothstein.yq


### PR DESCRIPTION
- Set the Helm chart `appVersion` and `version` during CI, based on the output of `nbgv`.
- Deploy the Helm chart to a k3d cluster