### PR TITLE
Add KubernetesClient.WaitForPodRunningAsync, DeletePodAsync methods

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           --results-directory ${{ github.workspace }}/bin/Kaponata.TestResults/
           --collect:"XPlat Code Coverage"
           --logger "junit;LogFileName=${{ github.workspace }}/bin/operator-{assembly}.TestResults.xml"
-          --filter FullyQualifiedName\!~Kaponata.Chart.Tests
+          --filter "TestCategory!=IntegrationTest"
           --
           DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
         working-directory: src/
@@ -138,11 +138,11 @@ jobs:
           --wait
           kaponata ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
 
-      - name: Test chart
+      - name: Run chart tests and integration tests
         run: >
           dotnet test
           --logger "junit;LogFileName=${{ github.workspace }}/bin/chart-{assembly}.TestResults.xml"
-          --filter FullyQualifiedName~Kaponata.Chart.Tests
+          --filter "TestCategory=IntegrationTest"
         working-directory: src/
 
       - name: Delete k3d cluster

--- a/src/Kaponata.Operator.Tests/Kaponata.Operator.Tests.csproj
+++ b/src/Kaponata.Operator.Tests/Kaponata.Operator.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
     <PackageReference Include="Nerdbank.Streams" Version="2.6.81" />
     <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Divergic.Logging.Xunit" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientIntegrationTests.cs
