### PR TITLE
CI: Create an Android pod using Redroid

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -169,6 +169,38 @@ jobs:
           --wait
           kaponata
           ${{ github.workspace }}/bin/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz
+      
+      - name: Redroid - Install the Android kernel modules
+        run: |
+          kernel=$(uname -r)
+
+          # install required packages
+          sudo apt-get install -y kmod make gcc linux-headers-$kernel
+
+          git clone https://github.com/remote-android/redroid-modules.git
+
+          cd redroid-modules
+          make
+          sudo make install
+
+      - name: Redroid - Check Android kernel module status
+        run: |
+          echo "Listing Android kernel modules. This should include 'ashmem_linux' and 'binder_linux'."
+          lsmod | grep -e ashmem_linux -e binder_linux
+
+          echo "Listing the binder file system. This should include 'nodev	binder'."
+          cat /proc/filesystems | grep binder
+
+          echo "Listing miscellaneous drivers registered on the miscellaneous major device. This should include '56 ashmem'."
+          cat /proc/misc | grep ashmem
+
+      - name: Redroid - Creating the Android pod
+        run: |
+          kubectl create -f ci/redroid.yaml
+          kubectl wait --for=condition=ready --timeout=120s pod redroid
+
+      - name: Redroid - Dump logcat output
+        run: kubectl exec redroid -- logcat -d
 
       - name: Run chart tests and integration tests
         run: >

--- a/ci/redroid.yaml
+++ b/ci/redroid.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redroid
+  labels:
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: android
+spec:
+  containers:
+    - name: android
+      image: redroid/redroid:11.0.0-latest
+      securityContext:
+        privileged: true
+      env:
+      - name: redroid.vncserver
+        value: "1"
+      ports:
+        - name: vnc
+          containerPort: 5900
+          protocol: TCP
+        - name: adbd
+          containerPort: 5555
+          protocol: TCP
+      readinessProbe:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - '[ "$(getprop init.svc.bootanim)x" == "stoppedx" ]'
+        initialDelaySeconds: 5
+        periodSeconds: 5
+  nodeSelector:
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux


### PR DESCRIPTION
This PR updates the CI system so that an pod running Redroid (Android) is running inside the k3s cluster.

This should allow us to run basic integration tests inside CI.

It will also increase the time required for a CI run; we may want to set up a separate lane for integration tests / unit tests.