### PR TITLE
Fix code coverage report

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,11 +42,6 @@ jobs:
           --
           DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
         working-directory: src/
-        
-      - name: Prepare coverage results
-        run: |
-          ls -l ${{ github.workspace }}/bin/Kaponata.TestResults/
-          ls -l ${{ github.workspace }}/bin/Kaponata.TestResults/**/coverage.cobertura.xml
 
       - name: Publish Operator Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.7
@@ -54,20 +49,21 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "bin/*.TestResults.xml"
-        
-      - name: Publish Operator Coverage Summary
-        uses: 5monkeys/cobertura-action@master
-        if: always()
-        with:
-          path:  ${{ github.workspace }}/bin/Kaponata.TestResults/**/coverage.cobertura.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          minimum_coverage: 75
 
       - name: Generate Code Coverage Report
         uses: danielpalme/ReportGenerator-GitHub-Action@4.8.4
         with:
           reports: ${{ github.workspace }}/bin/Kaponata.TestResults/**/coverage.cobertura.xml
           targetdir: ${{ github.workspace }}/bin/Kaponata.coveragereport
+          reporttypes: 'HtmlInline;Cobertura'
+        
+      - name: Publish Operator Coverage Summary
+        uses: 5monkeys/cobertura-action@master
+        if: always()
+        with:
+          path:  ${{ github.workspace }}/bin/Kaponata.coveragereport/Cobertura.xml
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          minimum_coverage: 75
 
       - name: Upload Code Coverage Report
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The GitHub action which calculates code coverage accepts glob patterns,
but picks the first coverage report which maps that pattern.

We have multiple code coverage reports. This causes the coverage to be
posted in GitHub to be incorrect.

Instead:
- Create a consolidated code coverage report using the report generator
- Upload that report to GitHub.