@@ -1,0 +1,89 @@
+﻿using Divergic.Logging.Xunit;
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Contains integration tests for the <see cref="KubernetesClient"/> class.
+    /// </summary>
+    public class KubernetesClientIntegrationTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesClientIntegrationTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// The test output helper which will be used to log to xunit.
+        /// </param>
+        public KubernetesClientIntegrationTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerFactory = LogFactory.Create(output);
+        }
+
+        /// <summary>
+        /// Runs an integration test for the <see cref="KubernetesClient.WaitForPodRunningAsync"/> method.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task WaitForPodRunning_IntegrationTest_Async()
+        {
+            using (var kubernetes = new KubernetesProtocol(
+                KubernetesClientConfiguration.BuildDefaultConfig(),
+                this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                this.loggerFactory))
+            using (var client = new KubernetesClient(kubernetes, this.loggerFactory.CreateLogger<KubernetesClient>()))
+            {
+                var pods = await kubernetes.ListNamespacedPodAsync("default", fieldSelector: $"metadata.name={FormatName(nameof(this.WaitForPodRunning_IntegrationTest_Async))}").ConfigureAwait(false);
+
+                foreach (var podToDelete in pods.Items)
+                {
+                    await client.DeletePodAsync(podToDelete, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
+                }
+
+                var pod = await kubernetes.CreateNamespacedPodAsync(
+                    new V1Pod()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = FormatName(nameof(this.WaitForPodRunning_IntegrationTest_Async)),
+                            NamespaceProperty = "default",
+                        },
+                        Spec = new V1PodSpec()
+                        {
+                            Containers = new V1Container[]
+                            {
+                                new V1Container()
+                                {
+                                    Name = "nginx",
+                                    Image = "nginx:1.19.6",
+                                },
+                            },
+                        },
+                    },
+                    "default").ConfigureAwait(false);
+
+                await client.WaitForPodRunningAsync(pod, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
+            }
+        }
+
+        private static string FormatName(string value)
+        {
+            return value.ToLower().Replace("_", "-");
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
@@ -1,0 +1,378 @@
+﻿// <copyright file="KubernetesClientTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesClient"/> class.
+    /// </summary>
+    public class KubernetesClientTests
+    {
+        /// <summary>
+        /// The <see cref="KubernetesClient"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("protocol", () => new KubernetesClient(null, NullLogger<KubernetesClient>.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesClient(Mock.Of<IKubernetesProtocol>(), null));
+        }
+
+        /// <summary>
+        /// Calling <see cref="KubernetesClient.Dispose"/> also disposes of the protocol.
+        /// </summary>
+        [Fact]
+        public void Dispose_DisposesProtocol()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance);
+            client.Dispose();
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("pod", () => client.WaitForPodRunningAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> immediately returns when the pod is running.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_PodRunning_Returns_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                await client.WaitForPodRunningAsync(
+                    new V1Pod()
+                    {
+                        Status = new V1PodStatus()
+                        {
+                            Phase = "Running",
+                        },
+                    },
+                    TimeSpan.FromMinutes(1),
+                    default).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> immediately fails when the pod has failed.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_PodFailed_Returns_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => client.WaitForPodRunningAsync(
+                    new V1Pod()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = "my-pod",
+                        },
+                        Status = new V1PodStatus()
+                        {
+                            Phase = "Failed",
+                            Reason = "Something went wrong!",
+                        },
+                    },
+                    TimeSpan.FromMinutes(1),
+                    default)).ConfigureAwait(false);
+
+                Assert.Equal("The pod my-pod has failed: Something went wrong!", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> fails when the pod is deleted.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_PodDeleted_Returns_Async()
+        {
+            var pod =
+                new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-pod",
+                    },
+                    Status = new V1PodStatus()
+                    {
+                        Phase = "Pending",
+                    },
+                };
+
+            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchPodAsync(pod, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // The callback throws an exception when a deleted event was received.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => callback(WatchEventType.Deleted, pod)).ConfigureAwait(false);
+                watchTask.SetException(ex);
+                Assert.Equal("The pod my-pod was deleted.", ex.Message);
+
+                // The watch task propagates this exception.
+                await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> fails when the pod fails.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_PodFails_Returns_Async()
+        {
+            var pod =
+                new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-pod",
+                    },
+                    Status = new V1PodStatus()
+                    {
+                        Phase = "Pending",
+                    },
+                };
+
+            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchPodAsync(pod, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // The callback throws an exception when a deleted event was received.
+                pod.Status.Phase = "Failed";
+                pod.Status.Reason = "Something went wrong!";
+
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => callback(WatchEventType.Modified, pod)).ConfigureAwait(false);
+                watchTask.SetException(ex);
+                Assert.Equal("The pod my-pod has failed: Something went wrong!", ex.Message);
+
+                // The watch task propagates this exception.
+                await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> completes when the pod starts.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_PodStarts_Returns_Async()
+        {
+            var pod =
+                new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-pod",
+                    },
+                    Status = new V1PodStatus()
+                    {
+                        Phase = "Pending",
+                    },
+                };
+
+            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchPodAsync(pod, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // Simulate a first callback where nothing changes. The task keeps listening.
+                Assert.Equal(WatchResult.Continue, await callback(WatchEventType.Modified, pod).ConfigureAwait(false));
+
+                // The callback signals to stop watching when the pod starts.
+                pod.Status.Phase = "Running";
+                Assert.Equal(WatchResult.Stop, await callback(WatchEventType.Modified, pod).ConfigureAwait(false));
+
+                // The watch completes successfully.
+                watchTask.SetResult(WatchExitReason.ClientDisconnected);
+                await task.ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> errors when the API server disconnects.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_ApiDisconnects_Errors_Async()
+        {
+            var pod =
+                new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-pod",
+                    },
+                    Status = new V1PodStatus()
+                    {
+                        Phase = "Pending",
+                    },
+                };
+
+            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchPodAsync(pod, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // Simulate the watch task stopping
+                watchTask.SetResult(WatchExitReason.ServerDisconnected);
+
+                // The watch completes with an exception.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+                Assert.Equal("The API server unexpectedly closed the connection while watching pod my-pod.", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForPodRunningAsync"/> respects the time out passed.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForPodRunning_RespectsTimeout_Async()
+        {
+            var pod =
+                new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-pod",
+                    },
+                    Status = new V1PodStatus()
+                    {
+                        Phase = "Pending",
+                    },
+                };
+
+            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchPodAsync(pod, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.WaitForPodRunningAsync(pod, TimeSpan.Zero, default);
+                Assert.NotNull(callback);
+
+                // The watch completes with an exception.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+                Assert.Equal("The pod my-pod did not transition to the completed state within a timeout of 0 seconds.", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.PortForward.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.PortForward.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="KubernetesClientTests.PortForward.cs" company="Quamotion bv">
+﻿// <copyright file="KubernetesProtocolTests.PortForward.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -16,12 +16,12 @@ using Xunit;
 namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 {
     /// <summary>
-    /// Tests the <see cref="KubernetesClient.ConnectToPodPortAsync"/> method.
+    /// Tests the <see cref="KubernetesProtocol.ConnectToPodPortAsync"/> method.
     /// </summary>
-    public partial class KubernetesClientTests
+    public partial class KubernetesProtocolTests
     {
         /// <summary>
-        /// <see cref="KubernetesClient.ConnectToPodPortAsync"/> validates its arguments.
+        /// <see cref="KubernetesProtocol.ConnectToPodPortAsync"/> validates its arguments.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> which represens the asynchronous test.
@@ -30,13 +30,13 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
         public Task ConnectToPodPortAsync_ValidatesArguments_Async()
         {
             var handler = new DummyHandler();
-            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(handler, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
 
             return Assert.ThrowsAsync<ArgumentNullException>(() => client.ConnectToPodPortAsync(null, 1, default));
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.ConnectToPodPortAsync"/> creates a correctly configured stream.
+        /// <see cref="KubernetesProtocol.ConnectToPodPortAsync"/> creates a correctly configured stream.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous unit test.
@@ -53,7 +53,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
                 .ReturnsAsync(webSocket.Object)
                 .Verifiable();
 
-            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(handler, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
             client.CreateWebSocketBuilder = () => webSocketBuilder.Object;
 
             var stream = await client.ConnectToPodPortAsync(

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.Watch.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.Watch.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="KubernetesClientTests.Watch.cs" company="Quamotion bv">
+﻿// <copyright file="KubernetesProtocolTests.Watch.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -20,12 +20,12 @@ using Xunit;
 namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 {
     /// <summary>
-    /// Tests the <see cref="KubernetesClient.WatchPodAsync"/> method.
+    /// Tests the <see cref="KubernetesProtocol.WatchPodAsync"/> method.
     /// </summary>
-    public partial class KubernetesClientTests
+    public partial class KubernetesProtocolTests
     {
         /// <summary>
-        /// The <see cref="KubernetesClient.WatchPodAsync"/> method validates the parameters passed to it.
+        /// The <see cref="KubernetesProtocol.WatchPodAsync"/> method validates the parameters passed to it.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous test.
@@ -33,13 +33,13 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
         [Fact]
         public async Task WatchPodAsync_ValidatesArguments_Async()
         {
-            var client = new KubernetesClient(new DummyHandler(), NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(new DummyHandler(), NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
             await Assert.ThrowsAsync<ArgumentNullException>("pod", () => client.WatchPodAsync(null, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
             await Assert.ThrowsAsync<ArgumentNullException>("eventHandler", () => client.WatchPodAsync(new V1Pod(), null, default)).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// The <see cref="KubernetesClient.WatchPodAsync"/> method immediately exists if it receives empty content.
+        /// The <see cref="KubernetesProtocol.WatchPodAsync"/> method immediately exists if it receives empty content.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous test.
@@ -58,7 +58,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(handler, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
             var result = await client.WatchPodAsync(
                 new V1Pod()
                 {
@@ -82,7 +82,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
         }
 
         /// <summary>
-        /// The <see cref="KubernetesClient.WatchPodAsync"/> method can be cancelled.
+        /// The <see cref="KubernetesProtocol.WatchPodAsync"/> method can be cancelled.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous test.
@@ -104,7 +104,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(handler, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
             var cts = new CancellationTokenSource();
 
             var watchTask = client.WatchPodAsync(
@@ -126,7 +126,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
         }
 
         /// <summary>
-        /// The <see cref="KubernetesClient.WatchPodAsync"/> method throws an exception when a Kubernetes
+        /// The <see cref="KubernetesProtocol.WatchPodAsync"/> method throws an exception when a Kubernetes
         /// error occurs.
         /// </summary>
         /// <returns>
@@ -157,7 +157,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(handler, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
             var cts = new CancellationTokenSource();
 
             var ex = await Assert.ThrowsAsync<KubernetesException>(
@@ -176,7 +176,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
         }
 
         /// <summary>
-        /// The <see cref="KubernetesClient.WatchPodAsync"/> method returns when the client
+        /// The <see cref="KubernetesProtocol.WatchPodAsync"/> method returns when the client
         /// returns <see cref="WatchResult.Stop"/>.
         /// </summary>
         /// <returns>
@@ -199,7 +199,7 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 
             Collection<(WatchEventType, V1Pod)> events = new Collection<(WatchEventType, V1Pod)>();
 
-            var client = new KubernetesClient(handler, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesProtocol(handler, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance);
             var cts = new CancellationTokenSource();
 
             var watchTask = client.WatchPodAsync(

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="KubernetesClientTests.cs" company="Quamotion bv">
+﻿// <copyright file="KubernetesProtocolTests.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -15,34 +15,34 @@ using Xunit;
 namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
 {
     /// <summary>
-    /// Tests the <see cref="KubernetesClient"/> class.
+    /// Tests the <see cref="KubernetesProtocol"/> class.
     /// </summary>
-    public partial class KubernetesClientTests
+    public partial class KubernetesProtocolTests
     {
         /// <summary>
-        /// The <see cref="KubernetesClient"/> constructor should validate its arguments.
+        /// The <see cref="KubernetesProtocol"/> constructor should validate its arguments.
         /// </summary>
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new KubernetesClient((HttpMessageHandler)null, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesClient(new SocketsHttpHandler(), null, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesClient(new SocketsHttpHandler(), NullLogger<KubernetesClient>.Instance, null));
+            Assert.Throws<ArgumentNullException>(() => new KubernetesProtocol((HttpMessageHandler)null, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesProtocol(new SocketsHttpHandler(), null, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesProtocol(new SocketsHttpHandler(), NullLogger<KubernetesProtocol>.Instance, null));
 
-            Assert.Throws<KubeConfigException>(() => new KubernetesClient((KubernetesClientConfiguration)null, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesClient(KubernetesClientConfiguration.BuildConfigFromConfigFile("Kubernetes/Polyfill/kubeconfig.yml"), null, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesClient(KubernetesClientConfiguration.BuildConfigFromConfigFile("Kubernetes/Polyfill/kubeconfig.yml"), NullLogger<KubernetesClient>.Instance, null));
+            Assert.Throws<KubeConfigException>(() => new KubernetesProtocol((KubernetesClientConfiguration)null, NullLogger<KubernetesProtocol>.Instance, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesProtocol(KubernetesClientConfiguration.BuildConfigFromConfigFile("Kubernetes/Polyfill/kubeconfig.yml"), null, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesProtocol(KubernetesClientConfiguration.BuildConfigFromConfigFile("Kubernetes/Polyfill/kubeconfig.yml"), NullLogger<KubernetesProtocol>.Instance, null));
         }
 
         /// <summary>
-        /// The <see cref="KubernetesClient"/> class reads its configuration from the Kubernetes config file.
+        /// The <see cref="KubernetesProtocol"/> class reads its configuration from the Kubernetes config file.
         /// </summary>
         [Fact]
         public void KubernetesClient_IsConfigured()
         {
-            using (var client = new KubernetesClient(
+            using (var client = new KubernetesProtocol(
                 KubernetesClientConfiguration.BuildConfigFromConfigFile("Kubernetes/Polyfill/kubeconfig.yml"),
-                NullLogger<KubernetesClient>.Instance,
+                NullLogger<KubernetesProtocol>.Instance,
                 NullLoggerFactory.Instance))
             {
                 Assert.Collection(

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -152,6 +152,11 @@ namespace Kaponata.Operator.Kubernetes
                 },
                 cts.Token);
 
+            await this.protocol.DeleteNamespacedPodAsync(
+                pod.Metadata.Name,
+                pod.Metadata.NamespaceProperty,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
             if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)
             {
                 cts.Cancel();

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -1,0 +1,142 @@
+﻿// <copyright file="KubernetesClient.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Performs high-level transactions (such as creating a Pod, waiting for a pod to enter a specific state,...)
+    /// on top of the <see cref="IKubernetesProtocol"/>.
+    /// </summary>
+    public class KubernetesClient : IDisposable
+    {
+        private readonly IKubernetesProtocol protocol;
+        private readonly ILogger<KubernetesClient> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
+        /// </summary>
+        /// <param name="protocol">
+        /// The protocol to use to communicate with the Kubernetes API server.
+        /// </param>
+        /// <param name="logger">
+        /// The logger to use when logging.
+        /// </param>
+        public KubernetesClient(IKubernetesProtocol protocol, ILogger<KubernetesClient> logger)
+        {
+            this.protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Asynchronously waits for a pod to enter the running phase.
+        /// </summary>
+        /// <param name="pod">
+        /// The pod which should enter the running state.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time in which the pod should enter the running state.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="V1Pod"/>.
+        /// </returns>
+        public virtual async Task<V1Pod> WaitForPodRunningAsync(V1Pod pod, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (pod == null)
+            {
+                throw new ArgumentNullException(nameof(pod));
+            }
+
+            if (IsRunning(pod))
+            {
+                return pod;
+            }
+
+            if (HasFailed(pod, out Exception ex))
+            {
+                throw ex;
+            }
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cancellationToken.Register(cts.Cancel);
+
+            var watchTask = this.protocol.WatchPodAsync(
+                pod,
+                onEvent: (type, updatedPod) =>
+                {
+                    pod = updatedPod;
+
+                    if (type == WatchEventType.Deleted)
+                    {
+                        throw new KubernetesException($"The pod {pod.Metadata.Name} was deleted.");
+                    }
+
+                    // Wait for the pod to be ready. Since we work with init containers, merely waiting for the pod to have an IP address is not enough -
+                    // we need both 'Running' status _and_ and IP address
+                    if (IsRunning(pod))
+                    {
+                        return Task.FromResult(WatchResult.Stop);
+                    }
+
+                    if (HasFailed(pod, out Exception ex))
+                    {
+                        throw ex;
+                    }
+
+                    return Task.FromResult(WatchResult.Continue);
+                },
+                cts.Token);
+
+            if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)
+            {
+                cts.Cancel();
+                throw new KubernetesException($"The pod {pod.Metadata.Name} did not transition to the completed state within a timeout of {timeout.TotalSeconds} seconds.");
+            }
+
+            var result = await watchTask.ConfigureAwait(false);
+
+            if (result != WatchExitReason.ClientDisconnected)
+            {
+                throw new KubernetesException($"The API server unexpectedly closed the connection while watching pod {pod.Metadata.Name}.");
+            }
+
+            return pod;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.protocol.Dispose();
+        }
+
+        private static bool IsRunning(V1Pod pod)
+        {
+            return pod != null && pod.Status.Phase == "Running";
+        }
+
+        private static bool HasFailed(V1Pod pod, out Exception ex)
+        {
+            if (pod.Status.Phase == "Failed")
+            {
+                ex = new KubernetesException($"The pod {pod.Metadata.Name} has failed: {pod.Status.Reason}");
+                return true;
+            }
+            else
+            {
+                ex = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesProtocol.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesProtocol.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IKubernetesClient.cs" company="Quamotion bv">
+﻿// <copyright file="IKubernetesProtocol.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -13,9 +13,9 @@ using System.Threading.Tasks;
 namespace Kaponata.Operator.Kubernetes.Polyfill
 {
     /// <summary>
-    /// Extens the <see cref="k8s.IKubernetes"/> client with polyfill methods.
+    /// Extends the <see cref="k8s.IKubernetes"/> client with polyfill methods.
     /// </summary>
-    public interface IKubernetesClient : IKubernetes
+    public interface IKubernetesProtocol : IKubernetes
     {
         /// <summary>
         /// Gets the <see cref="HttpClient"/> used to send HTTP requests.

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.PortForward.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.PortForward.cs
@@ -12,9 +12,9 @@ using System.Threading.Tasks;
 namespace Kaponata.Operator.Kubernetes.Polyfill
 {
     /// <summary>
-    /// Implements the <see cref="KubernetesClient.ConnectToPodPortAsync(V1Pod, int, CancellationToken)"/> method.
+    /// Implements the <see cref="KubernetesProtocol.ConnectToPodPortAsync(V1Pod, int, CancellationToken)"/> method.
     /// </summary>
-    public partial class KubernetesClient
+    public partial class KubernetesProtocol
     {
         /// <inheritdoc/>
         public async Task<Stream> ConnectToPodPortAsync(V1Pod pod, int port, CancellationToken cancellationToken)

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
@@ -13,9 +13,9 @@ using System.Threading.Tasks;
 namespace Kaponata.Operator.Kubernetes.Polyfill
 {
     /// <summary>
-    /// Implements the watch methods on the <see cref="KubernetesClient"/> class.
+    /// Implements the watch methods on the <see cref="KubernetesProtocol"/> class.
     /// </summary>
-    public partial class KubernetesClient
+    public partial class KubernetesProtocol
     {
         /// <inheritdoc/>
         public async Task<WatchExitReason> WatchPodAsync(

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="KubernetesClient.cs" company="Quamotion bv">
+﻿// <copyright file="KubernetesProtocol.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -9,16 +9,16 @@ using System.Net.Http;
 namespace Kaponata.Operator.Kubernetes.Polyfill
 {
     /// <summary>
-    /// The <see cref="KubernetesClient"/> class extends the <see cref="k8s.Kubernetes"/> class
+    /// The <see cref="KubernetesProtocol"/> class extends the <see cref="k8s.Kubernetes"/> class
     /// and provides additional functionality.
     /// </summary>
-    public partial class KubernetesClient : k8s.Kubernetes, IKubernetesClient
+    public partial class KubernetesProtocol : k8s.Kubernetes, IKubernetesProtocol
     {
-        private readonly ILogger<KubernetesClient> logger;
+        private readonly ILogger<KubernetesProtocol> logger;
         private readonly ILoggerFactory loggerFactory;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
+        /// Initializes a new instance of the <see cref="KubernetesProtocol"/> class.
         /// </summary>
         /// <param name="handler">
         /// The <see cref="HttpMessageHandler"/> which is used to send HTTP requests.
@@ -29,7 +29,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// <param name="loggerFactory">
         /// A logger factory which is used to create new logger objects.
         /// </param>
-        public KubernetesClient(HttpMessageHandler handler, ILogger<KubernetesClient> logger, ILoggerFactory loggerFactory)
+        public KubernetesProtocol(HttpMessageHandler handler, ILogger<KubernetesProtocol> logger, ILoggerFactory loggerFactory)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
@@ -38,7 +38,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
+        /// Initializes a new instance of the <see cref="KubernetesProtocol"/> class.
         /// </summary>
         /// <param name="config">
         /// The Kubernetes client configuration.
@@ -49,7 +49,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// <param name="loggerFactory">
         /// A logger factory which is used to create new logger objects.
         /// </param>
-        public KubernetesClient(k8s.KubernetesClientConfiguration config, ILogger<KubernetesClient> logger, ILoggerFactory loggerFactory)
+        public KubernetesProtocol(k8s.KubernetesClientConfiguration config, ILogger<KubernetesProtocol> logger, ILoggerFactory loggerFactory)
             : base(config)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));


### PR DESCRIPTION
This PR introduces the `KubernetesClient` class (and renames the old `KubernetesClient` to `KubernetesProtocol`), which provides high-level Kubernetes tasks.

In this PR, the first methods being added are:
- `KubernetesClient.WaitForPodRunningAsync`.
- `KubernetesClient.DeletePodAsync`