### PR TITLE
Add iproxy image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,28 @@
+name: images
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        image:
+        - iproxy
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: dotnet/nbgv@v0.4.0
+        id: nbgv
+        with:
+          path: src
+
+      - name: Build Docker image
+        run: |
+          make
+        working-directory: src/${{ matrix.image }}

--- a/src/iproxy/Dockerfile
+++ b/src/iproxy/Dockerfile
@@ -1,0 +1,40 @@
+ARG BUILDCONTAINER
+
+FROM --platform=$BUILDPLATFORM $BUILDCONTAINER AS build
+
+ARG libplist_version=2.2.0
+ARG libusbmuxd_version=2.0.2
+ARG build=x86_64-linux-gnu
+
+WORKDIR /src
+
+RUN curl -L https://github.com/libimobiledevice/libplist/archive/${libplist_version}.tar.gz --output libplist-${libplist_version}.tar.gz
+RUN curl -L https://github.com/libimobiledevice/libusbmuxd/archive/${libusbmuxd_version}.tar.gz --output libusbmuxd-${libusbmuxd_version}.tar.gz
+
+RUN tar -xvzf libplist-${libplist_version}.tar.gz
+RUN tar -xvzf libusbmuxd-${libusbmuxd_version}.tar.gz
+
+WORKDIR /src/libplist-${libplist_version}
+
+RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$CROSS_TRIPLE --prefix=/usr \
+&& make \
+&& DESTDIR=$CROSS_ROOT/$CROSS_TRIPLE/sysroot/ make install \
+&& make install
+
+WORKDIR /src/libusbmuxd-${libusbmuxd_version}
+
+RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$CROSS_TRIPLE --prefix=/usr \
+&& make \
+&& DESTDIR=$CROSS_ROOT/$CROSS_TRIPLE/sysroot/ make install \
+&& make install
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+FROM gcr.io/distroless/base-debian10
+
+COPY --from=build /usr/lib/libplist-2.0.so.3 /usr/lib/
+COPY --from=build /usr/lib/libusbmuxd-2.0.so.6 /usr/lib/
+COPY --from=build /usr/bin/iproxy /usr/bin/
+
+ENTRYPOINT [ "/usr/bin/iproxy" ]

--- a/src/iproxy/Makefile
+++ b/src/iproxy/Makefile
@@ -1,0 +1,21 @@
+registry=quay.io/kaponata
+image=iproxy
+
+all: .arm64.docker-id .amd64.docker-id .version
+
+push: all
+	docker push $(registry)/$(image):latest-amd64
+	docker push $(registry)/$(image):latest-arm64
+	docker manifest create $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64 $(registry)/$(image):latest-arm64
+	docker manifest push $(registry)/$(image):$(shell cat .version)
+
+.version: .amd64.docker-id
+	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/iproxy --version | awk '{ print $$2 }' | tee .version
+
+.amd64.docker-id: Dockerfile
+	docker buildx build --platform linux/amd64 --build-arg BUILDCONTAINER=dockcross/linux-x64 . -t $(registry)/$(image):latest-amd64
+	docker images --no-trunc --quiet $(registry)/$(image):amd64-latest > .amd64.docker-id
+
+.arm64.docker-id: Dockerfile
+	docker buildx build --platform linux/arm64 --build-arg BUILDCONTAINER=dockcross/linux-arm64 . -t $(registry)/$(image):latest-arm64
+	docker images --no-trunc --quiet $(registry)/$(image):arm64-latest > .arm64.docker-id


### PR DESCRIPTION
- Build Docker image for `iproxy` for amd64 and arm64 Linux, and generate a multi-arch manifest
- Add a CI pipeline to validate the script