### PR TITLE
Generate documentation for Kaponata.iOS, Kaponata.Android

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -10,6 +10,21 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.100'
+
+    - name: Document API
+      run: |
+        dotnet tool install -g xmldocmd
+        dotnet publish -c Release
+
+        xmldocmd ./Kaponata.Android/bin/Release/net5.0/publish/Kaponata.Android.dll ../website/docs/class/
+        xmldocmd ./Kaponata.iOS/bin/Release/net5.0/publish/Kaponata.iOS.dll ../website/docs/class/
+      working-directory: src/
 
     - name: Compile Website
       uses: docker://squidfunk/mkdocs-material:6.2.6

--- a/website/docs/class/.gitignore
+++ b/website/docs/class/.gitignore
@@ -1,0 +1,2 @@
+Kaponata.Android.*
+Kaponata.iOS.*

--- a/website/docs/class/index.md
+++ b/website/docs/class/index.md
@@ -1,0 +1,6 @@
+# Kaponata Assemblies
+
+| Assembly                             | description                                           |
+| ---                                  | ---                                                   |
+| [Kaponata.Android](Kaponata.Android) | Provides interfaces for working with Android devices. |
+| [Kaponata.iOS](Kaponata.iOS)         | Provides interfaces for working with iOS devices.     |

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -23,6 +23,16 @@ theme:
 
 plugins: []
 
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+
 # Page tree
 nav:
   - Home: index.md
+  - User Guide: user-guide
+  - Reference:
+    - Class Library:
+      - class/index.md
+      - Kaponata.Android: class/Kaponata.Android
+      - Kaponata.iOS: class/Kaponata.iOS


### PR DESCRIPTION
Use [xmldocmd](https://ejball.com/XmlDocMarkdown/) to convert XML documention to Markdown, and include it in the Kaponata website in the Reference section.