### PR TITLE
Build iproxy, usbmuxd and adb when needed

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+    - src/iproxy
+    - src/usbmuxd
+    - src/adb
 
 jobs:
   build:


### PR DESCRIPTION
Only trigger CI for the container images when the source code changes.