### PR TITLE
Install the MobileDevice CRD into the cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .vs/
 bin/
 obj/
+*.user
 
 # Helm charts
 *.tgz

--- a/src/Kaponata.Operator.Tests/ExtensionsInstallerTests.cs
+++ b/src/Kaponata.Operator.Tests/ExtensionsInstallerTests.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="ExtensionsInstallerTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="ExtensionsInstaller"/> class.
+    /// </summary>
+    public class ExtensionsInstallerTests
+    {
+        /// <summary>
+        /// The <see cref="ExtensionsInstaller"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("kubernetesClient", () => new ExtensionsInstaller(null, NullLogger<ExtensionsInstaller>.Instance, new TestConsole()));
+            Assert.Throws<ArgumentNullException>("logger", () => new ExtensionsInstaller(Mock.Of<KubernetesClient>(), null, new TestConsole()));
+            Assert.Throws<ArgumentNullException>("console", () => new ExtensionsInstaller(Mock.Of<KubernetesClient>(), NullLogger<ExtensionsInstaller>.Instance, null));
+        }
+
+        /// <summary>
+        /// The <see cref="ExtensionsInstaller.RunAsync(IHost)"/> uses the services from the host and installs the CRD.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task RunAsync_InstallsCrd_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes
+                .Setup(k => k.InstallOrUpgradeCustomResourceDefinitionAsync(It.IsAny<V1CustomResourceDefinition>(), TimeSpan.FromMinutes(1), default))
+                .Returns<V1CustomResourceDefinition, TimeSpan, CancellationToken>(
+                (crd, timeout, ct) =>
+                {
+                    return Task.FromResult(crd);
+                });
+
+            var builder = new HostBuilder();
+            builder.ConfigureServices(
+                (services) =>
+                {
+                    services.AddSingleton<IConsole, TestConsole>();
+                    services.AddSingleton<KubernetesClient>(kubernetes.Object);
+                    services.AddLogging();
+                    services.AddSingleton<ExtensionsInstaller>();
+                });
+            var host = builder.Build();
+
+            await ExtensionsInstaller.RunAsync(host);
+
+            kubernetes.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.CustomResourceDefinition.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.CustomResourceDefinition.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -269,6 +270,502 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 // The watch completes with an exception.
                 var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
                 Assert.Equal("The CustomResourceDefinition 'my-crd' was not deleted within a timeout of 0 seconds.", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync"/> method validates
+        /// the arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InstallOrUpgradeCustomResourceDefinitionAsync_ValidatesArguments_Async()
+        {
+            var clientMock = new Mock<KubernetesClient>()
+            {
+                CallBase = true,
+            };
+
+            var client = clientMock.Object;
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                    null,
+                    TimeSpan.Zero,
+                    default)).ConfigureAwait(false);
+
+            await Assert.ThrowsAsync<ValidationException>(
+                () => client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                    new V1CustomResourceDefinition() { },
+                    TimeSpan.Zero,
+                    default)).ConfigureAwait(false);
+
+            await Assert.ThrowsAsync<ValidationException>(
+                () => client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                    new V1CustomResourceDefinition()
+                    {
+                        Metadata = new V1ObjectMeta() { },
+                    },
+                    TimeSpan.Zero,
+                    default)).ConfigureAwait(false);
+
+            await Assert.ThrowsAsync<ValidationException>(
+                () => client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                    new V1CustomResourceDefinition()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = "test",
+                        },
+                    },
+                    TimeSpan.Zero,
+                    default)).ConfigureAwait(false);
+
+            await Assert.ThrowsAsync<ValidationException>(
+                () => client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                    new V1CustomResourceDefinition()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = "test",
+                            Labels = new Dictionary<string, string>(),
+                        },
+                    },
+                    TimeSpan.Zero,
+                    default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync"/> method validates
+        /// the arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InstallOrUpgradeCustomResourceDefinitionAsync_CrdNotInstalled_InstallsCrd_Async()
+        {
+            var clientMock = new Mock<KubernetesClient>()
+            {
+                CallBase = true,
+            };
+
+            var timeout = TimeSpan.Zero;
+            var crd = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>()
+                    {
+                        { Annotations.Version, "0.1" },
+                    },
+                },
+            };
+
+            clientMock.Setup(c => c.TryReadCustomResourceDefinitionAsync("test", default)).ReturnsAsync((V1CustomResourceDefinition)null).Verifiable();
+            clientMock.Setup(c => c.CreateCustomResourceDefinitionAsync(crd, default)).ReturnsAsync(crd).Verifiable();
+
+            var client = clientMock.Object;
+
+            await client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                crd,
+                timeout,
+                default).ConfigureAwait(false);
+
+            clientMock.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync"/> method installs
+        /// the updated CRD if the installed CRD has no version attribute.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InstallOrUpgradeCustomResourceDefinitionAsync_CrdHasNoVersionAttribute_DeleteAndInstallsCrd_Async()
+        {
+            var clientMock = new Mock<KubernetesClient>()
+            {
+                CallBase = true,
+            };
+
+            var timeout = TimeSpan.Zero;
+            var crdToInstall = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>()
+                    {
+                        { Annotations.Version, "0.2" },
+                    },
+                },
+            };
+
+            var crdInstalled = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>(),
+                },
+            };
+
+            clientMock.Setup(c => c.TryReadCustomResourceDefinitionAsync("test", default)).ReturnsAsync(crdInstalled).Verifiable();
+            clientMock.Setup(c => c.DeleteCustomResourceDefinitionAsync(crdInstalled, timeout, default)).Returns(Task.CompletedTask).Verifiable();
+            clientMock.Setup(c => c.CreateCustomResourceDefinitionAsync(crdToInstall, default)).ReturnsAsync(crdToInstall).Verifiable();
+
+            var client = clientMock.Object;
+
+            await client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                crdToInstall,
+                timeout,
+                default).ConfigureAwait(false);
+
+            clientMock.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync"/> method installs the CRD if the
+        /// installed CRD is outdated.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InstallOrUpgradeCustomResourceDefinitionAsync_CrdOutdated_DeleteAndInstallsCrd_Async()
+        {
+            var clientMock = new Mock<KubernetesClient>()
+            {
+                CallBase = true,
+            };
+
+            var timeout = TimeSpan.Zero;
+            var crdToInstall = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>()
+                    {
+                        { Annotations.Version, "0.2" },
+                    },
+                },
+            };
+
+            var crdInstalled = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>()
+                    {
+                        { Annotations.Version, "0.1" },
+                    },
+                },
+            };
+
+            clientMock.Setup(c => c.TryReadCustomResourceDefinitionAsync("test", default)).ReturnsAsync(crdInstalled).Verifiable();
+            clientMock.Setup(c => c.DeleteCustomResourceDefinitionAsync(crdInstalled, timeout, default)).Returns(Task.CompletedTask).Verifiable();
+            clientMock.Setup(c => c.CreateCustomResourceDefinitionAsync(crdToInstall, default)).ReturnsAsync(crdToInstall).Verifiable();
+
+            var client = clientMock.Object;
+
+            await client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                crdToInstall,
+                timeout,
+                default).ConfigureAwait(false);
+
+            clientMock.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="KubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync"/> method does nothing if the
+        /// installed CRD is up to date.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InstallOrUpgradeCustomResourceDefinitionAsync_CrdUpToDate_NoOp_Async()
+        {
+            var clientMock = new Mock<KubernetesClient>()
+            {
+                CallBase = true,
+            };
+
+            var timeout = TimeSpan.Zero;
+            var crdToInstall = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>()
+                    {
+                        { Annotations.Version, "0.2" },
+                    },
+                },
+            };
+
+            var crdInstalled = new V1CustomResourceDefinition()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    Labels = new Dictionary<string, string>()
+                    {
+                        { Annotations.Version, "0.2" },
+                    },
+                },
+            };
+
+            clientMock.Setup(c => c.TryReadCustomResourceDefinitionAsync("test", default)).ReturnsAsync(crdInstalled).Verifiable();
+
+            var client = clientMock.Object;
+
+            await client.InstallOrUpgradeCustomResourceDefinitionAsync(
+                crdToInstall,
+                timeout,
+                default).ConfigureAwait(false);
+
+            clientMock.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForCustomResourceDefinitionEstablishedAsync"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForCustomResourceDefinitionEstablishedAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.WaitForCustomResourceDefinitionEstablishedAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForCustomResourceDefinitionEstablishedAsync"/> immediately returns when the CRD is established.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForCustomResourceDefinitionEstablishedAsync_CrdAlreadyEstablished_Returns_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                await client.WaitForCustomResourceDefinitionEstablishedAsync(
+                    new V1CustomResourceDefinition()
+                    {
+                        Status = new V1CustomResourceDefinitionStatus()
+                        {
+                            Conditions = new V1CustomResourceDefinitionCondition[]
+                            {
+                                new V1CustomResourceDefinitionCondition()
+                                {
+                                     Type = "Established",
+                                     Status = "True",
+                                },
+                            },
+                        },
+                    },
+                    TimeSpan.FromMinutes(1),
+                    default).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForCustomResourceDefinitionEstablishedAsync"/> fails when the CRD is deleted.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForCustomResourceDefinitionEstablishedAsync_PodDeleted_Returns_Async()
+        {
+            var crd =
+                new V1CustomResourceDefinition()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((crd, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // The callback throws an exception when a deleted event was received.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => callback(WatchEventType.Deleted, crd)).ConfigureAwait(false);
+                watchTask.SetException(ex);
+                Assert.Equal("The CRD 'my-crd' was deleted.", ex.Message);
+
+                // The watch task propagates this exception.
+                await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForCustomResourceDefinitionEstablishedAsync"/> completes when the CRD is established.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForCustomResourceDefinitionEstablishedAsync_CrdEstablished_Returns_Async()
+        {
+            var crd =
+                new V1CustomResourceDefinition()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // Simulate a first callback where nothing changes. The task keeps listening.
+                Assert.Equal(WatchResult.Continue, await callback(WatchEventType.Modified, crd).ConfigureAwait(false));
+
+                // The callback signals to stop watching when the CRD is established.
+                crd.Status = new V1CustomResourceDefinitionStatus()
+                {
+                    Conditions = new V1CustomResourceDefinitionCondition[]
+                    {
+                        new V1CustomResourceDefinitionCondition()
+                        {
+                            Type = "Established",
+                            Status = "True",
+                        },
+                    },
+                };
+                Assert.Equal(WatchResult.Stop, await callback(WatchEventType.Modified, crd).ConfigureAwait(false));
+
+                // The watch completes successfully.
+                watchTask.SetResult(WatchExitReason.ClientDisconnected);
+                await task.ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForCustomResourceDefinitionEstablishedAsync"/> errors when the API server disconnects.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForCustomResourceDefinitionEstablishedAsync_ApiDisconnects_Errors_Async()
+        {
+            var crd =
+                new V1CustomResourceDefinition()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // Simulate the watch task stopping
+                watchTask.SetResult(WatchExitReason.ServerDisconnected);
+
+                // The watch completes with an exception.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+                Assert.Equal("The API server unexpectedly closed the connection while watching CRD 'my-crd'.", ex.Message);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WaitForCustomResourceDefinitionEstablishedAsync"/> respects the time out passed.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WaitForCustomResourceDefinitionEstablishedAsync_RespectsTimeout_Async()
+        {
+            var crd =
+                new V1CustomResourceDefinition()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-crd",
+                    },
+                };
+
+            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.Zero, default);
+                Assert.NotNull(callback);
+
+                // The watch completes with an exception.
+                var ex = await Assert.ThrowsAsync<KubernetesException>(() => task).ConfigureAwait(false);
+                Assert.Equal("The CRD 'my-crd' was not established within a timeout of 0 seconds.", ex.Message);
             }
 
             protocol.Verify();

--- a/src/Kaponata.Operator.Tests/Models/ModelDefinitionsTests.cs
+++ b/src/Kaponata.Operator.Tests/Models/ModelDefinitionsTests.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="ModelDefinitionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Models;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Models
+{
+    /// <summary>
+    /// Tests the <see cref="ModelDefinitions"/> class.
+    /// </summary>
+    public class ModelDefinitionsTests
+    {
+        /// <summary>
+        /// The <see cref="ModelDefinitions.MobileDevice"/> property returns the correct value.
+        /// </summary>
+        [Fact]
+        public void MobileDevice_Works()
+        {
+            Assert.NotNull(ModelDefinitions.MobileDevice);
+        }
+    }
+}

--- a/src/Kaponata.Operator/ExtensionsInstaller.cs
+++ b/src/Kaponata.Operator/ExtensionsInstaller.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="ExtensionsInstaller.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.CommandLine;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator
+{
+    /// <summary>
+    /// Installs the Kaponata extensions, which cannot be installed using a standard Helm chart, into your cluster.
+    /// </summary>
+    public class ExtensionsInstaller
+    {
+        private readonly KubernetesClient kubernetesClient;
+        private readonly ILogger<ExtensionsInstaller> logger;
+        private readonly IConsole console;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtensionsInstaller"/> class.
+        /// </summary>
+        /// <param name="kubernetesClient">
+        /// A <see cref="KubernetesClient"/> which provides connectivity to the Kubernetes cluster.
+        /// </param>
+        /// <param name="logger">
+        /// A logger to use when logging.
+        /// </param>
+        /// <param name="console">
+        /// The console to use when printing output.
+        /// </param>
+        public ExtensionsInstaller(KubernetesClient kubernetesClient, ILogger<ExtensionsInstaller> logger, IConsole console)
+        {
+            this.kubernetesClient = kubernetesClient ?? throw new ArgumentNullException(nameof(kubernetesClient));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.console = console ?? throw new ArgumentNullException(nameof(console));
+        }
+
+        /// <summary>
+        /// Asynchronously runs the <see cref="ExtensionsInstaller.InstallAsync(CancellationToken)"/> method.
+        /// </summary>
+        /// <param name="host">
+        /// A <see cref="IHost"/> which contains all required services.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public static Task RunAsync(IHost host)
+        {
+            var installer = host.Services.GetRequiredService<ExtensionsInstaller>();
+            return installer.InstallAsync(default);
+        }
+
+        /// <summary>
+        /// Asynchronously installs the Kaponata extensions into the cluster.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task InstallAsync(CancellationToken cancellationToken)
+        {
+            var mobileDeviceCrd = ModelDefinitions.MobileDevice;
+
+            this.logger.LogInformation("Installing the {crdName} custom resource definition", mobileDeviceCrd.Metadata.Name);
+            await this.kubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync(
+                mobileDeviceCrd,
+                TimeSpan.FromMinutes(1),
+                cancellationToken).ConfigureAwait(false);
+            this.logger.LogInformation("Successfully installed the {crdName} custom resource definition.", mobileDeviceCrd.Metadata.Name);
+        }
+    }
+}

--- a/src/Kaponata.Operator/GlobalSuppressions.cs
+++ b/src/Kaponata.Operator/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿// <copyright file="GlobalSuppressions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1303:Const field names should begin with upper-case letter", Justification = "Standard iOS naming", Scope = "member", Target = "~F:Kaponata.Operator.Kubernetes.Annotations.OperatingSystem.iOS")]

--- a/src/Kaponata.Operator/Kaponata.Operator.csproj
+++ b/src/Kaponata.Operator/Kaponata.Operator.csproj
@@ -1,14 +1,23 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Models\MobileDevice.yaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Models\MobileDevice.yaml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Kaponata.iOS\Kaponata.iOS.csproj" />
 
     <PackageReference Include="KubernetesClient" Version="4.0.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20574.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Kaponata.Operator/Kubernetes/Annotations.cs
+++ b/src/Kaponata.Operator/Kubernetes/Annotations.cs
@@ -1,0 +1,99 @@
+﻿// <copyright file="Annotations.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Defines annotations commonly used by Kubernetes.
+    /// </summary>
+    public class Annotations
+    {
+        /// <summary>
+        /// The name of the application.
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"/>
+        public const string Name = "app.kubernetes.io/name";
+
+        /// <summary>
+        /// A unique name identifying the instance of an application.
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"/>
+        public const string Instance = "app.kubernetes.io/instance";
+
+        /// <summary>
+        /// The current version of the application (e.g., a semantic version, revision hash, etc.).
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"/>
+        public const string Version = "app.kubernetes.io/version";
+
+        /// <summary>
+        /// The component within the architecture.
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"/>
+        public const string Component = "app.kubernetes.io/component";
+
+        /// <summary>
+        /// The name of a higher level application this one is part of.
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"/>
+        public const string PartOf = "app.kubernetes.io/part-of";
+
+        /// <summary>
+        /// The tool being used to manage the operation of an application.
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"/>
+        public const string ManagedBy = "app.kubernetes.io/managed-by";
+
+        /// <summary>
+        /// The architecture of the Kubernetes node or mobile device.
+        /// </summary>
+        /// <seealso href="https://v1-17.docs.kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-arch"/>
+        public const string Arch = "kubernetes.io/arch";
+
+        /// <summary>
+        /// The operating system of the Kubernetes node or mobile device.
+        /// </summary>
+        /// <seealso href="https://v1-17.docs.kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-os"/>
+        public const string Os = "kubernetes.io/os";
+
+        /// <summary>
+        /// Enumerates the values of well-known computer architectures, as used by the <see cref="Arch"/> annotation and the
+        /// <c>GOARCH</c> environment variable.
+        /// </summary>
+        /// <seealso href="https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/dist/build.go#L61"/>
+        public class Architecture
+        {
+            /// <summary>
+            /// The AMD64 processor architecture.
+            /// </summary>
+            public const string Amd64 = "amd64";
+
+            /// <summary>
+            /// The 64-bit ARM processor architecture.
+            /// </summary>
+            public const string Arm64 = "arm64";
+        }
+
+        /// <summary>
+        /// Enumerates values of well-known operating systems, as used by the <see cref="Os"/> annotation and the
+        /// <c>GOOS</c> environment variable.
+        /// </summary>
+        /// <seealso href="https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/dist/build.go#L79"/>
+        public class OperatingSystem
+        {
+            /// <summary>
+            /// The Google Android operating system.
+            /// </summary>
+            public const string Android = "android";
+
+            /// <summary>
+            /// The Apple iOS operating system.
+            /// </summary>
+            /// <remarks>
+            /// This value was added recently, and is currently only available on Go master (https://github.com/golang/go/commit/431d58da69e8c36d654876e7808f971c5667649c).
+            /// </remarks>
+            public const string iOS = "ios";
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Crd.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Crd.cs
@@ -4,6 +4,8 @@
 
 using k8s;
 using k8s.Models;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Rest;
 using System;
 using System.Linq;
 using System.Threading;
@@ -79,6 +81,157 @@ namespace Kaponata.Operator.Kubernetes
                 this.protocol.WatchCustomResourceDefinitionAsync,
                 timeout,
                 cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously installs a <see cref="V1CustomResourceDefinition"/> in the cluster, or, if the <see cref="V1CustomResourceDefinition"/>
+        /// is already installed, upgrades the <see cref="V1CustomResourceDefinition"/> if required.
+        /// </summary>
+        /// <param name="crd">
+        /// The custom resource definition to install into the cluster.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time alotted to the operation.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous task.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public virtual async Task<V1CustomResourceDefinition> InstallOrUpgradeCustomResourceDefinitionAsync(V1CustomResourceDefinition crd, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (crd == null)
+            {
+                throw new ArgumentNullException(nameof(crd));
+            }
+
+            if (crd.Metadata?.Name == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "value.Metadata.Name");
+            }
+
+            if (crd.Metadata?.Labels == null || !crd.Metadata.Labels.ContainsKey(Annotations.Version))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, $"value.Metadata.Labels[{Annotations.Version}]");
+            }
+
+            var installedCrd = await this.TryReadCustomResourceDefinitionAsync(
+                crd.Metadata.Name,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (installedCrd == null)
+            {
+                // Deploy the CRD
+                return await this.CreateCustomResourceDefinitionAsync(
+                    crd,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var version = new Version(crd.Metadata.Labels[Annotations.Version]);
+
+                // Get the version of the installed CRD; set the version to 0.0 if not version
+                // annotation could be found.
+                var installedVersion = new Version(0, 0);
+                if (installedCrd.Metadata.Labels.ContainsKey(Annotations.Version))
+                {
+                    installedVersion = new Version(installedCrd.Metadata.Labels[Annotations.Version]);
+                }
+
+                if (version > installedVersion)
+                {
+                    // Upgrade: delete and reinstall
+                    await this.DeleteCustomResourceDefinitionAsync(
+                        installedCrd,
+                        timeout,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    return await this.CreateCustomResourceDefinitionAsync(
+                        crd,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    return installedCrd;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for a CRD to enter be established.
+        /// </summary>
+        /// <param name="value">
+        /// The CRD which should be established.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time in which the CRD should be established.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="V1CustomResourceDefinition"/>.
+        /// </returns>
+        public virtual async Task<V1CustomResourceDefinition> WaitForCustomResourceDefinitionEstablishedAsync(V1CustomResourceDefinition value, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (IsEstablished(value))
+            {
+                return value;
+            }
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cancellationToken.Register(cts.Cancel);
+
+            var watchTask = this.protocol.WatchCustomResourceDefinitionAsync(
+                value,
+                eventHandler: (type, updatedCrd) =>
+                {
+                    value = updatedCrd;
+
+                    if (type == WatchEventType.Deleted)
+                    {
+                        throw new KubernetesException($"The CRD '{value.Metadata.Name}' was deleted.");
+                    }
+
+                    if (IsEstablished(updatedCrd))
+                    {
+                        return Task.FromResult(WatchResult.Stop);
+                    }
+
+                    return Task.FromResult(WatchResult.Continue);
+                },
+                cts.Token);
+
+            if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)
+            {
+                cts.Cancel();
+                throw new KubernetesException($"The CRD '{value.Metadata.Name}' was not established within a timeout of {timeout.TotalSeconds} seconds.");
+            }
+
+            var result = await watchTask.ConfigureAwait(false);
+
+            if (result != WatchExitReason.ClientDisconnected)
+            {
+                throw new KubernetesException($"The API server unexpectedly closed the connection while watching CRD '{value.Metadata.Name}'.");
+            }
+
+            return value;
+        }
+
+        private static bool IsEstablished(V1CustomResourceDefinition value)
+        {
+            if (value?.Status?.Conditions == null)
+            {
+                return false;
+            }
+
+            return value.Status.Conditions.Any(
+                c => string.Equals(c.Type, "Established", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(c.Status, "True", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -6,6 +6,7 @@ using k8s;
 using k8s.Models;
 using Kaponata.Operator.Kubernetes.Polyfill;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest;
 using Microsoft.Rest.Serialization;
 using System;
@@ -44,6 +45,18 @@ namespace Kaponata.Operator.Kubernetes
             this.protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is intended for unit testing purposes only.
+        /// </remarks>
+        protected KubernetesClient()
+        {
+            this.logger = NullLogger<KubernetesClient>.Instance;
+            this.loggerFactory = NullLoggerFactory.Instance;
         }
 
         private delegate Task<WatchExitReason> WatchObjectAsyncDelegate<T>(

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -80,7 +80,7 @@ namespace Kaponata.Operator.Kubernetes
             catch (HttpOperationException ex)
             when (ex.Response != null
                 && ex.Response.Content != null
-                && (ex.Response.StatusCode == HttpStatusCode.UnprocessableEntity || ex.Response.StatusCode == HttpStatusCode.Conflict))
+                && (ex.Response.StatusCode == HttpStatusCode.UnprocessableEntity || ex.Response.StatusCode == HttpStatusCode.Conflict || ex.Response.StatusCode == HttpStatusCode.BadRequest))
             {
                 // We should get a V1Status with a detailed error message, extract that error message.
                 var status = SafeJsonConvert.DeserializeObject<V1Status>(ex.Response.Content);

--- a/src/Kaponata.Operator/Models/MobileDevice.yaml
+++ b/src/Kaponata.Operator/Models/MobileDevice.yaml
@@ -1,0 +1,70 @@
+﻿apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: mobiledevices.kaponata.io
+  labels:
+    app.kubernetes.io/managed-by: Kaponata
+    # Set this to the version number of the last commit which modified this file. It's used by the
+    # operator to determine whether the CRD should be reinstalled or not.
+    # Use the following command to determine that version:
+    # nbgv get-version $( git rev-list -1 HEAD .\stylecop.json ) -v NuGetPackageVersion
+    app.kubernetes.io/version: "0.1.69"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: kaponata.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1alpha1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: |
+            A MobileDevice represents a physical iOS or Android devices connected to one of the nodes
+            in your Kubernetes cluster, an emulator running inside your Kubernets cluster, or a
+            cloud device which is remotely connected to your cluster.
+            The name of the MobileDevice object is the serial number or UDID of the device.
+            The kubernetes.io/os an kubernets.io/arch labels contain the operating system (for example,
+            iOS or Android) running on the device and the architecture (for example, arm64 or amd64)
+            of the device.
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                owner:
+                  type: string
+                  description: |
+                    The name of the pod which owns this device. This is usually the pod which hosts the
+                    usbmuxd or adb instance to which the device is connected.
+            status:
+              type: object
+              properties:
+                vncHost:
+                  type: string
+                  description: |
+                    When available, the name of a service which hosts a VNC server which allows users to
+                    remotely control this device.
+      # Shown in kubectl get
+      additionalPrinterColumns:
+      - name: Platform
+        type: string
+        jsonPath: .spec.platform
+      - name: Owner
+        type: string
+        jsonPath: .spec.owner
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: mobiledevices
+    # singular name to be used as an alias on the CLI and for display
+    singular: mobiledevice
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: MobileDevice
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - device

--- a/src/Kaponata.Operator/Models/ModelDefinitions.cs
+++ b/src/Kaponata.Operator/Models/ModelDefinitions.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="ModelDefinitions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using System.IO;
+
+namespace Kaponata.Operator.Models
+{
+    /// <summary>
+    /// Provides access to the <see cref="V1CustomResourceDefinition"/> used by Kaponata.
+    /// </summary>
+    public static class ModelDefinitions
+    {
+        /// <summary>
+        /// Gets the <see cref="V1CustomResourceDefinition"/> for the MobileDevice type.
+        /// </summary>
+        public static V1CustomResourceDefinition MobileDevice
+        {
+            get
+            {
+                using (Stream stream = typeof(ModelDefinitions).Assembly.GetManifestResourceStream("Kaponata.Operator.Models.MobileDevice.yaml"))
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    return Yaml.LoadFromString<V1CustomResourceDefinition>(reader.ReadToEnd());
+                }
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Properties/launchSettings.json
+++ b/src/Kaponata.Operator/Properties/launchSettings.json
@@ -1,21 +1,17 @@
-﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:41079",
-      "sslPort": 44308
-    }
-  },
+{
   "profiles": {
     "Kaponata.Operator": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": "true",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
+    "install-extensions": {
+      "commandName": "Project",
+      "commandLineArgs": "install-extensions"
     }
   }
 }

--- a/src/chart/templates/_helpers.tpl
+++ b/src/chart/templates/_helpers.tpl
@@ -38,6 +38,20 @@ Operator: Full Name
 {{- end }}
 
 {{/*
+Operator: Cluster Role Full Name
+*/}}
+{{- define "operator.clusterRole.fullname" -}}
+{{- printf "%s-operator-clusterrole" (include "kaponata.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Operator: Cluster Role Binding Full Name
+*/}}
+{{- define "operator.clusterRoleBinding.fullname" -}}
+{{- printf "%s-operator-clusterrolebinding" (include "kaponata.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Operator: Role Full Name
 */}}
 {{- define "operator.role.fullname" -}}

--- a/src/chart/templates/operator-clusterRole.yaml
+++ b/src/chart/templates/operator-clusterRole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "operator.clusterRole.fullname" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [ "apiextensions.k8s.io" ]
+  resources: [ "customresourcedefinitions" ]
+  verbs: [ "get", "list", "watch", "create", "delete" ]

--- a/src/chart/templates/operator-clusterRoleBinding.yaml
+++ b/src/chart/templates/operator-clusterRoleBinding.yaml
@@ -1,14 +1,14 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "operator.roleBinding.fullname" . }}
+  name: {{ include "operator.clusterRoleBinding.fullname" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
-roleRef:
-  kind: Role
-  name: {{ include "operator.role.fullname" . }}
-  apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: {{ template "operator.serviceAccount.fullname" . }}
   namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "operator.clusterRole.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/src/chart/templates/operator-deployment.yaml
+++ b/src/chart/templates/operator-deployment.yaml
@@ -14,6 +14,10 @@ spec:
         {{- include "operator.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "operator.serviceAccount.fullname" . }}
+      initContainers:
+        - name: "install-extensions"
+          image: "{{ .Values.operator.image.repository }}:{{ tpl .Values.operator.image.tag . }}"
+          command: [ "dotnet", "/app/Kaponata.Operator.dll", "install-extensions" ]
       containers:
         - name: "operator"
           image: "{{ .Values.operator.image.repository }}:{{ tpl .Values.operator.image.tag . }}"


### PR DESCRIPTION
[Helm doesn't provide a built-in way for managing CustomResourceDefinitions](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) in Helm charts. In particular, upgrading CRDs is something that Helm doesn't support (and they have good reasons for it).

In the Kaponata project, we currently plan on two CRDs: `MobileDevice` and `WebDriverSession`.
For both CRDs, the values are not "authorative": `MobileDevice` merely reflects the mobile device data as reported by adb/usbmuxd; `WebDriverSession` is a (relatively) short-lived object which tracks an Appium session which is running.

This means that it's acceptable for us to "upgrade" CRDs by deleting them and re-creating them from scratch. We'll lose all `MobileDevice` objects but the operator will re-created them.

This PR adds the infrastructure for deploying the CRDs ourselves:

- `KubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync` does the heavy lifting
- `ExtensionsInstaller` is a generic-purpose class which would contain all logic for installing all custom extensions (including CRDs)
- The `Kaponata.Operator` program ships with a new `install-extensions` command which executes the `ExtensionsInstaller`
- Finally, the `operator` pod runs `Kaponata.Operator --install-extensions` in an init container; and it is given the required permissions by a `ClusterRole`.

This way, we can be sure the extensions are installed properly by the time the Operator launches. The init container will fail if something goes wrong, preventing the Operator from launching. It should be easy to diagnose this failure by running `kubectl get pods`,  find the Operator in an error state, and run `kubectl logs [operator] -f -c "install-extensions"`.