### PR TITLE
KubernetesClient: Update API

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,10 @@ jobs:
 
       - name: Provision CI environment
         run: |
+          set -e
+
+          sudo apt-get update
+
           ansible-galaxy install geerlingguy.docker
           ansible-galaxy install geerlingguy.nodejs
           ansible-galaxy install andrewrothstein.k3d

--- a/docs/KubernetesClient.md
+++ b/docs/KubernetesClient.md
@@ -1,0 +1,127 @@
+# The motivation for the `KubernetesClient` class
+
+Although the Kubernetes project provides an official .NET client for Kubernetes: [KubernetesClient][1], Kaponata has its own
+`KubernetesClient` class.
+
+It's a thin wrapper around the `IKubernetes` interface which is part of the "official" [KubernetesClient][1], and attempts to make
+interacting with the Kubernets APIs in a .NET project a bit more enjoyable.
+
+It tries to achieve a couple of goals, which are outlined in this document.
+
+## Support mocking
+
+Not all of the APIs which the [KubernetesClient][1] exposes are methods on the `IKubernetes` interface. For example, some of them
+are extension methods. This makes mocking the Kubernetes API during unit testing cumbersome.
+
+For this reason:
+
+> All Kubernetes APIs which are used by the Kaponata project should be accessible as a `virtual` method on the `KubernetesClient` interface.
+
+## Simple watch algorithms
+
+The Kaponata operators observe the Kubernetes state and want to run a reconciliation loop whenever the state changes. This involves
+watching Kubernetes objects.
+
+[KubernetesClient][1] supports watching objects, via the `Watch<T>` object. Let's say you want to wait asynchronously wait for a
+pod to be deleted, with support for cancellation and timeouts. You may end up with code like this:
+
+```csharp
+private async Task WaitForPodDeleted(V1Pod pod, TimeSpan timeout, CancellationToken cancellationToken)
+{
+    TaskCompletionSource tcs = new TaskCompletionSource();
+    cancellationToken.Register(tcs.SetCanceled);
+
+    using (var response =
+        await this.protocol.ListNamespacedPodWithHttpMessagesAsync(
+            pod.Metadata.NamespaceProperty,
+            fieldSelector: $"metadata.name={pod.Metadata.Name}",
+            watch: true,
+            cancellationToken: cancellationToken).ConfigureAwait(false))
+    using (var watcher = response.Watch<V1Pod, V1PodList>(
+        onEvent: (eventType, pod) =>
+        {
+            if (eventType == WatchEventType.Deleted)
+            {
+                tcs.SetResult();
+            }
+        },
+        onError: (ex) =>
+        {
+            tcs.SetException(ex);
+        },
+        onClosed: () =>
+        {
+            tcs.SetCanceled();
+        }))
+    {
+        if (await Task.WhenAny(tcs.Task, Task.Delay(timeout)).ConfigureAwait(false) != tcs.Task)
+        {
+            throw new TimeoutException();
+        }
+    }
+}
+```
+
+That's a lot of code for a simple operation.
+
+At the core, the `Watcher<T>` class has an inner task which reads objects off a HTTP stream and invokes a callback. But
+that task is not exposed to the consumers of the `Watcher<T>` class. This means you'll need to use a `TaskCompletionSource`
+to reconstruct a task-like API. At the end, there are _two_ tasks running instead of one, and that feels like overhead.
+
+The `Watcher<T>` class _does not_ support mocking: there is no interface you can mock nor are the methods it exposes
+virtual.
+
+Finally, the `Watcher<T>` class also suffers from some issues - for example, it [does not attempt to reconnect when the
+connection with the Kubernetes server times out][2].
+
+For this reason:
+
+> The `KubernetesClient` class implements its own API for watching. It returns a `Task` which will complete when the watch
+> operation has completed, and notifies the caller of the reason for completion. It takes a single `onEvent` callback, which
+> the caller can use to instruct the watcher to continue watching for events or to exit:
+> ```csharp
+> Task<WatchExitReason> WatchPodAsync(
+>            V1Pod pod,
+>            Func<WatchEventType, V1Pod, Task<WatchResult>> onEvent,
+>            CancellationToken cancellationToken);
+> ```
+
+## Friendly exceptions
+
+By default, the [KubernetesClient][1] will throw a `HttpOperationException` when something goes wrong. This exception will have
+a generic error message, like `Microsoft.Rest.HttpOperationException: 'Operation returned an invalid status code '422'`.
+
+The Kubernetes API server actually returns more detailed 
+
+[This was closed as by design][3], but having to dig into an exception property to get the actual error message is not acceptable to the Kaponata project. Therefore:
+
+> The methods on the `KubernetesClient` will intercept `HttpOperationException` values and, where possible:
+> 1. Extract the `V1Status` object from the API server response.
+> 2. Throw an exception which includes the `V1Status.Message` in the exception message.
+> 3. Include the `V1Status` object in a property of the exception.
+
+## `TryRead*` methods
+
+Code may want to check for the existence of a specific Kubernetes object. By default, the `Read*`/`Get*` methods in the 
+[KubernetesClient][1] will throw an exception when the object was not found which you need to catch.
+
+Alternatively, you can do a `List*` operation and check whether the list is empty or not. This results in overhead.
+
+For this reason:
+
+> The `KubernetesClient` will exposes a `V1* TryRead*(string namespace, string name, CancellationToken cancellationToken)` 
+> method which returns the object if found, or `null` if the object does not exist.W
+
+## Overall API shape
+
+The current API shape for an individual object looks like this:
+
+```csharp
+Task<V1Pod> CreatePodAsync(V1Pod value, CancellationToken cancellationToken);
+Task<V1Pod> TryReadPodAsync(string @namespace, string name, CancellationToken cancellationToken);
+Task DeletePodAsync(V1Pod value, TimeSpan timeout, CancellationToken cancellationToken);
+```
+
+[1]: https://github.com/kubernetes-client/csharp
+[2]: https://github.com/kubernetes-client/csharp/issues/533
+[3]: https://github.com/kubernetes-client/csharp/issues/58

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientIntegrationTests.cs
@@ -49,14 +49,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 this.loggerFactory))
             using (var client = new KubernetesClient(kubernetes, this.loggerFactory.CreateLogger<KubernetesClient>()))
             {
-                var pods = await kubernetes.ListNamespacedPodAsync("default", fieldSelector: $"metadata.name={FormatName(nameof(this.WaitForPodRunning_IntegrationTest_Async))}").ConfigureAwait(false);
+                V1Pod pod;
 
-                foreach (var podToDelete in pods.Items)
+                if ((pod = await client.TryReadPodAsync("default", FormatName(nameof(this.WaitForPodRunning_IntegrationTest_Async)), default).ConfigureAwait(false)) != null)
                 {
-                    await client.DeletePodAsync(podToDelete, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
+                    await client.DeletePodAsync(pod, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
 
-                var pod = await kubernetes.CreateNamespacedPodAsync(
+                pod = await client.CreatePodAsync(
                     new V1Pod()
                     {
                         Metadata = new V1ObjectMeta()
@@ -76,7 +76,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                             },
                         },
                     },
-                    "default").ConfigureAwait(false);
+                    default).ConfigureAwait(false);
 
                 await client.WaitForPodRunningAsync(pod, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
             }

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
@@ -62,7 +62,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
             {
-                await Assert.ThrowsAsync<ArgumentNullException>("pod", () => client.WaitForPodRunningAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.WaitForPodRunningAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
 
             protocol.Verify();
@@ -392,7 +392,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
             {
-                await Assert.ThrowsAsync<ArgumentNullException>("pod", () => client.DeletePodAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.DeletePodAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
 
             protocol.Verify();
@@ -461,6 +461,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
             var pod =
                 new V1Pod()
                 {
+                    Kind = V1Pod.KubeKind,
                     Metadata = new V1ObjectMeta()
                     {
                         Name = "my-pod",
@@ -498,7 +499,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
                 // The watch completes with an exception.
                 var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
-                Assert.Equal("The API server unexpectedly closed the connection while watching pod my-pod.", ex.Message);
+                Assert.Equal("The API server unexpectedly closed the connection while watching Pod 'my-pod'.", ex.Message);
             }
 
             protocol.Verify();
@@ -514,6 +515,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
             var pod =
                 new V1Pod()
                 {
+                    Kind = V1Pod.KubeKind,
                     Metadata = new V1ObjectMeta()
                     {
                         Name = "my-pod",
@@ -548,10 +550,108 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
                 // The watch completes with an exception.
                 var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
-                Assert.Equal("The pod my-pod was not deleted within a timeout of 0 seconds.", ex.Message);
+                Assert.Equal("The Pod 'my-pod' was not deleted within a timeout of 0 seconds.", ex.Message);
             }
 
             protocol.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.CreatePodAsync(V1Pod, CancellationToken)"/> method validates the arguments passed to it.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreatePodAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.CreatePodAsync(null, default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ValidationException>(() => client.CreatePodAsync(new V1Pod(), default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ValidationException>(() => client.CreatePodAsync(new V1Pod() { Metadata = new V1ObjectMeta() }, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.CreatePodAsync(V1Pod, CancellationToken)"/> method captures any <see cref="V1Status"/> error messages
+        /// embedded in Kubernetes responses.
+        /// </summary>
+        /// <param name="statusCode">
+        /// The status code returned by the server.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(HttpStatusCode.Conflict)]
+        [InlineData(HttpStatusCode.UnprocessableEntity)]
+        public async Task CreatePodAsync_CapturesKubernetesError_Async(HttpStatusCode statusCode)
+        {
+            const string status = @"{""kind"":""Status"",""apiVersion"":""v1"",""metadata"":{},""status"":""Failure"",""message"":""pods 'waitforpodrunning-integrationtest-async' already exists"",""reason"":""AlreadyExists"",""details"":{ ""name"":""waitforpodrunning-integrationtest-async"",""kind"":""pods""},""code"":409}";
+
+            var pod = new V1Pod() { Metadata = new V1ObjectMeta() { NamespaceProperty = "default" } };
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.CreateNamespacedPodWithHttpMessagesAsync(pod, pod.Metadata.NamespaceProperty, null, null, null, null, default))
+                .ThrowsAsync(
+                    new HttpOperationException()
+                    {
+                        Response = new HttpResponseMessageWrapper(
+                            new HttpResponseMessage(statusCode),
+                            status),
+                    });
+
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => client.CreatePodAsync(pod, default)).ConfigureAwait(false);
+                Assert.Equal("pods 'waitforpodrunning-integrationtest-async' already exists", ex.Message);
+                Assert.NotNull(ex.Status);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns the object if the pod exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryReadPod_Found_ReturnsPod_Async()
+        {
+            var pod = new V1Pod();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.ListNamespacedPodWithHttpMessagesAsync("default", null, null, "metadata.name=my-pod", null, null, null, null, null, null, null, null, default))
+                .ReturnsAsync(new HttpOperationResponse<V1PodList>() { Body = new V1PodList() { Items = new V1Pod[] { pod } } });
+
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                Assert.Equal(pod, await client.TryReadPodAsync("default", "my-pod", default).ConfigureAwait(false));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns the <see langword=""="null"/> if the pod does exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryReadPod_NotFound_ReturnsNull_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.ListNamespacedPodWithHttpMessagesAsync("default", null, null, "metadata.name=my-pod", null, null, null, null, null, null, null, null, default))
+                .ReturnsAsync(new HttpOperationResponse<V1PodList>() { Body = new V1PodList() { Items = new V1Pod[] { } } });
+
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                Assert.Null(await client.TryReadPodAsync("default", "my-pod", default).ConfigureAwait(false));
+            }
         }
     }
 }

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="KubernetesClient.Delete.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Contains generic methods for deleting Kubernetes objects.
+    /// </summary>
+    public partial class KubernetesClient
+    {
+        private delegate Task<T> DeleteNamespacedObjectAsyncDelegate<T>(
+            string name,
+            string namespaceParameter,
+            V1DeleteOptions body = null,
+            string dryRun = null,
+            int? gracePeriodSeconds = null,
+            bool? orphanDependents = null,
+            string propagationPolicy = null,
+            string pretty = null,
+            CancellationToken cancellationToken = default)
+            where T : IKubernetesObject<V1ObjectMeta>;
+
+        private async Task DeleteNamespacedObjectAsync<T>(
+            T value,
+            DeleteNamespacedObjectAsyncDelegate<T> deleteAction,
+            WatchObjectAsyncDelegate<T> watchAction,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+            where T : IKubernetesObject<V1ObjectMeta>
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cancellationToken.Register(cts.Cancel);
+
+            var watchTask = watchAction(
+                value,
+                onEvent: (type, updatedValue) =>
+                {
+                    value = updatedValue;
+
+                    if (type == WatchEventType.Deleted)
+                    {
+                        return Task.FromResult(WatchResult.Stop);
+                    }
+
+                    return Task.FromResult(WatchResult.Continue);
+                },
+                cts.Token);
+
+            await deleteAction(
+                value.Metadata.Name,
+                value.Metadata.NamespaceProperty,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)
+            {
+                cts.Cancel();
+                throw new KubernetesException($"The {value.Kind} '{value.Metadata.Name}' was not deleted within a timeout of {timeout.TotalSeconds} seconds.");
+            }
+
+            var result = await watchTask.ConfigureAwait(false);
+
+            if (result != WatchExitReason.ClientDisconnected)
+            {
+                throw new KubernetesException($"The API server unexpectedly closed the connection while watching {value.Kind} '{value.Metadata.Name}'.");
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
@@ -31,7 +31,7 @@ namespace Kaponata.Operator.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the newly created pod
         /// when completed.
         /// </returns>
-        public Task<V1Pod> CreatePodAsync(V1Pod value, CancellationToken cancellationToken)
+        public virtual Task<V1Pod> CreatePodAsync(V1Pod value, CancellationToken cancellationToken)
         {
             if (value == null)
             {
@@ -43,7 +43,7 @@ namespace Kaponata.Operator.Kubernetes
                 throw new ValidationException(ValidationRules.CannotBeNull, "value.Metadata.NamespaceProperty");
             }
 
-            return this.RunTaskAsync(this.protocol.CreateNamespacedPodAsync(value, value?.Metadata?.NamespaceProperty, cancellationToken: cancellationToken));
+            return this.RunTaskAsync(this.protocol.CreateNamespacedPodAsync(value, value.Metadata.NamespaceProperty, cancellationToken: cancellationToken));
         }
 
         /// <summary>

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
@@ -1,0 +1,191 @@
+﻿// <copyright file="KubernetesClient.Pods.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Rest;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Contains methods for working with Kubernetes pods.
+    /// </summary>
+    public partial class KubernetesClient
+    {
+        /// <summary>
+        /// Asynchronously creates a new pod.
+        /// </summary>
+        /// <param name="value">
+        /// The pod to create.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the newly created pod
+        /// when completed.
+        /// </returns>
+        public Task<V1Pod> CreatePodAsync(V1Pod value, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (value.Metadata?.NamespaceProperty == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "value.Metadata.NamespaceProperty");
+            }
+
+            return this.RunTaskAsync(this.protocol.CreateNamespacedPodAsync(value, value?.Metadata?.NamespaceProperty, cancellationToken: cancellationToken));
+        }
+
+        /// <summary>
+        /// Asynchronously tries to read a pod.
+        /// </summary>
+        /// <param name="namespace">
+        /// The namespace in which the pod is located.
+        /// </param>
+        /// <param name="name">
+        /// The name which uniquely identifies the pod within the namespace.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested pod, or
+        /// <see langword="null"/> if the pod does not exist.
+        /// </returns>
+        public virtual async Task<V1Pod> TryReadPodAsync(string @namespace, string name, CancellationToken cancellationToken)
+        {
+            var list = await this.RunTaskAsync(this.protocol.ListNamespacedPodAsync(@namespace, fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return list.Items.SingleOrDefault();
+        }
+
+        /// <summary>
+        /// Asynchronously waits for a pod to enter the running phase.
+        /// </summary>
+        /// <param name="value">
+        /// The pod which should enter the running state.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time in which the pod should enter the running state.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="V1Pod"/>.
+        /// </returns>
+        public virtual async Task<V1Pod> WaitForPodRunningAsync(V1Pod value, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (IsRunning(value))
+            {
+                return value;
+            }
+
+            if (HasFailed(value, out Exception ex))
+            {
+                throw ex;
+            }
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cancellationToken.Register(cts.Cancel);
+
+            var watchTask = this.protocol.WatchPodAsync(
+                value,
+                eventHandler: (type, updatedPod) =>
+                {
+                    value = updatedPod;
+
+                    if (type == WatchEventType.Deleted)
+                    {
+                        throw new KubernetesException($"The pod {value.Metadata.Name} was deleted.");
+                    }
+
+                    // Wait for the pod to be ready. Since we work with init containers, merely waiting for the pod to have an IP address is not enough -
+                    // we need both 'Running' status _and_ and IP address
+                    if (IsRunning(value))
+                    {
+                        return Task.FromResult(WatchResult.Stop);
+                    }
+
+                    if (HasFailed(value, out Exception ex))
+                    {
+                        throw ex;
+                    }
+
+                    return Task.FromResult(WatchResult.Continue);
+                },
+                cts.Token);
+
+            if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)
+            {
+                cts.Cancel();
+                throw new KubernetesException($"The pod {value.Metadata.Name} did not transition to the completed state within a timeout of {timeout.TotalSeconds} seconds.");
+            }
+
+            var result = await watchTask.ConfigureAwait(false);
+
+            if (result != WatchExitReason.ClientDisconnected)
+            {
+                throw new KubernetesException($"The API server unexpectedly closed the connection while watching pod {value.Metadata.Name}.");
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a pod.
+        /// </summary>
+        /// <param name="value">
+        /// The pod to delete.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time in which the pod should be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public virtual Task DeletePodAsync(V1Pod value, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return this.DeleteNamespacedObjectAsync<V1Pod>(
+                value,
+                this.protocol.DeleteNamespacedPodAsync,
+                this.protocol.WatchPodAsync,
+                timeout,
+                cancellationToken);
+        }
+
+        private static bool IsRunning(V1Pod value)
+        {
+            return value.Status.Phase == "Running";
+        }
+
+        private static bool HasFailed(V1Pod value, out Exception ex)
+        {
+            if (value.Status.Phase == "Failed")
+            {
+                ex = new KubernetesException($"The pod {value.Metadata.Name} has failed: {value.Status.Reason}");
+                return true;
+            }
+            else
+            {
+                ex = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesProtocol.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesProtocol.cs
@@ -28,7 +28,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// <param name="pod">
         /// The pod being watched.
         /// </param>
-        /// <param name="onEvent">
+        /// <param name="eventHandler">
         /// An handler which processes a watch event, and lets the watcher know whether
         /// to continue watching or not.
         /// </param>
@@ -44,7 +44,32 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// </returns>
         Task<WatchExitReason> WatchPodAsync(
             V1Pod pod,
-            Func<WatchEventType, V1Pod, Task<WatchResult>> onEvent,
+            Func<WatchEventType, V1Pod, Task<WatchResult>> eventHandler,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously watches a custom resource definition.
+        /// </summary>
+        /// <param name="crd">
+        /// The custom resource definition being watched.
+        /// </param>
+        /// <param name="eventHandler">
+        /// An handler which processes a watch event, and lets the watcher know whether
+        /// to continue watching or not.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the watch operation. The task completes
+        /// when the watcher stops watching for events. The <see cref="WatchExitReason"/>
+        /// return value describes why the watcher stopped. The task errors if the watch
+        /// loop errors.
+        /// </returns>
+        Task<WatchExitReason> WatchCustomResourceDefinitionAsync(
+            V1CustomResourceDefinition crd,
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> eventHandler,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
@@ -5,8 +5,10 @@
 using k8s;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Rest;
 using Microsoft.Rest.Serialization;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,15 +20,78 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
     /// </summary>
     public partial class KubernetesProtocol
     {
+        private delegate
+            Task<HttpOperationResponse<TList>> ListNamespacedObjectWithHttpMessagesAsync<TObject, TList>(
+            string namespaceParameter,
+            bool? allowWatchBookmarks = null,
+            string continueParameter = null,
+            string fieldSelector = null,
+            string labelSelector = null,
+            int? limit = null,
+            string resourceVersion = null,
+            string resourceVersionMatch = null,
+            int? timeoutSeconds = null,
+            bool? watch = null,
+            string pretty = null,
+            Dictionary<string, List<string>> customHeaders = null,
+            CancellationToken cancellationToken = default)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>;
+
+        private delegate
+            Task<HttpOperationResponse<TList>> ListObjectWithHttpMessagesAsync<TObject, TList>(
+            bool? allowWatchBookmarks = null,
+            string continueParameter = null,
+            string fieldSelector = null,
+            string labelSelector = null,
+            int? limit = null,
+            string resourceVersion = null,
+            string resourceVersionMatch = null,
+            int? timeoutSeconds = null,
+            bool? watch = null,
+            string pretty = null,
+            Dictionary<string, List<string>> customHeaders = null,
+            CancellationToken cancellationToken = default)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>;
+
         /// <inheritdoc/>
-        public async Task<WatchExitReason> WatchPodAsync(
-            V1Pod pod,
+        public Task<WatchExitReason> WatchPodAsync(
+            V1Pod value,
             Func<WatchEventType, V1Pod, Task<WatchResult>> eventHandler,
             CancellationToken cancellationToken)
         {
-            if (pod == null)
+            return this.WatchNamespacedObjectAsync(
+                value,
+                this.ListNamespacedPodWithHttpMessagesAsync,
+                eventHandler,
+                cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<WatchExitReason> WatchCustomResourceDefinitionAsync(
+            V1CustomResourceDefinition value,
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> eventHandler,
+            CancellationToken cancellationToken)
+        {
+            return this.WatchObjectAsync(
+                value,
+                this.ListCustomResourceDefinitionWithHttpMessagesAsync,
+                eventHandler,
+                cancellationToken);
+        }
+
+        private async Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
+            TObject value,
+            ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
+            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            CancellationToken cancellationToken)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>
+        {
+            if (value == null)
             {
-                throw new ArgumentNullException(nameof(pod));
+                throw new ArgumentNullException(nameof(value));
             }
 
             if (eventHandler == null)
@@ -34,58 +99,97 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
                 throw new ArgumentNullException(nameof(eventHandler));
             }
 
-            using (var response = await this.ListNamespacedPodWithHttpMessagesAsync(
-                pod.Metadata.NamespaceProperty,
-                fieldSelector: $"metadata.name={pod.Metadata.Name}",
-                resourceVersion: pod.Metadata.ResourceVersion,
+            using (var response = await listOperation(
+                value.Metadata.NamespaceProperty,
+                fieldSelector: $"metadata.name={value.Metadata.Name}",
+                resourceVersion: value.Metadata.ResourceVersion,
                 watch: true,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {
-                using (var watchContent = (WatchHttpContent)response.Response.Content)
-                using (var content = watchContent.OriginalContent)
-                using (var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
-                using (var reader = new StreamReader(stream))
+                return await this.WatchAsync(value, response, eventHandler, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<WatchExitReason> WatchObjectAsync<TObject, TList>(
+            TObject value,
+            ListObjectWithHttpMessagesAsync<TObject, TList> listOperation,
+            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            CancellationToken cancellationToken)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException(nameof(eventHandler));
+            }
+
+            using (var response = await listOperation(
+                fieldSelector: $"metadata.name={value.Metadata.Name}",
+                resourceVersion: value.Metadata.ResourceVersion,
+                watch: true,
+                cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                return await this.WatchAsync(value, response, eventHandler, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<WatchExitReason> WatchAsync<TObject, TList>(
+            TObject value,
+            HttpOperationResponse<TList> response,
+            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            CancellationToken cancellationToken)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>
+        {
+            using (var watchContent = (WatchHttpContent)response.Response.Content)
+            using (var content = watchContent.OriginalContent)
+            using (var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+            using (var reader = new StreamReader(stream))
+            {
+                cancellationToken.Register(watchContent.Dispose);
+
+                string line;
+
+                // ReadLineAsync will return null when we've reached the end of the stream.
+                try
                 {
-                    cancellationToken.Register(watchContent.Dispose);
-
-                    string line;
-
-                    // ReadLineAsync will return null when we've reached the end of the stream.
-                    try
+                    while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
                     {
-                        while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
+                        var genericEvent =
+                            SafeJsonConvert.DeserializeObject<Watcher<KubernetesObject>.WatchEvent>(line);
+
+                        if (genericEvent.Object.Kind == "Status")
                         {
-                            var genericEvent =
-                                SafeJsonConvert.DeserializeObject<Watcher<KubernetesObject>.WatchEvent>(line);
+                            var statusEvent = SafeJsonConvert.DeserializeObject<Watcher<V1Status>.WatchEvent>(line);
+                            this.logger.LogInformation("Stopped watching '{kind}' object '{name}' because of a status event with payload {status}", value.Kind, value.Metadata.Name, statusEvent.Object);
+                            throw new KubernetesException(statusEvent.Object);
+                        }
+                        else
+                        {
+                            var @event = SafeJsonConvert.DeserializeObject<Watcher<TObject>.WatchEvent>(line);
+                            this.logger.LogDebug("Got an {event} event for object {object}", @event.Type, value.Metadata.Name);
 
-                            if (genericEvent.Object.Kind == "Status")
+                            if (await eventHandler(@event.Type, @event.Object).ConfigureAwait(false) == WatchResult.Stop)
                             {
-                                var statusEvent = SafeJsonConvert.DeserializeObject<Watcher<V1Status>.WatchEvent>(line);
-                                this.logger.LogInformation("Stopped watching pod {pod} because of a status event with payload {status}", pod.Metadata.Name, statusEvent.Object);
-                                throw new KubernetesException(statusEvent.Object);
-                            }
-                            else
-                            {
-                                var @event = SafeJsonConvert.DeserializeObject<Watcher<V1Pod>.WatchEvent>(line);
-                                this.logger.LogDebug("Got an {event} event for pod {pod}", @event.Type, pod.Metadata.Name);
-
-                                if (await eventHandler(@event.Type, @event.Object).ConfigureAwait(false) == WatchResult.Stop)
-                                {
-                                    this.logger.LogInformation("Stopped watching pod {pod} because the client requested to stop watching.", pod.Metadata.Name);
-                                    return WatchExitReason.ClientDisconnected;
-                                }
+                                this.logger.LogInformation("Stopped watching '{kind}' object '{name}' because the client requested to stop watching.", value.Kind, value.Metadata.Name);
+                                return WatchExitReason.ClientDisconnected;
                             }
                         }
                     }
-                    catch (Exception ex) when (cancellationToken.IsCancellationRequested)
-                    {
-                        this.logger.LogInformation("Stopped watching {pod} because a cancellation request was received.", pod.Metadata.Name);
-                        throw new TaskCanceledException("The watch operation was cancelled.", ex);
-                    }
-
-                    this.logger.LogInformation("Stopped watching {pod} because the server closed the connection.", pod.Metadata.Name);
-                    return WatchExitReason.ServerDisconnected;
                 }
+                catch (Exception ex) when (cancellationToken.IsCancellationRequested)
+                {
+                    this.logger.LogInformation("Stopped watching '{kind}' object '{name}' because a cancellation request was received.", value.Kind, value.Metadata.Name);
+                    throw new TaskCanceledException("The watch operation was cancelled.", ex);
+                }
+
+                this.logger.LogInformation("Stopped watching '{kind}' object '{name}' because the server closed the connection.", value.Kind, value.Metadata.Name);
+                return WatchExitReason.ServerDisconnected;
             }
         }
     }


### PR DESCRIPTION
Add a simple API for creating, reading an deleting individual pods:

```csharp
Task<V1Pod> CreatePodAsync(V1Pod value, CancellationToken cancellationToken);
Task<V1Pod> TryReadPodAsync(string @namespace, string name, CancellationToken cancellationToken);
Task DeletePodAsync(V1Pod value, TimeSpan timeout, CancellationToken cancellationToken);
```

Have the API translate HTTP errors with `V1Status` messages into `KubernetesException` objects with a clear error message.