### PR TITLE
KubernetesClient: Add methods for working with CRDs

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.CustomResourceDefinition.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.CustomResourceDefinition.cs
@@ -1,0 +1,277 @@
+﻿// <copyright file="KubernetesClientTests.CustomResourceDefinition.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Rest;
+using Moq;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the CRD-specific methods in the <see cref="KubernetesClient"/> class.
+    /// </summary>
+    public partial class KubernetesClientTests
+    {
+        /// <summary>
+        /// The <see cref="KubernetesClient.CreateCustomResourceDefinitionAsync(V1CustomResourceDefinition, CancellationToken)"/> method validates the arguments passed to it.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateCustomResourceDefinitionAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.CreateCustomResourceDefinitionAsync(null, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.CreateCustomResourceDefinitionAsync(V1CustomResourceDefinition, CancellationToken)"/> method calles into <see cref="IKubernetesProtocol"/>.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateCustomResourceDefinitionAsync_UsesProtocol_Async()
+        {
+            var crd = new V1CustomResourceDefinition() { Metadata = new V1ObjectMeta() { Name = "my-crd" } };
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.CreateCustomResourceDefinitionWithHttpMessagesAsync(crd, null, null, null, null, default))
+                .ReturnsAsync(new HttpOperationResponse<V1CustomResourceDefinition>() { Body = crd });
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var result = await client.CreateCustomResourceDefinitionAsync(crd, default).ConfigureAwait(false);
+                Assert.Same(crd, result);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.TryReadCustomResourceDefinitionAsync(string, CancellationToken)"/> returns the object if the pod exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryReadCustomResourceDefinitionAsync_Found_ReturnsPod_Async()
+        {
+            var crd = new V1CustomResourceDefinition();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.ListCustomResourceDefinitionWithHttpMessagesAsync(null, null, "metadata.name=my-crd", null, null, null, null, null, null, null, null, default))
+                .ReturnsAsync(new HttpOperationResponse<V1CustomResourceDefinitionList>() { Body = new V1CustomResourceDefinitionList() { Items = new V1CustomResourceDefinition[] { crd } } });
+
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                Assert.Equal(crd, await client.TryReadCustomResourceDefinitionAsync("my-crd", default).ConfigureAwait(false));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns the <see langword="null"/> if the pod does exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryReadCustomResourceDefinitionAsync_NotFound_ReturnsNull_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.ListCustomResourceDefinitionWithHttpMessagesAsync(null, null, "metadata.name=my-crd", null, null, null, null, null, null, null, null, default))
+                .ReturnsAsync(new HttpOperationResponse<V1CustomResourceDefinitionList>() { Body = new V1CustomResourceDefinitionList() { Items = new V1CustomResourceDefinition[] { } } });
+
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                Assert.Null(await client.TryReadCustomResourceDefinitionAsync("my-crd", default).ConfigureAwait(false));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.DeleteCustomResourceDefinitionAsync"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCustomResourceDefinitionAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.DeleteCustomResourceDefinitionAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.DeleteCustomResourceDefinitionAsync"/> returns when the CustomResourceDefinition is deleted.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCustomResourceDefinitionAsync_CustomResourceDefinitionDeleted_Returns_Async()
+        {
+            var customResourceDefinition =
+                new V1CustomResourceDefinition()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                    Status = new V1CustomResourceDefinitionStatus()
+                    {
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.DeleteCustomResourceDefinitionWithHttpMessagesAsync(customResourceDefinition.Metadata.Name, null, null, null, null, null, null, null, default))
+                .Returns(Task.FromResult(new HttpOperationResponse<V1Status>() { Body = new V1Status(), Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
+
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((customResourceDefinition, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.DeleteCustomResourceDefinitionAsync(customResourceDefinition, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // The callback continues watching until the CustomResourceDefinition is deleted
+                Assert.Equal(WatchResult.Continue, await callback(WatchEventType.Modified, customResourceDefinition).ConfigureAwait(false));
+                Assert.Equal(WatchResult.Stop, await callback(WatchEventType.Deleted, customResourceDefinition).ConfigureAwait(false));
+                watchTask.SetResult(WatchExitReason.ClientDisconnected);
+
+                await task.ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.DeleteCustomResourceDefinitionAsync"/> errors when the API server disconnects.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCustomResourceDefinitionAsync_ApiDisconnects_Errors_Async()
+        {
+            var customResourceDefinition =
+                new V1CustomResourceDefinition()
+                {
+                    Kind = V1CustomResourceDefinition.KubeKind,
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.DeleteCustomResourceDefinitionWithHttpMessagesAsync(customResourceDefinition.Metadata.Name, null, null, null, null, null, null, null, default))
+                .Returns(Task.FromResult(new HttpOperationResponse<V1Status>() { Body = new V1Status(), Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
+
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((customResourceDefinition, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.DeleteCustomResourceDefinitionAsync(customResourceDefinition, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // Simulate the watch task stopping
+                watchTask.SetResult(WatchExitReason.ServerDisconnected);
+
+                // The watch completes with an exception.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+                Assert.Equal("The API server unexpectedly closed the connection while watching CustomResourceDefinition 'my-crd'.", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.DeleteCustomResourceDefinitionAsync"/> respects the time out passed.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCustomResourceDefinitionAsync_RespectsTimeout_Async()
+        {
+            var customResourceDefinition =
+                new V1CustomResourceDefinition()
+                {
+                    Kind = V1CustomResourceDefinition.KubeKind,
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                    Status = new V1CustomResourceDefinitionStatus()
+                    {
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.DeleteCustomResourceDefinitionWithHttpMessagesAsync(customResourceDefinition.Metadata.Name, null, null, null, null, null, null, null, default))
+                .Returns(Task.FromResult(new HttpOperationResponse<V1Status>() { Body = new V1Status(), Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
+
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((customResourceDefinition, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance))
+            {
+                var task = client.DeleteCustomResourceDefinitionAsync(customResourceDefinition, TimeSpan.Zero, default);
+                Assert.NotNull(callback);
+
+                // The watch completes with an exception.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+                Assert.Equal("The CustomResourceDefinition 'my-crd' was not deleted within a timeout of 0 seconds.", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
@@ -626,8 +626,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
         [InlineData("{}")] // Empty json
         [InlineData(@"{""kind"":""Pod"", ""apiVersion"":""v1"" }")] // Unexpected object kind
         [InlineData(@"{""kind"":""Status"", ""apiVersion"":""v1beta1"", ""message"":""pods 'waitforpodrunning-integrationtest-async' already exists""}")] // Unexpected object version
-        [InlineData(@"{""kind"":""Status"", ""apiVersion"":""v1beta1"" ")] // No message
-        [InlineData(@"{""kind"":""Status"", ""apiVersion"":""v1beta1""  ""message"":""""")] // Empty message
+        [InlineData(@"{""kind"":""Status"", ""apiVersion"":""v1beta1"" }")] // No message
+        [InlineData(@"{""kind"":""Status"", ""apiVersion"":""v1beta1"", ""message"":""""}")] // Empty message
         public async Task CreatePodAsync_InvalidKubernetesError_Async(string statusJson)
         {
             var pod = new V1Pod() { Metadata = new V1ObjectMeta() { NamespaceProperty = "default" } };
@@ -639,7 +639,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     new HttpOperationException()
                     {
                         Response = new HttpResponseMessageWrapper(
-                            new HttpResponseMessage(HttpStatusCode.BadRequest),
+                            new HttpResponseMessage(HttpStatusCode.UnprocessableEntity),
                             statusJson),
                     });
 

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
@@ -23,7 +23,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
     /// <summary>
     /// Tests the <see cref="KubernetesClient"/> class.
     /// </summary>
-    public class KubernetesClientTests
+    public partial class KubernetesClientTests
     {
         /// <summary>
         /// The <see cref="KubernetesClient"/> constructor validates its arguments.
@@ -674,7 +674,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns the <see langword=""="null"/> if the pod does exist.
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns <see langword="null"/> if the pod does exist.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Crd.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Crd.cs
@@ -1,0 +1,84 @@
+﻿// <copyright file="KubernetesClient.Crd.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Contains methods for working with Custom Resource Definitions.
+    /// </summary>
+    public partial class KubernetesClient
+    {
+        /// <summary>
+        /// Asynchronously creates a new custom resource definition.
+        /// </summary>
+        /// <param name="value">
+        /// The custom resource definition to create.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the newly created custom resource definition
+        /// when completed.
+        /// </returns>
+        public virtual Task<V1CustomResourceDefinition> CreateCustomResourceDefinitionAsync(V1CustomResourceDefinition value, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return this.RunTaskAsync(this.protocol.CreateCustomResourceDefinitionAsync(value, cancellationToken: cancellationToken));
+        }
+
+        /// <summary>
+        /// Asynchronously tries to read a custom resource definition.
+        /// </summary>
+        /// <param name="name">
+        /// The name which uniquely identifies the custom resource definition.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested custom resource definition., or
+        /// <see langword="null"/> if the custom resource definition does not exist.
+        /// </returns>
+        public virtual async Task<V1CustomResourceDefinition> TryReadCustomResourceDefinitionAsync(string name, CancellationToken cancellationToken)
+        {
+            var list = await this.RunTaskAsync(this.protocol.ListCustomResourceDefinitionAsync(fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return list.Items.SingleOrDefault();
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a custom resource definition.
+        /// </summary>
+        /// <param name="crd">
+        /// The custom resource definition to delete.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time in which the pod should be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public virtual Task DeleteCustomResourceDefinitionAsync(V1CustomResourceDefinition crd, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return this.DeleteObjectAsync<V1CustomResourceDefinition>(
+                crd,
+                this.protocol.DeleteCustomResourceDefinitionAsync,
+                this.protocol.WatchCustomResourceDefinitionAsync,
+                timeout,
+                cancellationToken);
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
@@ -28,6 +28,16 @@ namespace Kaponata.Operator.Kubernetes
             CancellationToken cancellationToken = default)
             where T : IKubernetesObject<V1ObjectMeta>;
 
+        private delegate Task<V1Status> DeleteObjectAsyncDelegate(
+            string name,
+            V1DeleteOptions body = null,
+            string dryRun = null,
+            int? gracePeriodSeconds = null,
+            bool? orphanDependents = null,
+            string propagationPolicy = null,
+            string pretty = null,
+            CancellationToken cancellationToken = default);
+
         private async Task DeleteNamespacedObjectAsync<T>(
             T value,
             DeleteNamespacedObjectAsyncDelegate<T> deleteAction,
@@ -62,6 +72,55 @@ namespace Kaponata.Operator.Kubernetes
             await deleteAction(
                 value.Metadata.Name,
                 value.Metadata.NamespaceProperty,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)
+            {
+                cts.Cancel();
+                throw new KubernetesException($"The {value.Kind} '{value.Metadata.Name}' was not deleted within a timeout of {timeout.TotalSeconds} seconds.");
+            }
+
+            var result = await watchTask.ConfigureAwait(false);
+
+            if (result != WatchExitReason.ClientDisconnected)
+            {
+                throw new KubernetesException($"The API server unexpectedly closed the connection while watching {value.Kind} '{value.Metadata.Name}'.");
+            }
+        }
+
+        private async Task DeleteObjectAsync<T>(
+            T value,
+            DeleteObjectAsyncDelegate deleteAction,
+            WatchObjectAsyncDelegate<T> watchAction,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+            where T : IKubernetesObject<V1ObjectMeta>
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cancellationToken.Register(cts.Cancel);
+
+            var watchTask = watchAction(
+                value,
+                onEvent: (type, updatedValue) =>
+                {
+                    value = updatedValue;
+
+                    if (type == WatchEventType.Deleted)
+                    {
+                        return Task.FromResult(WatchResult.Stop);
+                    }
+
+                    return Task.FromResult(WatchResult.Continue);
+                },
+                cts.Token);
+
+            await deleteAction(
+                value.Metadata.Name,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -59,12 +59,15 @@ namespace Kaponata.Operator.Kubernetes
             {
                 return await task.ConfigureAwait(false);
             }
-            catch (HttpOperationException ex) when (ex.Response.StatusCode == HttpStatusCode.UnprocessableEntity || ex.Response.StatusCode == HttpStatusCode.Conflict)
+            catch (HttpOperationException ex)
+            when (ex.Response != null
+                && ex.Response.Content != null
+                && (ex.Response.StatusCode == HttpStatusCode.UnprocessableEntity || ex.Response.StatusCode == HttpStatusCode.Conflict))
             {
                 // We should get a V1Status with a detailed error message, extract that error message.
                 var status = SafeJsonConvert.DeserializeObject<V1Status>(ex.Response.Content);
 
-                if (status.Kind != V1Status.KubeKind || status.ApiVersion != V1Status.KubeApiVersion || string.IsNullOrEmpty(status.Message))
+                if (status == null || status.Kind != V1Status.KubeKind || status.ApiVersion != V1Status.KubeApiVersion || string.IsNullOrEmpty(status.Message))
                 {
                     throw;
                 }


### PR DESCRIPTION
```csharp
Task<V1CustomResourceDefinition> CreateCustomResourceDefinitionAsync(V1CustomResourceDefinition value, CancellationToken cancellationToken);
Task<V1CustomResourceDefinition> TryReadCustomResourceDefinitionAsync(string name, CancellationToken cancellationToken);
Task DeleteCustomResourceDefinitionAsync(V1CustomResourceDefinition crd, TimeSpan timeout, CancellationToken cancellationToken);
```