### PR TITLE
KubernetesProtocol, KubernetesClient: Simplify Watch signatures

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.CustomResourceDefinition.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.CustomResourceDefinition.cs
@@ -142,7 +142,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -152,8 +152,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Returns(Task.FromResult(new HttpOperationResponse<V1Status>() { Body = new V1Status(), Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((customResourceDefinition, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((customResourceDefinition, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;
@@ -192,7 +192,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -202,8 +202,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Returns(Task.FromResult(new HttpOperationResponse<V1Status>() { Body = new V1Status(), Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((customResourceDefinition, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((customResourceDefinition, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;
@@ -245,7 +245,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -255,8 +255,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Returns(Task.FromResult(new HttpOperationResponse<V1Status>() { Body = new V1Status(), Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((customResourceDefinition, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(customResourceDefinition, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((customResourceDefinition, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;
@@ -595,14 +595,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((crd, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((crd, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;
@@ -641,14 +641,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((pod, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;
@@ -728,14 +728,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((pod, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;
@@ -773,14 +773,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1CustomResourceDefinition> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1CustomResourceDefinition, Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>>, CancellationToken>((pod, watcher, ct) =>
+                .Setup(p => p.WatchCustomResourceDefinitionAsync(crd, It.IsAny<WatchEventDelegate<V1CustomResourceDefinition>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1CustomResourceDefinition, WatchEventDelegate<V1CustomResourceDefinition>, CancellationToken>((pod, watcher, ct) =>
                 {
                     callback = watcher;
                     return watchTask.Task;

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.MobileDevice.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.MobileDevice.cs
@@ -412,7 +412,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
                     device,
                     It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
-                    It.IsAny<Func<WatchEventType, MobileDevice, Task<WatchResult>>>(),
+                    It.IsAny<WatchEventDelegate<MobileDevice>>(),
                     default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
@@ -443,7 +443,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
         public void WatchMobileDevicedAsync_ForwardRequests()
         {
             var tcs = new TaskCompletionSource<WatchExitReason>();
-            var eventHandler = new Func<WatchEventType, MobileDevice, Task<WatchResult>>((type, pod) => Task.FromResult(WatchResult.Continue));
+            var eventHandler = new WatchEventDelegate<MobileDevice>((type, pod) => Task.FromResult(WatchResult.Continue));
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
@@ -527,7 +527,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, MobileDevice, Task<WatchResult>> callback = null;
+            WatchEventDelegate<MobileDevice> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -539,9 +539,9 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
                         mobileDevice,
                         It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
-                        It.IsAny<Func<WatchEventType, MobileDevice, Task<WatchResult>>>(),
+                        It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, Func<WatchEventType, MobileDevice, Task<WatchResult>>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;
@@ -599,7 +599,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, MobileDevice, Task<WatchResult>> callback = null;
+            WatchEventDelegate<MobileDevice> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -611,9 +611,9 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
                         mobileDevice,
                         It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
-                        It.IsAny<Func<WatchEventType, MobileDevice, Task<WatchResult>>>(),
+                        It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, Func<WatchEventType, MobileDevice, Task<WatchResult>>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;
@@ -662,7 +662,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, MobileDevice, Task<WatchResult>> callback = null;
+            WatchEventDelegate<MobileDevice> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -674,9 +674,9 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
                         mobileDevice,
                         It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
-                        It.IsAny<Func<WatchEventType, MobileDevice, Task<WatchResult>>>(),
+                        It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, Func<WatchEventType, MobileDevice, Task<WatchResult>>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;
@@ -733,7 +733,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, MobileDevice, Task<WatchResult>> callback = null;
+            WatchEventDelegate<MobileDevice> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -745,9 +745,9 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
                         mobileDevice,
                         It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
-                        It.IsAny<Func<WatchEventType, MobileDevice, Task<WatchResult>>>(),
+                        It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, Func<WatchEventType, MobileDevice, Task<WatchResult>>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.cs
@@ -151,14 +151,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -202,14 +202,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -256,14 +256,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -310,14 +310,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -360,14 +360,14 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -426,7 +426,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -436,8 +436,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Returns(Task.FromResult(new HttpOperationResponse<V1Pod>() { Body = pod, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -482,7 +482,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -492,8 +492,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Returns(Task.FromResult(new HttpOperationResponse<V1Pod>() { Body = pod, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -538,7 +538,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                     },
                 };
 
-            Func<WatchEventType, V1Pod, Task<WatchResult>> callback = null;
+            WatchEventDelegate<V1Pod> callback = null;
             TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
@@ -548,8 +548,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Returns(Task.FromResult(new HttpOperationResponse<V1Pod>() { Body = pod, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<Func<WatchEventType, V1Pod, Task<WatchResult>>>(), It.IsAny<CancellationToken>()))
-                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, Func<WatchEventType, V1Pod, Task<WatchResult>>, CancellationToken>((pod, list, watcher, ct) =>
+                .Setup(p => p.WatchNamespacedObjectAsync(pod, protocol.Object.ListNamespacedPodWithHttpMessagesAsync, It.IsAny<WatchEventDelegate<V1Pod>>(), It.IsAny<CancellationToken>()))
+                .Returns<V1Pod, ListNamespacedObjectWithHttpMessagesAsync<V1Pod, V1PodList>, WatchEventDelegate<V1Pod>, CancellationToken>((pod, list, watcher, ct) =>
                 {
                     Assert.NotNull(list);
                     callback = watcher;
@@ -794,7 +794,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
         public void WatchPodAsync_ForwardRequests()
         {
             var tcs = new TaskCompletionSource<WatchExitReason>();
-            var eventHandler = new Func<WatchEventType, V1Pod, Task<WatchResult>>((type, pod) => Task.FromResult(WatchResult.Continue));
+            var eventHandler = new WatchEventDelegate<V1Pod>((type, pod) => Task.FromResult(WatchResult.Continue));
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.MobileDevice.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.MobileDevice.cs
@@ -221,7 +221,7 @@ namespace Kaponata.Operator.Kubernetes
         /// </returns>
         public Task<WatchExitReason> WatchMobileDeviceAsync(
             MobileDevice value,
-            Func<WatchEventType, MobileDevice, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<MobileDevice> eventHandler,
             CancellationToken cancellationToken)
         {
             return this.protocol.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
@@ -264,12 +264,12 @@ namespace Kaponata.Operator.Kubernetes
         /// return value describes why the watcher stopped. The task errors if the watch
         /// loop errors.
         /// </returns>
-        public Task<WatchExitReason> WatchMobileDeviceAsync(
+        public virtual Task<WatchExitReason> WatchMobileDeviceAsync(
             string @namespace,
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
-            Func<WatchEventType, MobileDevice, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<MobileDevice> eventHandler,
             CancellationToken cancellationToken)
         {
             return this.protocol.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
@@ -164,7 +164,7 @@ namespace Kaponata.Operator.Kubernetes
         /// </returns>
         public virtual Task<WatchExitReason> WatchPodAsync(
             V1Pod value,
-            Func<WatchEventType, V1Pod, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<V1Pod> eventHandler,
             CancellationToken cancellationToken)
         {
             return this.protocol.WatchNamespacedObjectAsync(
@@ -212,7 +212,7 @@ namespace Kaponata.Operator.Kubernetes
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
-            Func<WatchEventType, V1Pod, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<V1Pod> eventHandler,
             CancellationToken cancellationToken)
         {
             return this.protocol.WatchNamespacedObjectAsync(

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -61,7 +61,7 @@ namespace Kaponata.Operator.Kubernetes
 
         private delegate Task<WatchExitReason> WatchObjectAsyncDelegate<T>(
             T value,
-            Func<WatchEventType, T, Task<WatchResult>> onEvent,
+            WatchEventDelegate<T> onEvent,
             CancellationToken cancellationToken)
             where T : IKubernetesObject<V1ObjectMeta>;
 

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesProtocol.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/IKubernetesProtocol.cs
@@ -4,7 +4,6 @@
 
 using k8s;
 using k8s.Models;
-using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,7 +42,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// </returns>
         Task<WatchExitReason> WatchCustomResourceDefinitionAsync(
             V1CustomResourceDefinition crd,
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<V1CustomResourceDefinition> eventHandler,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -78,7 +77,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
             TObject value,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>;
@@ -131,7 +130,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
             string labelSelector,
             string resourceVersion,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>;

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
@@ -40,7 +40,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         /// <inheritdoc/>
         public Task<WatchExitReason> WatchCustomResourceDefinitionAsync(
             V1CustomResourceDefinition value,
-            Func<WatchEventType, V1CustomResourceDefinition, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<V1CustomResourceDefinition> eventHandler,
             CancellationToken cancellationToken)
         {
             return this.WatchObjectAsync(
@@ -54,7 +54,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         public Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
             TObject value,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>
@@ -96,7 +96,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
             string labelSelector,
             string resourceVersion,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>
@@ -131,7 +131,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
         private Task<WatchExitReason> WatchObjectAsync<TObject, TList>(
             TObject value,
             ListObjectWithHttpMessagesAsync<TObject, TList> listOperation,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>
@@ -163,7 +163,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
             string fieldSelector,
             string resourceVersion,
             ListObjectWithHttpMessagesAsync<TObject, TList> listOperation,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>
@@ -185,7 +185,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
 
         private async Task<WatchExitReason> WatchAsync<TObject, TList>(
             HttpOperationResponse<TList> response,
-            Func<WatchEventType, TObject, Task<WatchResult>> eventHandler,
+            WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
             where TObject : IKubernetesObject<V1ObjectMeta>
             where TList : IItems<TObject>

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/WatchEventDelegate.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/WatchEventDelegate.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="WatchEventDelegate.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// The definition of a callback which is invoked when a the Kubernetes API server sends a watch event.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of object being watched.
+    /// </typeparam>
+    /// <param name="eventType">
+    /// The watch event which has just occurred.
+    /// </param>
+    /// <param name="value">
+    /// The object which has changed.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task"/> which represents the asynchronous operation during which the client
+    /// processes the watch event, and which returns a value indicating whether the watch loop
+    /// should to continue watching for events or should close the connection with the server.
+    /// </returns>
+    public delegate Task<WatchResult> WatchEventDelegate<T>(WatchEventType eventType, T value)
+        where T : IKubernetesObject<V1ObjectMeta>;
+}


### PR DESCRIPTION
Use `WatchEventDelegate<T>` instead of `Func<WatchEventType, T, Task<WatchResult>>`