### PR TITLE
Add KubernetesClient.ConnectToPodPortAsync

### DIFF
--- a/src/Kaponata.Operator.Tests/Kaponata.Operator.Tests.csproj
+++ b/src/Kaponata.Operator.Tests/Kaponata.Operator.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="3.0.1" PrivateAssets="all" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
     <PackageReference Include="Nerdbank.Streams" Version="2.6.81" />
+    <PackageReference Include="Moq" Version="4.16.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,9 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Kubernetes\Polyfill\kubeconfig.yml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Update="Kubernetes\Polyfill\kubeconfig.yml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesClientTests.PortForward.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesClientTests.PortForward.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="KubernetesClientTests.PortForward.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesClient.ConnectToPodPortAsync"/> method.
+    /// </summary>
+    public partial class KubernetesClientTests
+    {
+        /// <summary>
+        /// <see cref="KubernetesClient.ConnectToPodPortAsync"/> validates its arguments.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represens the asynchronous test.
+        /// </returns>
+        [Fact]
+        public Task ConnectToPodPortAsync_ValidatesArguments_Async()
+        {
+            var handler = new DummyHandler();
+            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+
+            return Assert.ThrowsAsync<ArgumentNullException>(() => client.ConnectToPodPortAsync(null, 1, default));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.ConnectToPodPortAsync"/> creates a correctly configured stream.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
+        [Fact]
+        public async Task ConnectToPodPortAsync_CreatesStream_Async()
+        {
+            var handler = new DummyHandler();
+            var webSocketBuilder = new Mock<WebSocketBuilder>(MockBehavior.Strict);
+            var webSocket = new Mock<WebSocket>();
+
+            webSocketBuilder
+                .Setup(b => b.BuildAndConnectAsync(new Uri("ws://localhost/api/v1/namespaces/default/pods/pod/portforward?ports=8080"), default))
+                .ReturnsAsync(webSocket.Object)
+                .Verifiable();
+
+            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            client.CreateWebSocketBuilder = () => webSocketBuilder.Object;
+
+            var stream = await client.ConnectToPodPortAsync(
+                new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta(name: "pod", namespaceProperty: "default", resourceVersion: "1"),
+                },
+                8080,
+                default).ConfigureAwait(false);
+
+            var portForwardStream = Assert.IsType<PortForwardStream>(stream);
+            Assert.Same(webSocket.Object, portForwardStream.WebSocket);
+
+            // No HTTP traffic
+            Assert.Empty(handler.Requests);
+
+            webSocketBuilder.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesClientTests.Watch.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesClientTests.Watch.cs
@@ -5,6 +5,7 @@
 using k8s;
 using k8s.Models;
 using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging.Abstractions;
 using Nerdbank.Streams;
 using Newtonsoft.Json;
 using System;
@@ -32,7 +33,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
         [Fact]
         public async Task WatchPodAsync_ValidatesArguments_Async()
         {
-            var client = new KubernetesClient(new DummyHandler());
+            var client = new KubernetesClient(new DummyHandler(), NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
             await Assert.ThrowsAsync<ArgumentNullException>("pod", () => client.WatchPodAsync(null, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
             await Assert.ThrowsAsync<ArgumentNullException>("eventHandler", () => client.WatchPodAsync(new V1Pod(), null, default)).ConfigureAwait(false);
         }
@@ -57,7 +58,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler);
+            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
             var result = await client.WatchPodAsync(
                 new V1Pod()
                 {
@@ -103,7 +104,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler);
+            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
             var cts = new CancellationTokenSource();
 
             var watchTask = client.WatchPodAsync(
@@ -156,7 +157,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler);
+            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
             var cts = new CancellationTokenSource();
 
             var ex = await Assert.ThrowsAsync<KubernetesException>(
@@ -198,7 +199,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler);
+            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
             var cts = new CancellationTokenSource();
 
             var watchTask = client.WatchPodAsync(

--- a/src/Kaponata.Operator.Tests/Kubernetes/PortForwardStreamTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/PortForwardStreamTests.cs
@@ -1,0 +1,215 @@
+﻿// <copyright file="PortForwardStreamTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="PortForwardStream"/> class.
+    /// </summary>
+    public class PortForwardStreamTests
+    {
+        /// <summary>
+        /// The <see cref="PortForwardStream"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("webSocket", () => new PortForwardStream(null, NullLogger<PortForwardStream>.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new PortForwardStream(Mock.Of<WebSocket>(), null));
+        }
+
+        /// <summary>
+        /// The <see cref="PortForwardStream"/> class disposes of the underlying socket.
+        /// </summary>
+        [Fact]
+        public void DisposesOfWebSocket()
+        {
+            var socket = new Mock<WebSocket>();
+            socket.Setup(s => s.Dispose()).Verifiable();
+
+            using (var stream = new PortForwardStream(socket.Object, NullLogger<PortForwardStream>.Instance))
+            {
+            }
+
+            socket.Verify();
+        }
+
+        /// <summary>
+        /// The default properties return correct values.
+        /// </summary>
+        [Fact]
+        public void DefaultPropertiesReturnCorrectValeus()
+        {
+            var socket = Mock.Of<WebSocket>();
+
+            using (var stream = new PortForwardStream(socket, NullLogger<PortForwardStream>.Instance))
+            {
+                Assert.True(stream.CanRead);
+                Assert.False(stream.CanSeek);
+                Assert.True(stream.CanWrite);
+                Assert.Same(socket, stream.WebSocket);
+            }
+        }
+
+        /// <summary>
+        /// The properties and methods which are not supported throw a <see cref="NotSupportedException"/>.
+        /// </summary>
+        [Fact]
+        public void NotSupportedMethodsAndPropertiesThrow()
+        {
+            using (var stream = new PortForwardStream(Mock.Of<WebSocket>(), NullLogger<PortForwardStream>.Instance))
+            {
+                Assert.True(stream.CanRead);
+                Assert.False(stream.CanSeek);
+                Assert.True(stream.CanWrite);
+                Assert.Throws<NotSupportedException>(() => stream.Length);
+                Assert.Throws<NotSupportedException>(() => stream.Position);
+                Assert.Throws<NotSupportedException>(() => { stream.Position = 1; });
+                Assert.Throws<NotSupportedException>(() => stream.Read(Array.Empty<byte>(), 0, 0));
+                Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Current));
+                Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
+                Assert.Throws<NotSupportedException>(() => stream.Write(Array.Empty<byte>(), 0, 0));
+            }
+        }
+
+        /// <summary>
+        /// Calls into <see cref="PortForwardStream.ReadAsync(byte[], int, int, CancellationToken)"/> read data from the
+        /// WebSocket. Kubernetes-specific metadata is stripped and the actual payload is copied to the caller.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task ReadMessage_Async()
+        {
+            Queue<(bool, byte[])> packets = new Queue<(bool, byte[])>(
+                new (bool, byte[])[]
+                {
+                    // Initialize stream 0 on port 80
+                    (true, new byte[] { 0, 0, 80 }),
+
+                    // Initialize stream 1 (error stream) on port 80
+                    (true, new byte[] { 1, 0, 80 }),
+
+                    // Partial reads on stream 0, data contains values 1 through 8
+                    (false, new byte[] { 0, 1, 2, 3 }),
+                    (false, new byte[] { 4, 5, 6, 7 }),
+                    (true, new byte[] { 8 }),
+                });
+
+            var socket = new Mock<WebSocket>(MockBehavior.Strict);
+            socket.Setup(s => s.Dispose()).Verifiable();
+            socket
+                .Setup(s => s.ReceiveAsync(It.IsAny<Memory<byte>>(), default))
+                .Returns<Memory<byte>, CancellationToken>((buffer, ct) =>
+                {
+                    (var endOfMessage, byte[] data) = packets.Dequeue();
+                    data.AsMemory().CopyTo(buffer);
+                    ValueWebSocketReceiveResult result =
+                    new ValueWebSocketReceiveResult(data.Length, WebSocketMessageType.Binary, endOfMessage);
+
+                    return ValueTask.FromResult(result);
+                });
+
+            using (var stream = new PortForwardStream(socket.Object, NullLogger<PortForwardStream>.Instance))
+            {
+                byte[] data = new byte[8];
+                Assert.Equal(3, await stream.ReadAsync(data, 0, 8, default).ConfigureAwait(false));
+                Assert.Equal(4, await stream.ReadAsync(data, 3, 5, default).ConfigureAwait(false));
+                Assert.Equal(1, await stream.ReadAsync(data, 7, 1, default).ConfigureAwait(false));
+            }
+
+            socket.Verify();
+        }
+
+        /// <summary>
+        /// Calls into <see cref="PortForwardStream.ReadAsync(byte[], int, int, CancellationToken)"/> read data from the
+        /// WebSocket. Kubernetes-specific metadata is stripped and the actual payload is copied to the caller.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task ReadMessage_HandlesError_Async()
+        {
+            Queue<(bool, byte[])> packets = new Queue<(bool, byte[])>(
+                new (bool, byte[])[]
+                {
+                    // Initialize stream 0 on port 80
+                    (true, new byte[] { 0, 0, 80 }),
+
+                    // Initialize stream 1 (error stream) on port 80
+                    (true, new byte[] { 1, 0, 80 }),
+
+                    // An error message
+                    (true, new byte[] { 1, (byte)'E', (byte)'R', (byte)'R', (byte)'O', (byte)'R' }),
+                });
+
+            var socket = new Mock<WebSocket>(MockBehavior.Strict);
+            socket.Setup(s => s.Dispose()).Verifiable();
+            socket
+                .Setup(s => s.ReceiveAsync(It.IsAny<Memory<byte>>(), default))
+                .Returns<Memory<byte>, CancellationToken>((buffer, ct) =>
+                {
+                    (var endOfMessage, byte[] data) = packets.Dequeue();
+                    data.AsMemory().CopyTo(buffer);
+                    ValueWebSocketReceiveResult result =
+                    new ValueWebSocketReceiveResult(data.Length, WebSocketMessageType.Binary, endOfMessage);
+
+                    return ValueTask.FromResult(result);
+                });
+
+            using (var stream = new PortForwardStream(socket.Object, NullLogger<PortForwardStream>.Instance))
+            {
+                byte[] data = new byte[8];
+                var exception = await Assert.ThrowsAsync<IOException>(() => stream.ReadAsync(data, 0, 8, default)).ConfigureAwait(false);
+                Assert.Equal("ERROR", exception.Message);
+            }
+        }
+
+        /// <summary>
+        /// Calls to <see cref="PortForwardStream.WriteAsync(byte[], int, int, CancellationToken)"/> are handled correctly;
+        /// the data is encapsulated in the Kubernetes-specific protocol and forwarded to the remote end.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task WriteAsync_Works_Async()
+        {
+            byte[] data = new byte[] { 1, 2, 3 };
+            byte[] encapsulatedData = new byte[] { 0, 1, 2, 3 };
+
+            var socket = new Mock<WebSocket>(MockBehavior.Strict);
+            socket.Setup(s => s.Dispose()).Verifiable();
+            socket
+                .Setup(s => s.SendAsync(It.IsAny<ReadOnlyMemory<byte>>(), WebSocketMessageType.Binary, false, default))
+                .Callback<ReadOnlyMemory<byte>, WebSocketMessageType, bool, CancellationToken>(
+                    (buffer, messageType, endOfMessage, cancellationToken)
+                    =>
+                    {
+                        Assert.Equal(encapsulatedData, buffer.ToArray());
+                    })
+                .Returns(ValueTask.CompletedTask);
+
+            using (var stream = new PortForwardStream(socket.Object, NullLogger<PortForwardStream>.Instance))
+            {
+                await stream.WriteAsync(data.AsMemory(), default).ConfigureAwait(false);
+            }
+
+            socket.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesClient.cs
@@ -5,6 +5,7 @@
 using k8s;
 using k8s.Models;
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,6 +45,29 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         Task<WatchExitReason> WatchPodAsync(
             V1Pod pod,
             Func<WatchEventType, V1Pod, Task<WatchResult>> onEvent,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Connects to a TCP port exposed by a pod.
+        /// </summary>
+        /// <param name="pod">
+        /// The pod to which to connect.
+        /// </param>
+        /// <param name="port">
+        /// The TCP port number of the port to which to connect.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns
+        /// a <see cref="Stream"/> which can be used to send and receive data to the remote
+        /// port.
+        /// </returns>
+        Task<Stream> ConnectToPodPortAsync(
+            V1Pod pod,
+            int port,
             CancellationToken cancellationToken);
     }
 }

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesClient.PortForward.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesClient.PortForward.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="KubernetesClient.PortForward.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// Implements the <see cref="KubernetesClient.ConnectToPodPortAsync(V1Pod, int, CancellationToken)"/> method.
+    /// </summary>
+    public partial class KubernetesClient
+    {
+        /// <inheritdoc/>
+        public async Task<Stream> ConnectToPodPortAsync(V1Pod pod, int port, CancellationToken cancellationToken)
+        {
+            if (pod == null)
+            {
+                throw new ArgumentNullException(nameof(pod));
+            }
+
+            this.logger.LogInformation("Connecting to port {port} on pod {pod}", port, pod.Metadata.Name);
+
+            var webSocket = await this.WebSocketNamespacedPodPortForwardAsync(
+                pod.Metadata.Name,
+                pod.Metadata.NamespaceProperty,
+                new int[] { port },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            this.logger.LogInformation("Connected to port {port} on pod {pod}", port, pod.Metadata.Name);
+            return new PortForwardStream(webSocket, this.loggerFactory.CreateLogger<PortForwardStream>());
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesClient.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 
@@ -13,14 +14,26 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
     /// </summary>
     public partial class KubernetesClient : k8s.Kubernetes, IKubernetesClient
     {
+        private readonly ILogger<KubernetesClient> logger;
+        private readonly ILoggerFactory loggerFactory;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
         /// </summary>
         /// <param name="handler">
         /// The <see cref="HttpMessageHandler"/> which is used to send HTTP requests.
         /// </param>
-        public KubernetesClient(HttpMessageHandler handler)
+        /// <param name="logger">
+        /// A logger which is used when logging.
+        /// </param>
+        /// <param name="loggerFactory">
+        /// A logger factory which is used to create new logger objects.
+        /// </param>
+        public KubernetesClient(HttpMessageHandler handler, ILogger<KubernetesClient> logger, ILoggerFactory loggerFactory)
         {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
             this.HttpClient = new HttpClient(handler);
         }
 
@@ -30,9 +43,18 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// <param name="config">
         /// The Kubernetes client configuration.
         /// </param>
-        public KubernetesClient(k8s.KubernetesClientConfiguration config)
+        /// <param name="logger">
+        /// A logger which is used when logging.
+        /// </param>
+        /// <param name="loggerFactory">
+        /// A logger factory which is used to create new logger objects.
+        /// </param>
+        public KubernetesClient(k8s.KubernetesClientConfiguration config, ILogger<KubernetesClient> logger, ILoggerFactory loggerFactory)
             : base(config)
         {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
             this.FirstMessageHandler = this.HttpClientHandler = CreateRootHandler();
             this.FirstMessageHandler = new WatchHandler(this.HttpClientHandler);
 

--- a/src/Kaponata.Operator/Kubernetes/PortForwardStream.cs
+++ b/src/Kaponata.Operator/Kubernetes/PortForwardStream.cs
@@ -1,0 +1,193 @@
+﻿// <copyright file="PortForwardStream.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Provides read-write access to a port on a Kubernetes pod, using the port-forward protocol.
+    /// </summary>
+    public class PortForwardStream : Stream
+    {
+        private readonly WebSocket webSocket;
+        private readonly ILogger<PortForwardStream> logger;
+
+        private readonly MemoryPool<byte> memoryPool = MemoryPool<byte>.Shared;
+        private bool streamsInitialized = false;
+        private bool newMessage = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortForwardStream"/> class.
+        /// </summary>
+        /// <param name="webSocket">
+        /// A <see cref="WebSocket"/> which represents the connection to the remote port.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which is used when logging.
+        /// </param>
+        public PortForwardStream(WebSocket webSocket, ILogger<PortForwardStream> logger)
+        {
+            this.webSocket = webSocket ?? throw new ArgumentNullException(nameof(webSocket));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets the underlying <see cref="WebSocket"/> which is used when communicating with the remote port.
+        /// </summary>
+        public WebSocket WebSocket
+        {
+            get { return this.webSocket; }
+        }
+
+        /// <inheritdoc/>
+        public override bool CanRead => true;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => true;
+
+        /// <inheritdoc/>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return this.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            // First byte contains the stream index
+            // Byte two and three the port number
+            if (!this.streamsInitialized)
+            {
+                this.logger.LogInformation("Initializing stream. Reading first packets.");
+
+                var tempBuffer = new byte[3];
+                var result = await this.webSocket.ReceiveAsync(tempBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                var port = BinaryPrimitives.ReadInt16LittleEndian(tempBuffer.AsSpan(1, 2));
+                this.logger.LogInformation("Initializing stream: read value {port} on stream {stream}.", port, tempBuffer[0]);
+
+                Debug.Assert(tempBuffer[0] == 0, "The first data packet must relate to stream 0");
+
+                result = await this.webSocket.ReceiveAsync(tempBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                port = BinaryPrimitives.ReadInt16LittleEndian(tempBuffer.AsSpan(1, 2));
+                this.logger.LogInformation("Initializing stream: read value {port} on stream {stream}.", port, tempBuffer[0]);
+
+                Debug.Assert(tempBuffer[0] == 1, "The second data packet must relate to stream 1");
+
+                this.streamsInitialized = true;
+
+                this.logger.LogInformation("Successfully intialized stream.");
+            }
+
+            if (!this.newMessage)
+            {
+                var result = await this.webSocket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+                this.newMessage = result.EndOfMessage;
+
+                this.logger.LogInformation("Read {read}/{count} bytes of a message continuation.", result.Count, buffer.Length);
+                return result.Count;
+            }
+            else
+            {
+                using (var memory = this.memoryPool.Rent(buffer.Length + 1))
+                {
+                    memory.Memory.Span.Fill(0);
+                    var result = await this.webSocket.ReceiveAsync(memory.Memory.Slice(0, buffer.Length + 1), cancellationToken).ConfigureAwait(false);
+                    this.newMessage = result.EndOfMessage;
+
+                    var index = memory.Memory.Span[0];
+                    Debug.Assert(index == 0 || index == 1, "Any data packet must relate to stream 0 or 1");
+
+                    if (index == 0)
+                    {
+                        memory.Memory.Slice(1, result.Count - 1).CopyTo(buffer);
+                        this.logger.LogInformation("Read {read}/{count} bytes of a message continuation.", result.Count, buffer.Length);
+                        return result.Count - 1;
+                    }
+                    else
+                    {
+                        this.logger.LogInformation("Got data on stream {stream}.", index);
+                        var message = Encoding.UTF8.GetString(memory.Memory.Slice(1, result.Count - 1).Span);
+                        throw new IOException(message);
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return this.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            using (var memory = this.memoryPool.Rent(buffer.Length + 1))
+            {
+                memory.Memory.Span[0] = 0;
+                buffer.CopyTo(memory.Memory.Slice(1, buffer.Length));
+
+                await this.webSocket.SendAsync(memory.Memory.Slice(0, buffer.Length + 1), WebSocketMessageType.Binary, endOfMessage: false, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Flush()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            this.webSocket.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Returns a `Stream` which allows you to send and receive data to/from the TCP port on the pod.

The operators will need this to connect to the adb/usbmuxd port on the device daemons.