### PR TITLE
Scaffold integration tests for the Helm chart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,10 +133,10 @@ jobs:
           k3d cluster create --api-port 6433 -p "80:80@loadbalancer"
 
       - name: Deploy Helm chart
-        run: |
-          set -e
-
-          helm install --wait kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
+        run: >
+          helm install
+          --wait
+          kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
 
       - name: Test chart
         run: >
@@ -157,3 +157,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "bin/*.TestResults.xml"
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test
+          path: |
+            ${{ github.workspace }}/bin/Kaponata.TestResults/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,17 +38,11 @@ jobs:
           dotnet test
           --results-directory ${{ github.workspace }}/bin/Kaponata.TestResults/
           --collect:"XPlat Code Coverage"
-          --logger "junit;LogFileName=${{ github.workspace }}/bin/{assembly}.TestResults.xml"
+          --logger "junit;LogFileName=${{ github.workspace }}/bin/operator-{assembly}.TestResults.xml"
+          --filter FullyQualifiedName\!~Kaponata.Chart.Tests
           --
           DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
         working-directory: src/
-
-      - name: Publish Operator Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.7
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: "bin/*.TestResults.xml"
 
       - name: Generate Code Coverage Report
         uses: danielpalme/ReportGenerator-GitHub-Action@4.8.4
@@ -142,10 +136,24 @@ jobs:
         run: |
           set -e
 
-          helm install kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
+          helm install --wait kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
+
+      - name: Test chart
+        run: >
+          dotnet test
+          --logger "junit;LogFileName=${{ github.workspace }}/bin/chart-{assembly}.TestResults.xml"
+          --filter FullyQualifiedName~Kaponata.Chart.Tests
+        working-directory: src/
 
       - name: Delete k3d cluster
         run: |
           set -e
 
           k3d cluster delete
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.7
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "bin/*.TestResults.xml"

--- a/src/Kaponata.Chart.Tests/Kaponata.Chart.Tests.csproj
+++ b/src/Kaponata.Chart.Tests/Kaponata.Chart.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
+    <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kaponata.iOS\Kaponata.iOS.csproj" />
+    <ProjectReference Include="..\Kaponata.Operator\Kaponata.Operator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kaponata.sln
+++ b/src/Kaponata.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Operator", "Kapona
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Operator.Tests", "Kaponata.Operator.Tests\Kaponata.Operator.Tests.csproj", "{1A33758D-9B24-4014-98A2-1704E553A1C9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Chart.Tests", "Kaponata.Chart.Tests\Kaponata.Chart.Tests.csproj", "{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,18 @@ Global
 		{1A33758D-9B24-4014-98A2-1704E553A1C9}.Release|x64.Build.0 = Release|Any CPU
 		{1A33758D-9B24-4014-98A2-1704E553A1C9}.Release|x86.ActiveCfg = Release|Any CPU
 		{1A33758D-9B24-4014-98A2-1704E553A1C9}.Release|x86.Build.0 = Release|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Debug|x64.Build.0 = Debug|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Debug|x86.Build.0 = Debug|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Release|x64.ActiveCfg = Release|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Release|x64.Build.0 = Release|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Release|x86.ActiveCfg = Release|Any CPU
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,6 +126,7 @@ Global
 		{BC95FA81-5A53-4DA5-B5A9-9AECE881F9AF} = {3C4D2817-BEF8-410D-89F4-DE685E1DB3D0}
 		{24995F8D-5E4F-4B74-BEB3-D11AB2266875} = {E46AA4D7-736B-46D2-80BA-30A5A6FB2FD0}
 		{1A33758D-9B24-4014-98A2-1704E553A1C9} = {3C4D2817-BEF8-410D-89F4-DE685E1DB3D0}
+		{C90977C9-1371-4D1A-B864-34CCFDFBDF0E} = {3C4D2817-BEF8-410D-89F4-DE685E1DB3D0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {734C5F7F-BA19-499C-B9F5-2C3E206557BC}


### PR DESCRIPTION
This PR adds the `Kaponata.Chart.Tests` test project, and updates the CI script to run these tests when the k3d cluster is provisioned.

We can add integration tests (e.g. to verify usbmuxd is running and we can connect to the usbmuxd pods) to this project.