### PR TITLE
MuxerClient: Move socket handling to MuxerSocketLocator, only operate on Stream objects

### DIFF
--- a/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,7 +37,7 @@ namespace Kaponata.iOS.Tests.Muxer
 
         /// <summary>
         /// <see cref="MuxerClient.TryConnectToMuxerAsync(CancellationToken)"/> returns <see langword="null"/> if
-        /// <see cref="MuxerSocketLocator.GetMuxerSocket"/> returns <see langword="null"/>.
+        /// <see cref="MuxerSocketLocator.ConnectToMuxerAsync(CancellationToken)"/> returns <see langword="null"/>.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous test.
@@ -45,7 +46,7 @@ namespace Kaponata.iOS.Tests.Muxer
         public async Task TryConnectToMuxerAsync_ReturnsNull_Async()
         {
             var locator = new Mock<MuxerSocketLocator>();
-            locator.Setup(l => l.GetMuxerSocket()).Returns((null, null));
+            locator.Setup(l => l.ConnectToMuxerAsync(default)).ReturnsAsync((Stream)null);
 
             var client = new MuxerClient(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance, locator.Object);
             Assert.Null(await client.TryConnectToMuxerAsync(default).ConfigureAwait(false));
@@ -62,7 +63,7 @@ namespace Kaponata.iOS.Tests.Muxer
         public async Task ListDevicesAsync_NoSocket_ReturnsEmptyList_Async()
         {
             var locator = new Mock<MuxerSocketLocator>();
-            locator.Setup(l => l.GetMuxerSocket()).Returns((null, null));
+            locator.Setup(l => l.ConnectToMuxerAsync(default)).ReturnsAsync((Stream)null);
 
             var client = new MuxerClient(NullLogger<MuxerClient>.Instance, NullLoggerFactory.Instance, locator.Object);
             var result = await client.ListDevicesAsync(default).ConfigureAwait(false);

--- a/src/Kaponata.iOS/Muxer/MuxerClient.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerClient.cs
@@ -4,8 +4,6 @@
 
 using Microsoft.Extensions.Logging;
 using System;
-using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -65,17 +63,15 @@ namespace Kaponata.iOS.Muxer
         /// </returns>
         public virtual async Task<MuxerProtocol> TryConnectToMuxerAsync(CancellationToken cancellationToken)
         {
-            (Socket socket, EndPoint endPoint) = this.socketLocator.GetMuxerSocket();
+            var stream = await this.socketLocator.ConnectToMuxerAsync(cancellationToken).ConfigureAwait(false);
 
-            if (socket == null || endPoint == null)
+            if (stream == null)
             {
                 return null;
             }
 
-            await socket.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
-
             return new MuxerProtocol(
-                new NetworkStream(socket, ownsSocket: true),
+                stream,
                 ownsStream: true,
                 this.loggerFactory.CreateLogger<MuxerProtocol>());
         }

--- a/src/Kaponata.iOS/Muxer/MuxerSocketLocator.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerSocketLocator.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Kaponata.iOS.Muxer
 {
@@ -44,6 +46,29 @@ namespace Kaponata.iOS.Muxer
         public MuxerSocketLocator()
         {
             this.isWindowsSubsystemForLinux = new Lazy<bool>(this.GetIsWindowsSubsystemForLinux);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Stream"/> which represents a connection to the usbmuxd daemon.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public virtual async Task<Stream> ConnectToMuxerAsync(CancellationToken cancellationToken)
+        {
+            (var socket, var endPoint) = this.GetMuxerSocket();
+
+            if (socket == null)
+            {
+                return null;
+            }
+
+            await socket.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
+
+            return new NetworkStream(socket, ownsSocket: true);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR updates the `MuxerSocketLocator` class so that it returns a `Stream` which can be used by the `MuxerClient`. 

Returning a `Socket` and `EndPoint` does not always work: for example, when connecting to a port on a pod running in Kubernetes, we may only get a `Stream`, which represents the connection being tunneled over a WebSocket connection to the API server, and there isn't an actual `Socket` which we can connect to.

So this adds the `Task<Stream> MuxerSocketLocator.ConnectToMuxerAsync(CancellationToken cancellationToken)` API.