### PR TITLE
Add usbmuxd image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         image:
         - iproxy
+        - usbmuxd
     steps:
       - uses: actions/checkout@v2
         with:

--- a/src/iproxy/Dockerfile
+++ b/src/iproxy/Dockerfile
@@ -1,11 +1,26 @@
-ARG BUILDCONTAINER
-
-FROM --platform=$BUILDPLATFORM $BUILDCONTAINER AS build
+FROM --platform=$BUILDPLATFORM debian:10 AS build
 
 ARG libplist_version=2.2.0
 ARG libusbmuxd_version=2.0.2
 ARG build=x86_64-linux-gnu
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV build=x86_64-linux-gnu
+ARG host=aarch64-linux-gnu
+ARG arch=arm64
+
+# Add the host architecture if needed
+RUN if [ -n "$arch" ]; then dpkg --add-architecture $arch; fi
+
+# Core build tools
+RUN apt-get update \
+&& apt-get install -y make libtool pkg-config curl dpkg-dev
+
+# Install the cross-compiler toolchain if cross-compiling
+RUN if [ -n "$host" ]; then apt-get install -y g++-$host; fi
+
+# Download and compile
 WORKDIR /src
 
 RUN curl -L https://github.com/libimobiledevice/libplist/archive/${libplist_version}.tar.gz --output libplist-${libplist_version}.tar.gz
@@ -16,25 +31,23 @@ RUN tar -xvzf libusbmuxd-${libusbmuxd_version}.tar.gz
 
 WORKDIR /src/libplist-${libplist_version}
 
-RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$CROSS_TRIPLE --prefix=/usr \
+RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
 && make \
-&& DESTDIR=$CROSS_ROOT/$CROSS_TRIPLE/sysroot/ make install \
 && make install
 
 WORKDIR /src/libusbmuxd-${libusbmuxd_version}
 
-RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$CROSS_TRIPLE --prefix=/usr \
+RUN ./autogen.sh --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
 && make \
-&& DESTDIR=$CROSS_ROOT/$CROSS_TRIPLE/sysroot/ make install \
 && make install
-
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
 
 FROM gcr.io/distroless/base-debian10
 
-COPY --from=build /usr/lib/libplist-2.0.so.3 /usr/lib/
-COPY --from=build /usr/lib/libusbmuxd-2.0.so.6 /usr/lib/
+ARG host=aarch64-linux-gnu
+ARG arch=arm64
+
+COPY --from=build /usr/lib/$host/libplist-2.0.so.3 /usr/lib/$host/
+COPY --from=build /usr/lib/$host/libusbmuxd-2.0.so.6 /usr/lib/$host/
 COPY --from=build /usr/bin/iproxy /usr/bin/
 
 ENTRYPOINT [ "/usr/bin/iproxy" ]

