### PR TITLE
Add helper methods for injecting Kubernetes services, minor fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,9 +197,10 @@ jobs:
       - name: Redroid - Creating the Android pod
         run: |
           kubectl create -f ci/redroid.yaml
-          kubectl wait --for=condition=ready --timeout=120s pod redroid
+          kubectl wait --for=condition=ready --timeout=180s pod redroid || kubectl describe pod redroid
 
       - name: Redroid - Dump logcat output
+        if: always()
         run: kubectl exec redroid -- logcat -d
 
       - name: Run chart tests and integration tests

--- a/ci/redroid.yaml
+++ b/ci/redroid.yaml
@@ -29,6 +29,10 @@ spec:
             - '[ "$(getprop init.svc.bootanim)x" == "stoppedx" ]'
         initialDelaySeconds: 5
         periodSeconds: 5
+      resources:
+        limits:
+          memory: "2Gi"
+          cpu: "1"
   nodeSelector:
     kubernetes.io/arch: amd64
     kubernetes.io/os: linux

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesServiceCollectionExtensionsTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesServiceCollectionExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="KubernetesServiceCollectionExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesServiceCollectionExtensions"/> class.
+    /// </summary>
+    public class KubernetesServiceCollectionExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="KubernetesServiceCollectionExtensions.AddKubernetes"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void AddKubernetes_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("services", () => KubernetesServiceCollectionExtensions.AddKubernetes(null));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesServiceCollectionExtensions.AddKubernetes"/> works correctly, and you can extract a <see cref="KubernetesClient"/>
+        /// out of the configured service provider.
+        /// </summary>
+        [Fact]
+        public void AddKubernetes_Works()
+        {
+            var collection = new ServiceCollection();
+            collection.AddLogging();
+            collection.AddKubernetes();
+
+            using (var serviceProvider = collection.BuildServiceProvider())
+            {
+                var client = serviceProvider.GetRequiredService<KubernetesClient>();
+                Assert.NotNull(client);
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesServiceCollectionExtensions.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="KubernetesServiceCollectionExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Extension methods for setting up Kubernetes services in an <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class KubernetesServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the <see cref="KubernetesClient"/> to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The <see cref="IServiceCollection"/> to add services to.
+        /// </param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> so that additional calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddKubernetes(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddSingleton<KubernetesClientConfiguration>(KubernetesClientConfiguration.BuildDefaultConfig());
+            services.AddSingleton<IKubernetesProtocol, KubernetesProtocol>();
+            services.AddSingleton<KubernetesClient>();
+            return services;
+        }
+    }
+}

--- a/src/Kaponata.Operator/Models/MobileDevice.yaml
+++ b/src/Kaponata.Operator/Models/MobileDevice.yaml
@@ -8,8 +8,8 @@ metadata:
     # Set this to the version number of the last commit which modified this file. It's used by the
     # operator to determine whether the CRD should be reinstalled or not.
     # Use the following command to determine that version:
-    # nbgv get-version $( git rev-list -1 HEAD .\stylecop.json ) -v NuGetPackageVersion
-    app.kubernetes.io/version: "0.1.69"
+    # nbgv get-version $(git rev-list -1 HEAD) -v NuGetPackageVersion
+    app.kubernetes.io/version: "0.1.105"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kaponata.io
@@ -50,9 +50,9 @@ spec:
                     remotely control this device.
       # Shown in kubectl get
       additionalPrinterColumns:
-      - name: Platform
+      - name: Labels
         type: string
-        jsonPath: .spec.platform
+        jsonPath: .metadata.labels
       - name: Owner
         type: string
         jsonPath: .spec.owner

--- a/src/Kaponata.Operator/Program.cs
+++ b/src/Kaponata.Operator/Program.cs
@@ -94,9 +94,7 @@ namespace Kaponata.Operator
                     host.ConfigureServices(
                         (services) =>
                         {
-                            services.AddSingleton<KubernetesClientConfiguration>(KubernetesClientConfiguration.BuildDefaultConfig());
-                            services.AddScoped<IKubernetesProtocol, KubernetesProtocol>();
-                            services.AddScoped<KubernetesClient>();
+                            services.AddKubernetes();
                             services.AddLogging();
                             services.AddScoped<ExtensionsInstaller>();
                         });


### PR DESCRIPTION
- Use a helper method for injecting the Kubernetes services into a service container
- Limit CPU and memory usage for the Android container
- Print the labels of the MobileDevice object