### PR TITLE
Add usbmuxd to Helm chart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,11 +133,17 @@ jobs:
 
           k3d cluster create --api-port 6433 -p "80:80@loadbalancer"
 
+      # Override the usbmuxd image tag in the usbmuxd subchart to
+      # latest-udev-amd64. This fixes an issue where usbmuxd will fail
+      # to start on a VM with no USB stack (because libusb fails to
+      # initialize.)
       - name: Deploy Helm chart
         run: >
           helm install
+          --set usbmuxd.usbmuxd.image.tag=latest-udev-amd64
           --wait
-          kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
+          kaponata
+          ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
 
       - name: Run chart tests and integration tests
         run: >

--- a/src/Kaponata.Chart.Tests/Kaponata.Chart.Tests.csproj
+++ b/src/Kaponata.Chart.Tests/Kaponata.Chart.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
+    <PackageReference Include="Divergic.Logging.Xunit" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Chart.Tests/UsbmuxdTests.cs
+++ b/src/Kaponata.Chart.Tests/UsbmuxdTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="UsbmuxdTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+using k8s;
+using Kaponata.iOS.Muxer;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// Tests the usbmuxd Helm chart.
+    /// </summary>
+    public class UsbmuxdTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsbmuxdTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// The test output helper which will be used to log to xunit.
+        /// </param>
+        public UsbmuxdTests(ITestOutputHelper output)
+        {
+            this.loggerFactory = LogFactory.Create(output);
+            this.output = output;
+        }
+
+        /// <summary>
+        /// At least one usbmuxd pod is running in the cluster.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task Usbmuxd_Is_Running_Async()
+        {
+            var config = KubernetesClientConfiguration.BuildDefaultConfig();
+            if (config.Namespace == null)
+            {
+                config.Namespace = "default";
+            }
+
+            var kubernetes = new KubernetesProtocol(
+                config,
+                this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                this.loggerFactory);
+
+            // There's at least one usbmuxd pod
+            var pods = await kubernetes.ListNamespacedPodAsync(config.Namespace, labelSelector: "app.kubernetes.io/component=usbmuxd");
+            Assert.NotEmpty(pods.Items);
+            var pod = pods.Items[0];
+
+            var client = new KubernetesClient(
+                kubernetes,
+                this.output.BuildLoggerFor<KubernetesClient>());
+
+            // The pod is in the running state
+            pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+            Assert.Equal("Running", pod.Status.Phase);
+
+            // We can connect to port 27015 and retrieve an empty device list
+            var locator = new KubernetesMuxerSocketLocator(kubernetes, pod, this.loggerFactory.CreateLogger<KubernetesMuxerSocketLocator>(), this.loggerFactory);
+            var muxerClient = new MuxerClient(this.loggerFactory.CreateLogger<MuxerClient>(), this.loggerFactory, locator);
+
+            Exception exception = null;
+
+            // The usbmuxd port may not yet be ready; in that case an IOException is thrown.
+            // Try up to 10 times.
+            for (int i = 0; i < 10; i++)
+            {
+                exception = null;
+
+                try
+                {
+                    var devices = await muxerClient.ListDevicesAsync(default).ConfigureAwait(false);
+                    break;
+                }
+                catch (IOException ex)
+                {
+                    exception = ex;
+                    this.output.WriteLine(ex.Message);
+                    await Task.Delay(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+                }
+            }
+
+            if (exception != null)
+            {
+                throw exception;
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesMuxerSocketLocatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesMuxerSocketLocatorTests.cs
@@ -1,0 +1,78 @@
+﻿// <copyright file="KubernetesMuxerSocketLocatorTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesMuxerSocketLocator"/> class.
+    /// </summary>
+    public class KubernetesMuxerSocketLocatorTests
+    {
+        /// <summary>
+        /// The <see cref="KubernetesMuxerSocketLocator"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("kubernetes", () => new KubernetesMuxerSocketLocator(null, new V1Pod(), NullLogger<KubernetesMuxerSocketLocator>.Instance, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("pod", () => new KubernetesMuxerSocketLocator(Mock.Of<IKubernetes>(), null, NullLogger<KubernetesMuxerSocketLocator>.Instance, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesMuxerSocketLocator(Mock.Of<IKubernetes>(), new V1Pod(), null, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesMuxerSocketLocator(Mock.Of<IKubernetes>(), new V1Pod(), NullLogger<KubernetesMuxerSocketLocator>.Instance, null));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesMuxerSocketLocator.ConnectToMuxerAsync"/> uses Kubernetes port forwarding.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task ConnectToMuxerAsync_UsesPortForwarding_Async()
+        {
+            var pod = new V1Pod()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    NamespaceProperty = "my-namespace",
+                    Name = "usbmuxd-abcd",
+                },
+            };
+
+            var websocket = Mock.Of<WebSocket>();
+            var kubernetes = new Mock<IKubernetes>(MockBehavior.Strict);
+            kubernetes
+                .Setup(k => k.WebSocketNamespacedPodPortForwardAsync("usbmuxd-abcd", "my-namespace", new int[] { 27015 }, null, null, default))
+                .ReturnsAsync(websocket);
+
+            var locator = new KubernetesMuxerSocketLocator(kubernetes.Object, pod, NullLogger<KubernetesMuxerSocketLocator>.Instance, NullLoggerFactory.Instance);
+            using (var stream = await locator.ConnectToMuxerAsync(default))
+            {
+                var portForwardStream = Assert.IsType<PortForwardStream>(stream);
+                Assert.Same(websocket, portForwardStream.WebSocket);
+            }
+
+            kubernetes.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesMuxerSocketLocator.GetMuxerSocket"/> is not implemented.
+        /// </summary>
+        [Fact]
+        public void GetMuxerSocket_Throws()
+        {
+            var locator = new KubernetesMuxerSocketLocator(Mock.Of<IKubernetes>(), new V1Pod(), NullLogger<KubernetesMuxerSocketLocator>.Instance, NullLoggerFactory.Instance);
+            Assert.Throws<NotSupportedException>(() => locator.GetMuxerSocket());
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kaponata.Operator.csproj
+++ b/src/Kaponata.Operator/Kaponata.Operator.csproj
@@ -5,6 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Kaponata.iOS\Kaponata.iOS.csproj" />
+
     <PackageReference Include="KubernetesClient" Version="4.0.5" />
   </ItemGroup>
+
 </Project>

--- a/src/Kaponata.Operator/Kubernetes/KubernetesMuxerSocketLocator.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesMuxerSocketLocator.cs
@@ -1,0 +1,79 @@
+﻿// <copyright file="KubernetesMuxerSocketLocator.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.iOS.Muxer;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// An implementation of the <see cref="MuxerSocketLocator"/> which connects to usbmuxd running in a Kubernetes pod,
+    /// using port forwarding over the API server.
+    /// </summary>
+    public class KubernetesMuxerSocketLocator : MuxerSocketLocator
+    {
+        private readonly ILogger<KubernetesMuxerSocketLocator> logger;
+        private readonly ILoggerFactory loggerFactory;
+        private readonly IKubernetes kubernetes;
+        private readonly V1Pod pod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesMuxerSocketLocator"/> class.
+        /// </summary>
+        /// <param name="kubernetes">
+        /// A connection to the Kubernetes cluster.
+        /// </param>
+        /// <param name="pod">
+        /// The pod in which usbmuxd is running.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which is used when logging.
+        /// </param>
+        /// <param name="loggerFactory">
+        /// A logger factory which an be used to create new loggers.
+        /// </param>
+        public KubernetesMuxerSocketLocator(
+            IKubernetes kubernetes,
+            V1Pod pod,
+            ILogger<KubernetesMuxerSocketLocator> logger,
+            ILoggerFactory loggerFactory)
+        {
+            this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
+            this.pod = pod ?? throw new ArgumentNullException(nameof(pod));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        /// <inheritdoc/>
+        public override async Task<Stream> ConnectToMuxerAsync(CancellationToken cancellationToken)
+        {
+            this.logger.LogInformation("Connecting to port {port} on pod {pod}", DefaultMuxerPort, this.pod.Metadata.Name);
+
+            var webSocket = await this.kubernetes.WebSocketNamespacedPodPortForwardAsync(
+                this.pod.Metadata.Name,
+                this.pod.Metadata.NamespaceProperty,
+                new int[] { DefaultMuxerPort },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            this.logger.LogInformation("Connected to port {port} on pod {pod}", DefaultMuxerPort, this.pod.Metadata.Name);
+            return new PortForwardStream(webSocket, this.loggerFactory.CreateLogger<PortForwardStream>());
+
+        }
+
+        /// <inheritdoc/>
+        public override (Socket, EndPoint) GetMuxerSocket()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/chart/.helmignore
+++ b/src/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/chart/Chart.yaml
+++ b/src/chart/Chart.yaml
@@ -1,7 +1,16 @@
 apiVersion: v2
 name: kaponata
 description: Kaponata manages your mobile device test farm for you, so you can run Appium tests at scale on iOS and Android devices.
+home: https://www.kaponata.io/
 
 type: application
 version: 0.1.0
 appVersion: "1.16.0"
+
+dependencies:
+  - name: "usbmuxd"
+    version: "1.0.0"
+
+maintainers:
+  - name: Frederik Carlier
+    email: frederik.carlier@quamotion.mobi

--- a/src/chart/Makefile
+++ b/src/chart/Makefile
@@ -1,0 +1,6 @@
+deploy:
+	helm uninstall kaponata || echo "Not installed, skipping uninstall"
+	helm install kaponata .
+
+lint:
+	helm lint .

--- a/src/chart/charts/usbmuxd/Chart.yaml
+++ b/src/chart/charts/usbmuxd/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: usbmuxd
+description: USB multiplexing daemon, in charge of multiplexing connections over USB to an iOS device
+home: https://github.com/libimobiledevice/usbmuxd/
+
+type: application
+version: 1.0.0
+appVersion: "1.1.2"
+
+maintainers:
+  - name: Frederik Carlier
+    email: frederik.carlier@quamotion.mobi

--- a/src/chart/charts/usbmuxd/templates/_helpers.tpl
+++ b/src/chart/charts/usbmuxd/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "usbmuxd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "usbmuxd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "usbmuxd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "usbmuxd.labels" -}}
+helm.sh/chart: {{ include "usbmuxd.chart" . }}
+{{ include "usbmuxd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "usbmuxd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "usbmuxd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "usbmuxd"
+{{- end }}

--- a/src/chart/charts/usbmuxd/templates/daemonset.yaml
+++ b/src/chart/charts/usbmuxd/templates/daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "usbmuxd.fullname" . }}
+  labels:
+    {{- include "usbmuxd.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "usbmuxd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "usbmuxd.selectorLabels" . | nindent 8 }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+      - name: usbmuxd
+        image: {{ .Values.usbmuxd.image.repository }}:{{ .Values.usbmuxd.image.tag }}
+        securityContext:
+          privileged: true
+        volumeMounts: 
+          - mountPath: /dev/bus/usb
+            name: usb
+          - mountPath: /var/lib/lockdown
+            name: lockdown
+        command: [ "/usr/sbin/usbmuxd" ]
+        args:
+        # Verbose logging
+        - "-v"
+        # foreground
+        - "-f"
+        # Listen on 0.0.0.0:27015
+        - "-S"
+        - "0.0.0.0:27015"
+
+      # Required volumes
+      volumes:
+      - name: usb
+        hostPath:
+            path: /dev/bus/usb
+      - name: lockdown
+        hostPath:
+          path: /var/lib/lockdown
+          type: DirectoryOrCreate

--- a/src/chart/charts/usbmuxd/values.yaml
+++ b/src/chart/charts/usbmuxd/values.yaml
@@ -1,0 +1,4 @@
+usbmuxd:
+  image:
+    repository: quay.io/kaponata/usbmuxd
+    tag: 1.1.2


### PR DESCRIPTION
This PR adds an usbmuxd subchart to the kaponata chart, which will deploy an usbmuxd daemon to all nodes in the cluster.

It also introduces an integration test in the `Kaponata.Chart.Tests` project which runs when the kaponata chart is deployed to the k3d cluster. It simply connects to usbmuxd, list the devices, and makes sure no exception occurs.

As a side effect, this PR introduces the `PortForwardStream` and `KubernetesMuxerSocketLocator` classes which allow `MuxerClient` to connect to an instance of usbmuxd running in a Kubernetes pod
