### PR TITLE
Add MuxerClient.ListenAsync

### DIFF
--- a/src/Kaponata.iOS.Tests/Muxer/DeviceAttachedMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/DeviceAttachedMessageTests.cs
@@ -23,5 +23,31 @@ namespace Kaponata.iOS.Tests.Muxer
         {
             Assert.Throws<ArgumentNullException>("data", () => DeviceAttachedMessage.Read(null));
         }
+
+        /// <summary>
+        /// The <see cref="DeviceAttachedMessage.Read(NSDictionary)"/> method propertly
+        /// parses its property list representation.
+        /// </summary>
+        [Fact]
+        public void Read_Works()
+        {
+            var message = DeviceAttachedMessage.Read((NSDictionary)PropertyListParser.Parse("Muxer/attached.xml"));
+            Assert.Equal(2, message.DeviceID);
+            Assert.Equal(MuxerMessageType.Attached, message.MessageType);
+            Assert.NotNull(message.Properties);
+
+            Assert.Equal(480000000, message.Properties.ConnectionSpeed);
+            Assert.Equal(MuxerConnectionType.USB, message.Properties.ConnectionType);
+            Assert.Equal(2, message.Properties.DeviceID);
+            Assert.Null(message.Properties.EscapedFullServiceName);
+            Assert.Equal(0, message.Properties.InterfaceIndex);
+            Assert.Null(message.Properties.IPAddress);
+            Assert.Equal(65539, message.Properties.LocationID);
+            Assert.Null(message.Properties.NetworkAddress);
+            Assert.Equal(0x12A8, message.Properties.ProductID);
+            Assert.Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", message.Properties.SerialNumber);
+            Assert.Null(message.Properties.UDID);
+            Assert.Null(message.Properties.USBSerialNumber);
+        }
     }
 }