--- a/src/usbmuxd/Dockerfile
+++ b/src/usbmuxd/Dockerfile
@@ -1,0 +1,88 @@
+FROM --platform=$BUILDPLATFORM debian:10 AS build
+
+ARG libusb_version=1.0.23
+ARG libplist_version=2.2.0
+ARG libusbmuxd_version=2.0.2
+ARG libimobiledevice_version=1.3.0
+ARG usbmuxd_version=1248a070f872e15a15b348150ff8bfb96491ddc3
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV build=x86_64-linux-gnu
+ARG host=aarch64-linux-gnu
+ARG arch=arm64
+
+# Add the host architecture if needed
+RUN if [ -n "$arch" ]; then dpkg --add-architecture $arch; fi
+
+# Core build tools
+RUN apt-get update \
+&& apt-get install -y make libtool pkg-config curl dpkg-dev
+
+# Install the cross-compiler toolchain if cross-compiling
+RUN if [ -n "$host" ]; then apt-get install -y g++-$host; fi
+
+# Install libssl for the host architecture
+RUN apt-get install -y libssl-dev:$arch
+
+WORKDIR /src
+RUN curl -L https://github.com/libusb/libusb/archive/v${libusb_version}.tar.gz --output libusb-${libusb_version}.tar.gz
+RUN curl -L https://github.com/libimobiledevice/libplist/archive/${libplist_version}.tar.gz --output libplist-${libplist_version}.tar.gz
+RUN curl -L https://github.com/libimobiledevice/libusbmuxd/archive/${libusbmuxd_version}.tar.gz --output libusbmuxd-${libusbmuxd_version}.tar.gz
+RUN curl -L https://github.com/libimobiledevice/libimobiledevice/archive/${libimobiledevice_version}.tar.gz --output libimobiledevice-${libimobiledevice_version}.tar.gz
+RUN curl -L https://github.com/libimobiledevice/usbmuxd/archive/${usbmuxd_version}.tar.gz --output usbmuxd-${usbmuxd_version}.tar.gz
+
+RUN tar -xvzf libusb-${libusb_version}.tar.gz
+RUN tar -xvzf libplist-${libplist_version}.tar.gz
+RUN tar -xvzf libusbmuxd-${libusbmuxd_version}.tar.gz
+RUN tar -xvzf libimobiledevice-${libimobiledevice_version}.tar.gz
+RUN tar -xvzf usbmuxd-${usbmuxd_version}.tar.gz
+
+WORKDIR /src/libusb-${libusb_version}
+
+RUN ./autogen.sh enable_udev=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+&& make \
+&& make install
+
+WORKDIR /src/libplist-${libplist_version}
+
+RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+&& make \
+&& make install
+
+WORKDIR /src/libusbmuxd-${libusbmuxd_version}
+
+RUN ./autogen.sh --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+&& make \
+&& make install
+
+WORKDIR /src/libimobiledevice-${libimobiledevice_version}
+
+RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+&& make \
+&& make install
+
+WORKDIR /src/usbmuxd-${usbmuxd_version}
+
+RUN ./autogen.sh --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+&& make \
+&& make install
+
+FROM gcr.io/distroless/base-debian10
+
+ARG host=aarch64-linux-gnu
+ARG arch=arm64
+
+COPY --from=build /usr/lib/$host/libusb-1.0.so.0 /usr/lib/$host/
+COPY --from=build /usr/lib/$host/libplist-2.0.so.3 /usr/lib/$host/
+COPY --from=build /usr/lib/$host/libusbmuxd-2.0.so.6 /usr/lib/$host/
+COPY --from=build /usr/lib/$host/libimobiledevice-1.0.so.6 /usr/lib/$host/
+COPY --from=build /usr/bin/idevice_id /usr/bin/
+COPY --from=build /usr/bin/idevicepair /usr/bin/
+COPY --from=build /usr/bin/ideviceinfo /usr/bin/
+
+COPY --from=build /usr/sbin/usbmuxd /usr/sbin/usbmuxd
+
+ENV USBMUXD_SOCKET_ADDRESS=127.0.0.1:27015
+
+ENTRYPOINT [ "/usr/sbin/usbmuxd", "-v", "-f", "-S", "0.0.0.0:27015" ]

--- a/src/usbmuxd/Makefile
+++ b/src/usbmuxd/Makefile
@@ -1,5 +1,5 @@
 registry=quay.io/kaponata
-image=iproxy
+image=usbmuxd
 
 all: .arm64.docker-id .amd64.docker-id .version
 
@@ -10,7 +10,7 @@ push: all
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/iproxy --version | awk '{ print $$2 }' | tee .version
+	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/usbmuxd --version | awk '{ print $$2 }' | tee .version
 
 .amd64.docker-id: Dockerfile
 	docker buildx build --platform linux/amd64 --build-arg host= --build-arg arch= . -t $(registry)/$(image):latest-amd64


### PR DESCRIPTION
This adds an amd64 and arm64 image for usbmuxd.

The arm64 image is cross-built form amd64 to arm64 using the Debian multi-arch features.