### PR TITLE
usbmuxd image: Build an -udev variant

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -23,6 +23,13 @@ jobs:
         with:
           path: src
 
+      - name: Install gomplate
+        run: |
+          # Install gomplate, used by some Dockerfile templates
+          sudo curl -L https://github.com/hairyhenderson/gomplate/releases/download/v3.8.0/gomplate_linux-amd64 -o /usr/local/bin/gomplate -s
+          sudo chmod +x /usr/local/bin/gomplate
+          gomplate --version
+
       - name: Build Docker image
         run: |
           make

--- a/src/usbmuxd/.gitignore
+++ b/src/usbmuxd/.gitignore
@@ -1,0 +1,2 @@
+Dockerfile.udev
+Dockerfile.default

--- a/src/usbmuxd/Dockerfile.template
+++ b/src/usbmuxd/Dockerfile.template
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV build=x86_64-linux-gnu
 ARG host=aarch64-linux-gnu
 ARG arch=arm64
+ARG with_udev=no
 
 # Add the host architecture if needed
 RUN if [ -n "$arch" ]; then dpkg --add-architecture $arch; fi
@@ -24,6 +25,9 @@ RUN if [ -n "$host" ]; then apt-get install -y g++-$host; fi
 
 # Install libssl for the host architecture
 RUN apt-get install -y libssl-dev:$arch
+
+# Install libudev
+RUN apt-get install -y libudev-dev
 
 WORKDIR /src
 RUN curl -L https://github.com/libusb/libusb/archive/v${libusb_version}.tar.gz --output libusb-${libusb_version}.tar.gz
@@ -40,7 +44,7 @@ RUN tar -xvzf usbmuxd-${usbmuxd_version}.tar.gz
 
 WORKDIR /src/libusb-${libusb_version}
 
-RUN ./autogen.sh enable_udev=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+RUN ./autogen.sh --enable-udev=$with_udev --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
 && make \
 && make install
 
@@ -68,7 +72,7 @@ RUN ./autogen.sh --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$ho
 && make \
 && make install
 
-FROM gcr.io/distroless/base-debian10
+FROM {{ (ds "config").image }}
 
 ARG host=aarch64-linux-gnu
 ARG arch=arm64
@@ -103,5 +107,11 @@ COPY --from=build /usr/bin/ideviceinfo /usr/bin/
 COPY --from=build /usr/sbin/usbmuxd /usr/sbin/usbmuxd
 
 ENV USBMUXD_SOCKET_ADDRESS=127.0.0.1:27015
+
+{{- if (ds "config").install_packages }}
+RUN apt-get update \
+&& apt-get install -y libudev1 libssl1.1 \
+&& rm -rf /var/lib/apt/lists/*
+{{- end }}
 
 ENTRYPOINT [ "/usr/sbin/usbmuxd", "-v", "-f", "-S", "0.0.0.0:27015" ]

--- a/src/usbmuxd/Makefile
+++ b/src/usbmuxd/Makefile
@@ -1,18 +1,26 @@
 registry=quay.io/kaponata
 image=usbmuxd
 
-all: .arm64.docker-id .amd64.docker-id .version
+all: .arm64.docker-id .amd64.docker-id .amd64.udev.docker-id .version
 
 push: all
 	docker push $(registry)/$(image):latest-amd64
 	docker push $(registry)/$(image):latest-arm64
 	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64 $(registry)/$(image):latest-arm64
 	docker manifest push $(registry)/$(image):$(shell cat .version)
+	
+	docker push $(registry)/$(image):latest-udev-amd64
 
 .version: .amd64.docker-id
 	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/usbmuxd --version | awk '{ print $$2 }' | tee .version
 
-.amd64.docker-id: Dockerfile
+Dockerfile.default: Dockerfile.template default.yaml
+	gomplate -d config=./default.yaml -f Dockerfile.template -o Dockerfile.default
+
+Dockerfile.udev: Dockerfile.template udev.yaml
+	gomplate -d config=./udev.yaml -f Dockerfile.template -o Dockerfile.udev
+
+.amd64.docker-id: Dockerfile.default
 	docker buildx build \
 		--platform linux/amd64 \
 		--build-arg host= \
@@ -23,10 +31,11 @@ push: all
 		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
 		--build-arg VERSION="$(shell nbgv get-version -v SemVer2)" \
 		. \
+		-f Dockerfile.default \
 		-t $(registry)/$(image):latest-amd64
 	docker images --no-trunc --quiet $(registry)/$(image):latest-amd64 > .amd64.docker-id
 
-.arm64.docker-id: Dockerfile
+.arm64.docker-id: Dockerfile.default
 	docker buildx build --platform linux/arm64 \
 		--build-arg host=aarch64-linux-gnu \
 		--build-arg arch=arm64 \
@@ -36,5 +45,22 @@ push: all
 		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
 		--build-arg VERSION="$(shell nbgv get-version -v SemVer2)" \
 		. \
+		-f Dockerfile.default \
 		-t $(registry)/$(image):latest-arm64
 	docker images --no-trunc --quiet $(registry)/$(image):latest-arm64 > .arm64.docker-id
+
+.amd64.udev.docker-id: Dockerfile.udev
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg host= \
+		--build-arg arch= \
+		--build-arg with_udev=yes \
+		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
+		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
+		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
+		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
+		--build-arg VERSION="$(shell nbgv get-version -v SemVer2)" \
+		. \
+		-f Dockerfile.udev \
+		-t $(registry)/$(image):latest-udev-amd64
+	docker images --no-trunc --quiet $(registry)/$(image):latest-udev-amd64 > .amd64.udev.docker-id

--- a/src/usbmuxd/default.yaml
+++ b/src/usbmuxd/default.yaml
@@ -1,0 +1,2 @@
+image: gcr.io/distroless/base-debian10
+install_packages: false

--- a/src/usbmuxd/udev.yaml
+++ b/src/usbmuxd/udev.yaml
@@ -1,0 +1,2 @@
+image: debian:10
+install_packages: true


### PR DESCRIPTION
By default, we build libusb with `--enable-udev=no`.
On Linux environments where usbfs is not available, `libusb_init` will
fail and usbmuxd will exit with a SIGSEV.

While it's okay for usbmuxd to fail when no USB stack is available
(no iOS devices are present either), this causes issues in CI systems,
where we'd prefer for usbmuxd to run but just report an empty device
list.

As a workaround, we can compile libusb with udev support. This will
cause libusb to report an empty device list and usbmuxd to work
correctly.

Because we don't want udev support in the main container image,
this introduces a new tag, latest-udev-amd64.

The Dockerfiles for usbmuxd with and without udev support are similar,
and are built from a template using gomplate.