### PR TITLE
Add adb container image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -13,6 +13,7 @@ jobs:
         image:
         - iproxy
         - usbmuxd
+        - adb
     steps:
       - uses: actions/checkout@v2
         with:

--- a/src/adb/Dockerfile
+++ b/src/adb/Dockerfile
@@ -1,0 +1,36 @@
+FROM --platform=$BUILDPLATFORM ubuntu:focal AS build
+
+ARG platform_tools_version=30.0.4
+
+RUN apt-get update \
+&& apt-get install -y curl unzip
+
+RUN mkdir -p /build \
+&& curl -X GET https://dl.google.com/android/repository/platform-tools_r${platform_tools_version}-linux.zip --output /build/platform-tools_r${platform_tools_version}-linux.zip \
+&& unzip -j /build/platform-tools_r${platform_tools_version}-linux.zip platform-tools/adb -d /build \
+&& unzip -j /build/platform-tools_r${platform_tools_version}-linux.zip platform-tools/NOTICE.txt -d /build
+
+FROM gcr.io/distroless/cc-debian10
+
+ARG GIT_COMMIT_DATE
+ARG GIT_COMMIT_ID
+ARG GIT_REF
+ARG GIT_REMOTE
+ARG VERSION
+
+LABEL org.opencontainers.image.title="adb"
+LABEL org.opencontainers.image.description="Android Debug Bridge"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+LABEL org.opencontainers.image.created=$GIT_COMMIT_DATE
+LABEL org.opencontainers.image.authors="Frederik Carlier <frederik.carlier@quamotion.mobi>"
+LABEL org.opencontainers.image.vendor="Quamotion bv <info@quamotion.mobi>"
+LABEL org.opencontainers.image.url="https://www.kaponata.io/"
+LABEL org.opencontainers.image.source=$GIT_REMOTE
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$GIT_COMMIT_ID
+LABEL org.opencontainers.image.ref.name=$GIT_REF
+
+COPY --from=build /build/adb /usr/bin/
+
+CMD [ "/usr/bin/adb",  "-a", "-P", "5037", "server", "nodaemon" ]

--- a/src/adb/Makefile
+++ b/src/adb/Makefile
@@ -1,0 +1,26 @@
+registry=quay.io/kaponata
+image=adb
+
+all: .amd64.docker-id .version
+
+push: all
+	docker push $(registry)/$(image):latest-amd64
+	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64
+	docker manifest push $(registry)/$(image):$(shell cat .version)
+
+.version: .amd64.docker-id
+	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/adb --version | head -n 1 | awk '{ print $$5 }' | tee .version
+
+.amd64.docker-id: Dockerfile
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg host= \
+		--build-arg arch= \
+		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
+		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
+		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
+		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
+		--build-arg VERSION="$(shell nbgv get-version -v SemVer2)" \
+		. \
+		-t $(registry)/$(image):latest-amd64
+	docker images --no-trunc --quiet $(registry)/$(image):latest-amd64 > .amd64.docker-id


### PR DESCRIPTION
This PR adds the `quay.io/kaponata/adb` image. The tag is the adb version (e.g. `1.0.41`); not the platform-tools version.

The `adb` executable is extracted from the `platform-tools` package built by the upstream Android project.
There is no arm64 tag for now because the Android project doesn't provide prebuilt `adb` images.