### PR TITLE
Upload code coverage reports to static website

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,14 +54,14 @@ jobs:
         uses: danielpalme/ReportGenerator-GitHub-Action@4.8.4
         with:
           reports: ${{ github.workspace }}/bin/Kaponata.TestResults/**/coverage.cobertura.xml
-          targetdir: ${{ github.workspace }}/bin/Kaponata.coveragereport
+          targetdir: ${{ github.workspace }}/bin/Kaponata.coveragereport/${{ github.ref }}/
           reporttypes: 'HtmlInline;Cobertura'
         
       - name: Publish Operator Coverage Summary
         uses: 5monkeys/cobertura-action@master
         if: always()
         with:
-          path:  ${{ github.workspace }}/bin/Kaponata.coveragereport/Cobertura.xml
+          path:  ${{ github.workspace }}/bin/Kaponata.coveragereport/${{ github.ref }}/Cobertura.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           minimum_coverage: 75
 
@@ -69,7 +69,32 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: coveragereport
-          path: ${{ github.workspace }}/bin/Kaponata.coveragereport
+          path: ${{ github.workspace }}/bin/${{ github.ref }}/Kaponata.coveragereport
+
+      - name: Publish Operator Coverage Summary to CI website
+        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        with:
+          source_dir: ${{ github.workspace }}/bin/Kaponata.coveragereport/
+          container_name: '$web'
+          connection_string: ${{ secrets.CiStorageConnectionString }}
+          sync: false
+
+      - name: Find Code Coverage Comment
+        uses: peter-evans/find-comment@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: The code coverage report for this pull request
+
+      - name: Create Code Coverage Comment
+        if: ${{ github.event_name == 'pull_request' && steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            The code coverage report for this pull request [is available online](https://ci.kaponata.io/${{ github.ref }}/index.html)
 
       - name: Package operator
         run: |


### PR DESCRIPTION
The code coverage summary is published as a code comment, but the full code coverage report is not easily accessible. (It is uploaded as an artifact, but you'd need to download the artifact, unzip it and then view it).

This PR adds an action which uploads the code coverage report to the ci.kaponata.io blob storage account, and adds a comment to each PR with a link.