--- a/src/Kaponata.iOS.Tests/Muxer/DeviceDetachedMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/DeviceDetachedMessageTests.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="DeviceDetachedMessageTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Muxer;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="DeviceDetachedMessage"/> class.
+    /// </summary>
+    public class DeviceDetachedMessageTests
+    {
+        /// <summary>
+        /// The <see cref="DeviceDetachedMessage.Read(NSDictionary)"/> method throws an
+        /// <see cref="ArgumentNullException"/> when passed a <see langword="null"/> value.
+        /// </summary>
+        [Fact]
+        public void Read_NullArgument_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>("data", () => DeviceDetachedMessage.Read(null));
+        }
+
+        /// <summary>
+        /// The <see cref="DeviceDetachedMessage.Read(NSDictionary)"/> method propertly
+        /// parses its property list representation.
+        /// </summary>
+        [Fact]
+        public void Read_Works()
+        {
+            var message = DeviceDetachedMessage.Read((NSDictionary)PropertyListParser.Parse("Muxer/detached.xml"));
+            Assert.Equal(2, message.DeviceID);
+            Assert.Equal(MuxerMessageType.Detached, message.MessageType);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Muxer/DevicePairedMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/DevicePairedMessageTests.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="DevicePairedMessageTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Muxer;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="DevicePairedMessageTests"/> class.
+    /// </summary>
+    public class DevicePairedMessageTests
+    {
+        /// <summary>
+        /// The <see cref="DevicePairedMessage.Read(NSDictionary)"/> method throws an
+        /// <see cref="ArgumentNullException"/> when passed a <see langword="null"/> value.
+        /// </summary>
+        [Fact]
+        public void Read_NullArgument_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>("data", () => DevicePairedMessage.Read(null));
+        }
+
+        /// <summary>
+        /// The <see cref="DevicePairedMessage.Read(NSDictionary)"/> method propertly
+        /// parses its property list representation.
+        /// </summary>
+        [Fact]
+        public void Read_Works()
+        {
+            var message = DevicePairedMessage.Read((NSDictionary)PropertyListParser.Parse("Muxer/paired.xml"));
+            Assert.Equal(3, message.DeviceID);
+            Assert.Equal(MuxerMessageType.Paired, message.MessageType);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Muxer/ListenMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/ListenMessageTests.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ListenMessageTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+using System.IO;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="ListenMessage"/> class.
+    /// </summary>
+    public class ListenMessageTests
+    {
+        /// <summary>
+        /// The <see cref="ListenMessage.ToPropertyList"/> method generates a valid property list representation of the object.
+        /// </summary>
+        [Fact]
+        public void ToPropertyList_Works()
+        {
+            var message = new ListenMessage()
+            {
+                BundleID = "com.apple.iTunes",
+                ClientVersionString = "usbmuxd-374.70",
+                ConnType = 1,
+                MessageType = MuxerMessageType.Listen,
+                ProgName = "iTunes",
+                kLibUSBMuxVersion = 3,
+            };
+
+            var dict = message.ToPropertyList();
+            var xml = dict.ToXmlPropertyList();
+
+            Assert.Equal(File.ReadAllText("Muxer/listen.xml"), xml);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
@@ -7,7 +7,7 @@ using Kaponata.iOS.Muxer;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
-using System.IO;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -118,6 +118,313 @@ namespace Kaponata.iOS.Tests.Muxer
                     Assert.Equal("cccccccccccccccccccccccccccccccccccccccc", device.Udid);
                 });
 
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> returns <see langword="false"/> when the muxer is unavailable.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_NoMuxer_ReturnsFalse_Async()
+        {
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync((MuxerProtocol)null);
+            var client = clientMock.Object;
+
+            Assert.False(await client.ListenAsync(null, null, null, default).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> returns <see langword="false"/> when the muxer closes the connection
+        /// after receiving the listen request.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_NoResponse_ReturnsFalse_Async()
+        {
+            var protocol = new Mock<MuxerProtocol>();
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<MuxerMessage>(), default))
+                .Returns(Task.CompletedTask)
+                .Callback<MuxerMessage, CancellationToken>((message, ct) =>
+                {
+                    var listenRequest = Assert.IsType<ListenMessage>(message);
+                })
+                .Verifiable();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync((MuxerMessage)null);
+
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
+            var client = clientMock.Object;
+
+            Assert.False(await client.ListenAsync(null, null, null, default).ConfigureAwait(false));
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> throws an exception when the muxer returns an error message.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_ErrorResponse_Throws_Async()
+        {
+            var protocol = new Mock<MuxerProtocol>();
+            protocol.Setup(p => p.WriteMessageAsync(It.IsAny<MuxerMessage>(), default))
+                .Returns(Task.CompletedTask)
+                .Callback<MuxerMessage, CancellationToken>((message, ct) =>
+                {
+                    var listenRequest = Assert.IsType<ListenMessage>(message);
+                })
+                .Verifiable();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(new ResultMessage() { Number = MuxerError.BadCommand });
+
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
+            var client = clientMock.Object;
+
+            await Assert.ThrowsAsync<MuxerException>(() => client.ListenAsync(null, null, null, default)).ConfigureAwait(false);
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> loops through all messages until the muxer closes the connection.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_ReadAll_Async()
+        {
+            var queue = new Queue<MuxerMessage>(
+                new MuxerMessage[]
+                {
+                    new ResultMessage() { Number = MuxerError.Success },
+                    new DeviceAttachedMessage() { DeviceID = 1 },
+                    new DevicePairedMessage() { DeviceID = 1 },
+                    new DeviceDetachedMessage() { DeviceID = 1 },
+                    new DeviceAttachedMessage() { DeviceID = 2 },
+                    new DevicePairedMessage() { DeviceID = 2 },
+                    new DeviceDetachedMessage() { DeviceID = 2 },
+                    null,
+                });
+
+            var protocol = new Mock<MuxerProtocol>();
+            protocol.Setup(p => p.WriteMessageAsync(It.IsAny<MuxerMessage>(), default))
+                .Returns(Task.CompletedTask)
+                .Callback<MuxerMessage, CancellationToken>((message, ct) =>
+                {
+                    var listenRequest = Assert.IsType<ListenMessage>(message);
+                })
+                .Verifiable();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(queue.Dequeue);
+
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
+            var client = clientMock.Object;
+
+            Assert.False(
+                await client.ListenAsync(
+                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    default).ConfigureAwait(false));
+
+            Assert.Empty(queue);
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> stops looping when the on attached callback instructs it to do so.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_StopsOnAttached_Async()
+        {
+            var queue = new Queue<MuxerMessage>(
+                new MuxerMessage[]
+                {
+                    new ResultMessage() { Number = MuxerError.Success },
+                    new DeviceAttachedMessage() { DeviceID = 1 },
+                    new DevicePairedMessage() { DeviceID = 1 },
+                    new DeviceDetachedMessage() { DeviceID = 1 },
+                    new DeviceAttachedMessage() { DeviceID = 2 },
+                    new DevicePairedMessage() { DeviceID = 2 },
+                    new DeviceDetachedMessage() { DeviceID = 2 },
+                    null,
+                });
+
+            var protocol = new Mock<MuxerProtocol>();
+            protocol.Setup(p => p.WriteMessageAsync(It.IsAny<MuxerMessage>(), default))
+                .Returns(Task.CompletedTask)
+                .Callback<MuxerMessage, CancellationToken>((message, ct) =>
+                {
+                    var listenRequest = Assert.IsType<ListenMessage>(message);
+                })
+                .Verifiable();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(queue.Dequeue);
+
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
+            var client = clientMock.Object;
+
+            Assert.True(
+                await client.ListenAsync(
+                    (onAttached) => { return Task.FromResult(onAttached.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
+                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    default).ConfigureAwait(false));
+
+            Assert.Equal(3, queue.Count);
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> stops looping when the on paired callback instructs it to do so.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_StopsOnPaired_Async()
+        {
+            var queue = new Queue<MuxerMessage>(
+                new MuxerMessage[]
+                {
+                    new ResultMessage() { Number = MuxerError.Success },
+                    new DeviceAttachedMessage() { DeviceID = 1 },
+                    new DevicePairedMessage() { DeviceID = 1 },
+                    new DeviceDetachedMessage() { DeviceID = 1 },
+                    new DeviceAttachedMessage() { DeviceID = 2 },
+                    new DevicePairedMessage() { DeviceID = 2 },
+                    new DeviceDetachedMessage() { DeviceID = 2 },
+                    null,
+                });
+
+            var protocol = new Mock<MuxerProtocol>();
+            protocol.Setup(p => p.WriteMessageAsync(It.IsAny<MuxerMessage>(), default))
+                .Returns(Task.CompletedTask)
+                .Callback<MuxerMessage, CancellationToken>((message, ct) =>
+                {
+                    var listenRequest = Assert.IsType<ListenMessage>(message);
+                })
+                .Verifiable();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(queue.Dequeue);
+
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
+            var client = clientMock.Object;
+
+            Assert.True(
+                await client.ListenAsync(
+                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached) => { return Task.FromResult(onDetached.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
+                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    default).ConfigureAwait(false));
+
+            Assert.Single(queue);
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MuxerClient.ListenAsync"/> stops looping when the on paired callback instructs it to do so.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchrounous test.
+        /// </returns>
+        [Fact]
+        public async Task ListenAsync_StopsOnDetached_Async()
+        {
+            var queue = new Queue<MuxerMessage>(
+                new MuxerMessage[]
+                {
+                    new ResultMessage() { Number = MuxerError.Success },
+                    new DeviceAttachedMessage() { DeviceID = 1 },
+                    new DevicePairedMessage() { DeviceID = 1 },
+                    new DeviceDetachedMessage() { DeviceID = 1 },
+                    new DeviceAttachedMessage() { DeviceID = 2 },
+                    new DevicePairedMessage() { DeviceID = 2 },
+                    new DeviceDetachedMessage() { DeviceID = 2 },
+                    null,
+                });
+
+            var protocol = new Mock<MuxerProtocol>();
+            protocol.Setup(p => p.WriteMessageAsync(It.IsAny<MuxerMessage>(), default))
+                .Returns(Task.CompletedTask)
+                .Callback<MuxerMessage, CancellationToken>((message, ct) =>
+                {
+                    var listenRequest = Assert.IsType<ListenMessage>(message);
+                })
+                .Verifiable();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(queue.Dequeue);
+
+            var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
+            {
+                CallBase = true,
+            };
+
+            clientMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
+            var client = clientMock.Object;
+
+            Assert.True(
+                await client.ListenAsync(
+                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening);  },
+                    (onPaired) => { return Task.FromResult(onPaired.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
+                    default).ConfigureAwait(false));
+
+            Assert.Equal(2, queue.Count);
             protocol.Verify();
         }
     }

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
@@ -96,7 +96,9 @@ namespace Kaponata.iOS.Tests.Muxer
 
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
-                .ReturnsAsync((NSDictionary)PropertyListParser.Parse("Muxer/devicelist-wifi.xml"));
+                .ReturnsAsync(
+                    DeviceListMessage.Read(
+                        (NSDictionary)PropertyListParser.Parse("Muxer/devicelist-wifi.xml")));
 
             var clientMock = new Mock<MuxerClient>(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance)
             {

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerExceptionTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerExceptionTests.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="MuxerExceptionTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="MuxerExceptionTests"/> class.
+    /// </summary>
+    public class MuxerExceptionTests
+    {
+        /// <summary>
+        /// The <see cref="MuxerException.MuxerException()"/> constructor works.
+        /// </summary>
+        [Fact]
+        public void Constructor_Works()
+        {
+            var ex = new MuxerException();
+            Assert.Equal("An unexpected usbmuxd exception occurred.", ex.Message);
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerException.MuxerException(string)"/> constructor works.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithMessage_Works()
+        {
+            var ex = new MuxerException("test.");
+            Assert.Equal("test.", ex.Message);
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerException.MuxerException(string, MuxerError)"/> constructor works.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithMessageAndCode_Works()
+        {
+            var ex = new MuxerException("test.", MuxerError.BadDevice);
+            Assert.Equal("test.", ex.Message);
+            Assert.Equal((int)MuxerError.BadDevice, ex.HResult);
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerException.MuxerException(string, MuxerError)"/> constructor works.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithMessageAndInner_Works()
+        {
+            var inner = new Exception();
+            var ex = new MuxerException("test.", inner);
+            Assert.Equal("test.", ex.Message);
+            Assert.Same(inner, ex.InnerException);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerMessageTests.cs
@@ -56,6 +56,7 @@ namespace Kaponata.iOS.Tests.Muxer
             Assert.IsType<DeviceDetachedMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/detached.xml")));
             Assert.IsType<DevicePairedMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/paired.xml")));
             Assert.IsType<ResultMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/result.xml")));
+            Assert.IsType<DeviceListMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/devicelist.xml")));
         }
     }
 }

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerMessageTests.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="MuxerMessageTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Muxer;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="MuxerMessage" /> class.
+    /// </summary>
+    public class MuxerMessageTests
+    {
+        /// <summary>
+        /// The <see cref="MuxerMessage.ReadAny(NSDictionary)"/> method throws an
+        /// <see cref="ArgumentNullException"/> when passed a <see langword="null"/> value.
+        /// </summary>
+        [Fact]
+        public void ReadAny_NullArgument_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>("data", () => MuxerMessage.ReadAny(null));
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerMessage.ReadAny(NSDictionary)"/> method throws an
+        /// <see cref="ArgumentOutOfRangeException"/> when passed an empty dictionary.
+        /// </summary>
+        [Fact]
+        public void ReadAny_EmptyDictionary_ThrowsException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("data", () => MuxerMessage.ReadAny(new NSDictionary()));
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerMessage.ReadAny(NSDictionary)"/> method throws an
+        /// <see cref="ArgumentOutOfRangeException"/> when passed an empty dictionary.
+        /// </summary>
+        [Fact]
+        public void ReadAny_InvalidMessageType_ThrowsException()
+        {
+            var dict = new NSDictionary();
+            dict.Add("MessageType", new NSString(nameof(MuxerMessageType.None)));
+            Assert.Throws<ArgumentOutOfRangeException>("data", () => MuxerMessage.ReadAny(new NSDictionary()));
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerMessage.ReadAny(NSDictionary)"/> correctly parses muxer messages.
+        /// </summary>
+        [Fact]
+        public void ReadAny_ReadMessage()
+        {
+            Assert.IsType<DeviceAttachedMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/attached.xml")));
+            Assert.IsType<DeviceDetachedMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/detached.xml")));
+            Assert.IsType<DevicePairedMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/paired.xml")));
+            Assert.IsType<ResultMessage>(MuxerMessage.ReadAny((NSDictionary)PropertyListParser.Parse("Muxer/result.xml")));
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerProtocolTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerProtocolTests.cs
@@ -120,9 +120,7 @@ namespace Kaponata.iOS.Tests.Muxer
                 var value = await protocol.ReadMessageAsync(
                     default).ConfigureAwait(false);
 
-                Assert.Collection(
-                    value.Keys,
-                    v => Assert.Equal("DeviceList", v));
+                Assert.IsType<DeviceListMessage>(value);
             }
         }
 
@@ -223,7 +221,8 @@ namespace Kaponata.iOS.Tests.Muxer
             await using (var protocol = new MuxerProtocol(stream, ownsStream: true, NullLogger<MuxerProtocol>.Instance))
             {
                 var payload = new NSDictionary();
-                payload.Add("Hello", new NSString("World"));
+                payload.Add("MessageType", new NSString(nameof(MuxerMessageType.Result)));
+                payload.Add("Number", new NSNumber((int)MuxerError.Success));
 
                 byte[] payloadData = Encoding.UTF8.GetBytes(payload.ToXmlPropertyList());
                 byte[] headerData = new byte[MuxerHeader.BinarySize];
@@ -243,7 +242,7 @@ namespace Kaponata.iOS.Tests.Muxer
                 var value = await protocol.ReadMessageAsync(
                     default).ConfigureAwait(false);
 
-                Assert.Equal(new NSString("World"), value.Get("Hello"));
+                Assert.IsType<ResultMessage>(value);
             }
         }
     }

--- a/src/Kaponata.iOS.Tests/Muxer/ResultMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/ResultMessageTests.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="ResultMessageTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Muxer;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="ResultMessage"/> class.
+    /// </summary>
+    public class ResultMessageTests
+    {
+        /// <summary>
+        /// <see cref="ResultMessage.Read(NSDictionary)"/> throws an error when passed
+        /// <see langword="null"/> values.
+        /// </summary>
+        [Fact]
+        public void Read_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("data", () => ResultMessage.Read(null));
+        }
+
+        /// <summary>
+        /// <see cref="ResultMessage.Read(NSDictionary)"/> correctly parses a <see cref="NSDictionary"/>
+        /// object.
+        /// </summary>
+        [Fact]
+        public void Read_Works()
+        {
+            var result = ResultMessage.Read(
+                (NSDictionary)PropertyListParser.Parse("Muxer/result.xml"));
+
+            Assert.Equal(MuxerMessageType.Result, result.MessageType);
+            Assert.Equal(MuxerError.Success, result.Number);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Muxer/attached.xml
+++ b/src/Kaponata.iOS.Tests/Muxer/attached.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MessageType</key>
+	<string>Attached</string>
+	<key>DeviceID</key>
+	<integer>2</integer>
+	<key>Properties</key>
+	<dict>
+		<key>ConnectionSpeed</key>
+		<integer>480000000</integer>
+		<key>ConnectionType</key>
+		<string>USB</string>
+		<key>DeviceID</key>
+		<integer>2</integer>
+		<key>LocationID</key>
+		<integer>65539</integer>
+		<key>ProductID</key>
+		<integer>4776</integer>
+		<key>SerialNumber</key>
+		<string>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</string>
+	</dict>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/Muxer/detached.xml
+++ b/src/Kaponata.iOS.Tests/Muxer/detached.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MessageType</key>
+	<string>Detached</string>
+	<key>DeviceID</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/Muxer/listen.xml
+++ b/src/Kaponata.iOS.Tests/Muxer/listen.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BundleID</key>
+	<string>com.apple.iTunes</string>
+	<key>ClientVersionString</key>
+	<string>usbmuxd-374.70</string>
+	<key>ConnType</key>
+	<integer>1</integer>
+	<key>MessageType</key>
+	<string>Listen</string>
+	<key>ProgName</key>
+	<string>iTunes</string>
+	<key>kLibUSBMuxVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/Muxer/paired.xml
+++ b/src/Kaponata.iOS.Tests/Muxer/paired.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MessageType</key>
+	<string>Paired</string>
+	<key>DeviceID</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/Muxer/result.xml
+++ b/src/Kaponata.iOS.Tests/Muxer/result.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MessageType</key>
+	<string>Result</string>
+	<key>Number</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/src/Kaponata.iOS/Muxer/DeviceDetachedMessage.Serialization.cs
+++ b/src/Kaponata.iOS/Muxer/DeviceDetachedMessage.Serialization.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="DeviceDetachedMessage.Serialization.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Adds the <see cref="DeviceDetachedMessage.Read(NSDictionary)"/> method.
+    /// </summary>
+    public partial class DeviceDetachedMessage
+    {
+        /// <summary>
+        /// Reads a <see cref="DeviceDetachedMessage"/> from a <see cref="NSDictionary"/>.
+        /// </summary>
+        /// <param name="data">
+        /// The message data.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DeviceDetachedMessage"/> object.
+        /// </returns>
+        public static DeviceDetachedMessage Read(NSDictionary data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            DeviceDetachedMessage value = new DeviceDetachedMessage();
+            value.DeviceID = (int)data.Get(nameof(DeviceID)).ToObject();
+            value.MessageType = Enum.Parse<MuxerMessageType>((string)data.Get(nameof(MessageType)).ToObject());
+            return value;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/DeviceDetachedMessage.cs
+++ b/src/Kaponata.iOS/Muxer/DeviceDetachedMessage.cs
@@ -1,0 +1,14 @@
+﻿// <copyright file="DeviceDetachedMessage.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Represents the message which is sent by <c>usbmuxd</c> when a device is detached (disconnected)
+    /// from the host.
+    /// </summary>
+    public partial class DeviceDetachedMessage : DeviceMessage
+    {
+    }
+}

--- a/src/Kaponata.iOS/Muxer/DevicePairedMessage.Serialization.cs
+++ b/src/Kaponata.iOS/Muxer/DevicePairedMessage.Serialization.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="DevicePairedMessage.Serialization.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Adds the <see cref="DevicePairedMessage.DevicePairedMessage"/> method.
+    /// </summary>
+    public partial class DevicePairedMessage
+    {
+        /// <summary>
+        /// Reads a <see cref="DevicePairedMessage"/> from a <see cref="NSDictionary"/>.
+        /// </summary>
+        /// <param name="data">
+        /// The message data.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DeviceDetachedMessage"/> object.
+        /// </returns>
+        public static DevicePairedMessage Read(NSDictionary data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            DevicePairedMessage value = new DevicePairedMessage();
+            value.DeviceID = (int)data.Get(nameof(DeviceID)).ToObject();
+            value.MessageType = Enum.Parse<MuxerMessageType>((string)data.Get(nameof(MessageType)).ToObject());
+            return value;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/DevicePairedMessage.cs
+++ b/src/Kaponata.iOS/Muxer/DevicePairedMessage.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="DevicePairedMessage.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// The message which is sent by <c>usbmuxd</c> when a device has paired succesfully with the host.
+    /// </summary>
+    /// <remarks>
+    /// This message is not sent for devices which have previously paired with the PC and are attached
+    /// to the host; so the absence of a pairing message does not indicate that the device is not paired
+    /// with the host.
+    /// </remarks>
+    public partial class DevicePairedMessage : DeviceMessage
+    {
+    }
+}

--- a/src/Kaponata.iOS/Muxer/ListenMessage.cs
+++ b/src/Kaponata.iOS/Muxer/ListenMessage.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="ListenMessage.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Represents a message requesting <c>usbmuxd</c> to send notifications about device connect/disconnect/trust
+    /// events.
+    /// </summary>
+    public class ListenMessage : RequestMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListenMessage"/> class.
+        /// </summary>
+        public ListenMessage()
+        {
+            this.MessageType = MuxerMessageType.Listen;
+        }
+
+        /// <summary>
+        /// Gets or sets the connection type being used.
+        /// </summary>
+        public int ConnType
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the version of the <c>usbmux</c> protocol being used.
+        /// </summary>
+        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element must begin with upper-case letter", Justification = "Standard iOS naming")]
+        public int kLibUSBMuxVersion
+        {
+            get;
+            set;
+        }
+
+        /// <inheritdoc/>
+        public override NSDictionary ToPropertyList()
+        {
+            NSDictionary dictionary = new NSDictionary();
+            dictionary.Add(nameof(this.BundleID), new NSString(this.BundleID));
+            dictionary.Add(nameof(this.ClientVersionString), new NSString(this.ClientVersionString));
+            dictionary.Add(nameof(this.ConnType), new NSNumber(this.ConnType));
+            dictionary.Add(nameof(this.MessageType), new NSString(this.MessageType.ToString()));
+            dictionary.Add(nameof(this.ProgName), new NSString(this.ProgName));
+            dictionary.Add(nameof(this.kLibUSBMuxVersion), new NSNumber(this.kLibUSBMuxVersion));
+            return dictionary;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerClient.List.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerClient.List.cs
@@ -45,7 +45,7 @@ namespace Kaponata.iOS.Muxer
                     cancellationToken).ConfigureAwait(false);
 
                 var response = await protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
-                var deviceList = DeviceListMessage.Read(response);
+                var deviceList = (DeviceListMessage)response;
 
                 foreach (var device in deviceList.DeviceList)
                 {

--- a/src/Kaponata.iOS/Muxer/MuxerClient.Listen.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerClient.Listen.cs
@@ -1,0 +1,130 @@
+﻿// <copyright file="MuxerClient.Listen.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Adds the <see cref="MuxerClient.ListenAsync"/> method.
+    /// </summary>
+    public partial class MuxerClient
+    {
+        /// <summary>
+        /// Listens for device notifications on a <see cref="MuxerProtocol"/>.
+        /// </summary>
+        /// <param name="onAttached">
+        /// The action to take when an <see cref="DeviceAttachedMessage"/> is received.
+        /// </param>
+        /// <param name="onDetached">
+        /// The action to take when an <see cref="DeviceDetachedMessage"/> is received.
+        /// </param>
+        /// <param name="onPaired">
+        /// The action to take when an <see cref="DevicePairedMessage"/> is received.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation. Returns <see langword="true"/> when
+        /// the client aborted the listen operation, <see langword="false"/> when the server disconnected.
+        /// </returns>
+        public async Task<bool> ListenAsync(
+            Func<DeviceAttachedMessage, Task<MuxerListenAction>> onAttached,
+            Func<DeviceDetachedMessage, Task<MuxerListenAction>> onDetached,
+            Func<DevicePairedMessage, Task<MuxerListenAction>> onPaired,
+            CancellationToken cancellationToken)
+        {
+            var protocol = await this.TryConnectToMuxerAsync(cancellationToken).ConfigureAwait(false);
+
+            if (protocol == null)
+            {
+                return false;
+            }
+
+            await using (protocol)
+            {
+                // Send the Listen request
+                await protocol.WriteMessageAsync(
+                    new ListenMessage()
+                    {
+                        ConnType = 1,
+                        MessageType = MuxerMessageType.Listen,
+                        kLibUSBMuxVersion = 3,
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                var message = await protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
+
+                if (message == null)
+                {
+                    this.logger.LogWarning("The server unexpectedly close the connection when sending the Listen command.");
+                    return false;
+                }
+
+                var resultMessage = (ResultMessage)message;
+                if (resultMessage.Number != MuxerError.Success)
+                {
+                    throw new MuxerException("An error occurred while listening for device notifications.", resultMessage.Number);
+                }
+
+                while ((message = await protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false)) != null)
+                {
+                    if (message is DeviceAttachedMessage)
+                    {
+                        var attachedMessage = (DeviceAttachedMessage)message;
+
+                        if (onAttached != null)
+                        {
+                            if (await onAttached(attachedMessage) == MuxerListenAction.StopListening)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else if (message is DeviceDetachedMessage)
+                    {
+                        var detachedMessage = (DeviceDetachedMessage)message;
+
+                        if (onDetached != null)
+                        {
+                            if (await onDetached(detachedMessage) == MuxerListenAction.StopListening)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else if (message is DevicePairedMessage)
+                    {
+                        var pairedMessage = (DevicePairedMessage)message;
+
+                        if (onPaired != null)
+                        {
+                            if (await onPaired(pairedMessage) == MuxerListenAction.StopListening)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        throw new InvalidDataException();
+                    }
+                }
+
+                // If message is null, the server closed the connection. Let the caller know.
+                if (message == null)
+                {
+                    this.logger.LogWarning("The server unexpectedly close the connection when listening for device notifications.");
+                }
+
+                return message != null;
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerError.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerError.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="MuxerError.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Represents the error messages returned by the muxer.
+    /// </summary>
+    public enum MuxerError
+    {
+        /// <summary>
+        /// The operation completed successfully.
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// The muxer received a bad command.
+        /// </summary>
+        BadCommand = 1,
+
+        /// <summary>
+        /// An attempt was made to connect to a bad device.
+        /// </summary>
+        BadDevice = 2,
+
+        /// <summary>
+        /// The connection was refused by the device.
+        /// </summary>
+        ConnectionRefused = 3,
+
+        /// <summary>
+        /// A bad muxer version was used.
+        /// </summary>
+        BadVersion = 6,
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerException.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerException.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="MuxerException.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Represents an error returned by the muxer.
+    /// </summary>
+    public class MuxerException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MuxerException"/> class.
+        /// </summary>
+        public MuxerException()
+            : this("An unexpected usbmuxd exception occurred.")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MuxerException"/> class with an error message.
+        /// </summary>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        public MuxerException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MuxerException"/> class with an error message
+        /// and error number.
+        /// </summary>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        /// <param name="error">
+        /// An error code which represents the error.
+        /// </param>
+        public MuxerException(string message, MuxerError error)
+            : base(message)
+        {
+            this.HResult = (int)error;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MuxerException"/> class with an error message
+        /// and an inner exception.
+        /// </summary>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        /// <param name="innerException">
+        /// The inner exception which caused this exception.
+        /// </param>
+        public MuxerException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerListenAction.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerListenAction.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="MuxerListenAction.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Defines whether a listener should continue listening or stop listening for device connect or disconnect events.
+    /// </summary>
+    public enum MuxerListenAction : byte
+    {
+        /// <summary>
+        /// The listener should keep listening for new device connect or disconnect events.
+        /// </summary>
+        ContinueListening = 1,
+
+        /// <summary>
+        /// The listener should stop listening for device connect or disconnect events.
+        /// </summary>
+        StopListening = 2,
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerMessage.Serialization.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerMessage.Serialization.cs
@@ -28,29 +28,35 @@ namespace Kaponata.iOS.Muxer
                 throw new ArgumentNullException(nameof(data));
             }
 
-            if (!data.ContainsKey(nameof(MessageType)))
+            if (data.ContainsKey(nameof(MessageType)))
+            {
+                var messageType = Enum.Parse<MuxerMessageType>((string)data.Get(nameof(MessageType)).ToObject());
+
+                switch (messageType)
+                {
+                    case MuxerMessageType.Attached:
+                        return DeviceAttachedMessage.Read(data);
+
+                    case MuxerMessageType.Detached:
+                        return DeviceDetachedMessage.Read(data);
+
+                    case MuxerMessageType.Paired:
+                        return DevicePairedMessage.Read(data);
+
+                    case MuxerMessageType.Result:
+                        return ResultMessage.Read(data);
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(data));
+                }
+            }
+            else if (data.ContainsKey("DeviceList"))
+            {
+                return DeviceListMessage.Read(data);
+            }
+            else
             {
                 throw new ArgumentOutOfRangeException(nameof(data));
-            }
-
-            var messageType = Enum.Parse<MuxerMessageType>((string)data.Get(nameof(MessageType)).ToObject());
-
-            switch (messageType)
-            {
-                case MuxerMessageType.Attached:
-                    return DeviceAttachedMessage.Read(data);
-
-                case MuxerMessageType.Detached:
-                    return DeviceDetachedMessage.Read(data);
-
-                case MuxerMessageType.Paired:
-                    return DevicePairedMessage.Read(data);
-
-                case MuxerMessageType.Result:
-                    return ResultMessage.Read(data);
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(data));
             }
         }
     }

--- a/src/Kaponata.iOS/Muxer/MuxerMessage.Serialization.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerMessage.Serialization.cs
@@ -1,0 +1,57 @@
+﻿// <copyright file="MuxerMessage.Serialization.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Adds the <see cref="MuxerMessage.ReadAny(NSDictionary)"/> method.
+    /// </summary>
+    public partial class MuxerMessage
+    {
+        /// <summary>
+        /// Reads a <see cref="MuxerMessage"/> object from a <see cref="NSDictionary"/> value.
+        /// </summary>
+        /// <param name="data">
+        /// The data to read.
+        /// </param>
+        /// <returns>
+        /// The <see cref="MuxerMessage"/> representation of the <paramref name="data"/>.
+        /// </returns>
+        public static MuxerMessage ReadAny(NSDictionary data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (!data.ContainsKey(nameof(MessageType)))
+            {
+                throw new ArgumentOutOfRangeException(nameof(data));
+            }
+
+            var messageType = Enum.Parse<MuxerMessageType>((string)data.Get(nameof(MessageType)).ToObject());
+
+            switch (messageType)
+            {
+                case MuxerMessageType.Attached:
+                    return DeviceAttachedMessage.Read(data);
+
+                case MuxerMessageType.Detached:
+                    return DeviceDetachedMessage.Read(data);
+
+                case MuxerMessageType.Paired:
+                    return DevicePairedMessage.Read(data);
+
+                case MuxerMessageType.Result:
+                    return ResultMessage.Read(data);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(data));
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerMessage.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerMessage.cs
@@ -10,7 +10,7 @@ namespace Kaponata.iOS.Muxer
     /// <summary>
     /// Represents a message which is sent to, or received from, <c>usbmuxd</c>.
     /// </summary>
-    public abstract class MuxerMessage
+    public abstract partial class MuxerMessage
     {
         /// <summary>
         /// Gets or sets the type of message which was sent or received.

--- a/src/Kaponata.iOS/Muxer/MuxerProtocol.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerProtocol.cs
@@ -115,10 +115,10 @@ namespace Kaponata.iOS.Muxer
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
         /// <returns>
-        /// A <see cref="NSDictionary"/> object which represents the property list value received
+        /// A <see cref="DeviceListMessage"/> object which represents the property list value received
         /// from the remote muxer.
         /// </returns>
-        public virtual async Task<NSDictionary> ReadMessageAsync(CancellationToken cancellationToken)
+        public virtual async Task<MuxerMessage> ReadMessageAsync(CancellationToken cancellationToken)
         {
             int read;
             MuxerHeader header;
@@ -151,7 +151,7 @@ namespace Kaponata.iOS.Muxer
                 var propertyListData = messageBuffer.Memory.Slice(0, messageLength).ToArray();
                 var propertyList = (NSDictionary)XmlPropertyListParser.Parse(propertyListData);
 
-                return propertyList;
+                return MuxerMessage.ReadAny(propertyList);
             }
         }
 

--- a/src/Kaponata.iOS/Muxer/ResultMessage.Serialization.cs
+++ b/src/Kaponata.iOS/Muxer/ResultMessage.Serialization.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ResultMessage.Serialization.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Adds the <see cref="ResultMessage.Read(NSDictionary)"/> method.
+    /// </summary>
+    public partial class ResultMessage
+    {
+        /// <summary>
+        /// Reads a <see cref="DeviceAttachedMessage"/> from a <see cref="NSDictionary"/>.
+        /// </summary>
+        /// <param name="data">
+        /// The message data.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DeviceAttachedMessage"/> object.
+        /// </returns>
+        public static ResultMessage Read(NSDictionary data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            ResultMessage value = new ResultMessage();
+            value.MessageType = (MuxerMessageType)data.Get(nameof(MessageType)).ToObject();
+            value.Number = (MuxerError)data.Get(nameof(Number)).ToObject();
+            return value;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/ResultMessage.Serialization.cs
+++ b/src/Kaponata.iOS/Muxer/ResultMessage.Serialization.cs
@@ -29,7 +29,7 @@ namespace Kaponata.iOS.Muxer
             }
 
             ResultMessage value = new ResultMessage();
-            value.MessageType = (MuxerMessageType)data.Get(nameof(MessageType)).ToObject();
+            value.MessageType = Enum.Parse<MuxerMessageType>((string)data.Get(nameof(MessageType)).ToObject());
             value.Number = (MuxerError)data.Get(nameof(Number)).ToObject();
             return value;
         }

--- a/src/Kaponata.iOS/Muxer/ResultMessage.cs
+++ b/src/Kaponata.iOS/Muxer/ResultMessage.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="ResultMessage.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Represents the result of a method invocation request.
+    /// </summary>
+    public partial class ResultMessage : MuxerMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResultMessage"/> class.
+        /// </summary>
+        public ResultMessage()
+        {
+            this.MessageType = MuxerMessageType.Result;
+        }
+
+        /// <summary>
+        /// Gets or sets the response code.
+        /// </summary>
+        public MuxerError Number
+        {
+            get;
+            set;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `MuxerClient.ListenAsync` method, which supports listening for device attached/paired/detached events.