### PR TITLE
API server: Add primary endpoints

### DIFF
--- a/src/Kaponata.Api.Tests/WebDriver/WebDriverDataTests.cs
+++ b/src/Kaponata.Api.Tests/WebDriver/WebDriverDataTests.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="WebDriverDataTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.WebDriver;
+using Xunit;
+
+namespace Kaponata.Api.Tests.WebDriver
+{
+    /// <summary>
+    /// Tests the <see cref="WebDriverData"/> class.
+    /// </summary>
+    public class WebDriverDataTests
+    {
+        /// <summary>
+        /// The <see cref="WebDriverData"/> constructors work correctly.
+        /// </summary>
+        [Fact]
+        public void DefaultConstructor_Works()
+        {
+            Assert.Null(new WebDriverData().Data);
+            Assert.Null(new WebDriverData(null).Data);
+
+            var data = new object();
+            Assert.Same(data, new WebDriverData(data).Data);
+        }
+    }
+}

--- a/src/Kaponata.Api.Tests/WebDriver/WebDriverErrorCodeTests.cs
+++ b/src/Kaponata.Api.Tests/WebDriver/WebDriverErrorCodeTests.cs
@@ -1,0 +1,116 @@
+﻿// <copyright file="WebDriverErrorCodeTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.WebDriver;
+using System;
+using System.Net;
+using Xunit;
+
+namespace Kaponata.Api.Tests.WebDriver
+{
+    /// <summary>
+    /// Tests the <see cref="WebDriverErrorCode"/> class.
+    /// </summary>
+    public class WebDriverErrorCodeTests
+    {
+        /// <summary>
+        /// The <see cref="WebDriverErrorCode"/> constructor validates the arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("jsonErrorCode", () => new WebDriverErrorCode(null, HttpStatusCode.OK, "OK"));
+            Assert.Throws<ArgumentNullException>("message", () => new WebDriverErrorCode("ok", HttpStatusCode.OK, null));
+        }
+
+        /// <summary>
+        /// The <see cref="WebDriverErrorCode"/> constructor initializes the properties.
+        /// </summary>
+        [Fact]
+        public void Constructor_SetsProperties()
+        {
+            var error = new WebDriverErrorCode("code", HttpStatusCode.BadRequest, "test");
+            Assert.Equal("code", error.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.BadRequest, error.HttpStatusCode);
+            Assert.Equal("test", error.Message);
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverErrorCode.Equals(object)"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void Equals_Works()
+        {
+            var invalidArgument = new WebDriverErrorCode(
+                "invalid argument",
+                HttpStatusCode.BadRequest,
+                "The arguments passed to a command are either invalid or malformed.");
+
+            Assert.True(WebDriverErrorCode.InvalidArgument.Equals(invalidArgument));
+            Assert.True(invalidArgument.Equals(WebDriverErrorCode.InvalidArgument));
+
+            Assert.False(invalidArgument.Equals(WebDriverErrorCode.InvalidSessionId));
+            Assert.False(invalidArgument.Equals(null));
+            Assert.False(invalidArgument.Equals("invalid session"));
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverErrorCode.GetHashCode"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void GetHashCode_Works()
+        {
+            var invalidArgument = new WebDriverErrorCode(
+                "invalid argument",
+                HttpStatusCode.BadRequest,
+                "The arguments passed to a command are either invalid or malformed.");
+
+            Assert.Equal(WebDriverErrorCode.InvalidArgument.GetHashCode(), invalidArgument.GetHashCode());
+            Assert.Equal(invalidArgument.GetHashCode(), WebDriverErrorCode.InvalidArgument.GetHashCode());
+
+            Assert.NotEqual(invalidArgument.GetHashCode(), WebDriverErrorCode.InvalidSessionId.GetHashCode());
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverErrorCode.ToString()"/> method returns the JSON error code.
+        /// </summary>
+        [Fact]
+        public void ToString_ReturnsErrorCode()
+        {
+            var error = new WebDriverErrorCode("code", HttpStatusCode.BadRequest, "test");
+            Assert.Equal("code", error.ToString());
+        }
+
+        /// <summary>
+        /// The well-known errors are correct.
+        /// </summary>
+        [Fact]
+        public void KnownErrors_AreCorrect()
+        {
+            Assert.Equal("invalid argument", WebDriverErrorCode.InvalidArgument.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.BadRequest, WebDriverErrorCode.InvalidArgument.HttpStatusCode);
+
+            Assert.Equal("invalid session id", WebDriverErrorCode.InvalidSessionId.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.NotFound, WebDriverErrorCode.InvalidSessionId.HttpStatusCode);
+
+            Assert.Equal("session not created", WebDriverErrorCode.SessionNotCreated.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, WebDriverErrorCode.SessionNotCreated.HttpStatusCode);
+
+            Assert.Equal("timeout", WebDriverErrorCode.Timeout.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, WebDriverErrorCode.Timeout.HttpStatusCode);
+
+            Assert.Equal("unknown command", WebDriverErrorCode.UnknownCommand.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.NotFound, WebDriverErrorCode.UnknownCommand.HttpStatusCode);
+
+            Assert.Equal("unknown error", WebDriverErrorCode.UnknownError.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, WebDriverErrorCode.UnknownError.HttpStatusCode);
+
+            Assert.Equal("unknown method", WebDriverErrorCode.UnknownMethod.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, WebDriverErrorCode.UnknownMethod.HttpStatusCode);
+
+            Assert.Equal("unsupported operation", WebDriverErrorCode.UnsupportedOperation.JsonErrorCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, WebDriverErrorCode.UnsupportedOperation.HttpStatusCode);
+        }
+    }
+}

--- a/src/Kaponata.Api.Tests/WebDriver/WebDriverErrorResultTests.cs
+++ b/src/Kaponata.Api.Tests/WebDriver/WebDriverErrorResultTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="WebDriverErrorResultTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.WebDriver;
+using System;
+using System.Net;
+using Xunit;
+
+namespace Kaponata.Api.Tests.WebDriver
+{
+    /// <summary>
+    /// Tests the <see cref="WebDriverErrorResult"/> class.
+    /// </summary>
+    public class WebDriverErrorResultTests
+    {
+        /// <summary>
+        /// <see cref="WebDriverErrorResult"/> constructors validates the arguments
+        /// passed to them.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("errorCode", () => new WebDriverErrorResult(null));
+            Assert.Throws<ArgumentNullException>("errorCode", () => new WebDriverErrorResult(null, "message"));
+            Assert.Throws<ArgumentNullException>("message", () => new WebDriverErrorResult(WebDriverErrorCode.InvalidArgument, null));
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverErrorResult"/> constructors initialize the error data.
+        /// </summary>
+        [Fact]
+        public void Constructor_CopiesErrorCode()
+        {
+            var result = new WebDriverErrorResult(WebDriverErrorCode.InvalidArgument);
+
+            Assert.Equal((int)HttpStatusCode.BadRequest, result.StatusCode);
+
+            var data = Assert.IsType<WebDriverErrorData>(result.Value);
+            Assert.Equal("The arguments passed to a command are either invalid or malformed.", data.Message);
+            Assert.Equal("invalid argument", data.Error);
+            Assert.Null(data.Data);
+            Assert.Null(data.StackTrace);
+        }
+    }
+}

--- a/src/Kaponata.Api.Tests/WebDriver/WebDriverResultTests.cs
+++ b/src/Kaponata.Api.Tests/WebDriver/WebDriverResultTests.cs
@@ -1,0 +1,57 @@
+﻿// <copyright file="WebDriverResultTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.WebDriver;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Kaponata.Api.Tests.WebDriver
+{
+    /// <summary>
+    /// Tests the <see cref="WebDriverResult"/> class.
+    /// </summary>
+    public class WebDriverResultTests
+    {
+        /// <summary>
+        /// The <see cref="WebDriverResult.WebDriverResult(object)"/> constructor
+        /// embeds the data in a <see cref="WebDriverData"/> class.
+        /// </summary>
+        [Fact]
+        public void Constructor_EmbedsData()
+        {
+            string value = "test";
+
+            WebDriverResult result = new WebDriverResult(value);
+            var data = Assert.IsType<WebDriverData>(result.Value);
+            Assert.Equal(value, data.Data);
+        }
+
+        /// <summary>
+        /// The <see cref="WebDriverResult.WebDriverResult(object)"/> constructor
+        /// copies the <see cref="WebDriverData"/> value passed to it.
+        /// </summary>
+        [Fact]
+        public void Constructor_CopiesData()
+        {
+            var data = new WebDriverData();
+
+            WebDriverResult result = new WebDriverResult(data);
+            Assert.Same(data, result.Value);
+        }
+
+        /// <summary>
+        /// The <see cref="WebDriverResult"/> constructor initializes the <see cref="JsonResult.Value"/>
+        /// to an empty <see cref="WebDriverData"/> object.
+        /// </summary>
+        [Fact]
+        public void Constructor_InitializesEmptyData()
+        {
+            var result = new WebDriverResult((WebDriverData)null);
+            Assert.IsType<WebDriverData>(result.Value);
+
+            result = new WebDriverResult((object)null);
+            Assert.IsType<WebDriverData>(result.Value);
+        }
+    }
+}

--- a/src/Kaponata.Api.Tests/WebDriverControllerTests.cs
+++ b/src/Kaponata.Api.Tests/WebDriverControllerTests.cs
@@ -1,0 +1,88 @@
+﻿// <copyright file="WebDriverControllerTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.WebDriver;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Api.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="WebDriverController"/> class.
+    /// </summary>
+    public class WebDriverControllerTests
+    {
+        /// <summary>
+        /// The <see cref="WebDriverController"/> validates the arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new WebDriverController(null));
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverController.NewSessionAsync(object, CancellationToken)"/> returns
+        /// an error.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
+        [Fact]
+        public async Task NewSessionAsync_ReturnsError_Async()
+        {
+            var controller = new WebDriverController(NullLogger<WebDriverController>.Instance);
+            var result = await controller.NewSessionAsync(null, default).ConfigureAwait(false);
+
+            var webDriverResult = Assert.IsType<WebDriverErrorResult>(result);
+            Assert.Equal(500, webDriverResult.StatusCode);
+
+            var error = Assert.IsType<WebDriverErrorData>(webDriverResult.Value);
+            Assert.Equal("session not created", error.Error);
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverController.DeleteAsync(string, CancellationToken)"/> returns
+        /// an error.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
+        [Fact]
+        public async Task DeleteAsync_ReturnsError_Async()
+        {
+            var controller = new WebDriverController(NullLogger<WebDriverController>.Instance);
+            var result = await controller.DeleteAsync(null, default).ConfigureAwait(false);
+
+            var webDriverResult = Assert.IsType<WebDriverErrorResult>(result);
+            Assert.Equal(404, webDriverResult.StatusCode);
+
+            var error = Assert.IsType<WebDriverErrorData>(webDriverResult.Value);
+            Assert.Equal("invalid session id", error.Error);
+        }
+
+        /// <summary>
+        /// <see cref="WebDriverController.StatusAsync(CancellationToken)"/> returns a
+        /// status object.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
+        [Fact]
+        public async Task StatusAsync_ReturnsValue_Async()
+        {
+            var controller = new WebDriverController(NullLogger<WebDriverController>.Instance);
+            var result = await controller.StatusAsync(default).ConfigureAwait(false);
+
+            var webDriverResult = Assert.IsType<WebDriverResult>(result);
+            Assert.Equal(200, webDriverResult.StatusCode);
+
+            var data = Assert.IsType<WebDriverData>(webDriverResult.Value);
+            var status = Assert.IsType<WebDriverStatus>(data.Data);
+        }
+    }
+}

--- a/src/Kaponata.Api/Startup.cs
+++ b/src/Kaponata.Api/Startup.cs
@@ -25,6 +25,7 @@ namespace Kaponata.Api
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddHealthChecks();
+            services.AddControllers();
         }
 
         /// <summary>
@@ -58,6 +59,8 @@ namespace Kaponata.Api
                     context.Response.ContentType = "text/plain";
                     await context.Response.WriteAsync("Hello World!");
                 });
+
+                endpoints.MapControllers();
 
                 endpoints.MapHealthChecks("/health/ready");
                 endpoints.MapHealthChecks("/health/alive");

--- a/src/Kaponata.Api/WebDriver/WebDriverData.cs
+++ b/src/Kaponata.Api/WebDriver/WebDriverData.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="WebDriverData.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Api.WebDriver
+{
+    /// <summary>
+    /// Represents the base payload of a WebDriver error or success response. In both cases, the
+    /// root object contains a <see cref="Data"/> field.
+    /// </summary>
+    public class WebDriverData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverData"/> class.
+        /// </summary>
+        public WebDriverData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverData"/> class, and initializes
+        /// the <see cref="Data"/> property.
+        /// </summary>
+        /// <param name="data">
+        /// The initial value of the <see cref="Data"/> property.
+        /// </param>
+        public WebDriverData(object data)
+        {
+            this.Data = data;
+        }
+
+        /// <summary>
+        /// Gets or sets the embedded data.
+        /// </summary>
+        public object Data { get; set; }
+    }
+}

--- a/src/Kaponata.Api/WebDriver/WebDriverErrorCode.cs
+++ b/src/Kaponata.Api/WebDriver/WebDriverErrorCode.cs
@@ -1,0 +1,158 @@
+﻿// <copyright file="WebDriverErrorCode.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System;
+using System.Net;
+
+namespace Kaponata.Api.WebDriver
+{
+    /// <summary>
+    /// Represents a well-known WebDriver error code.
+    /// </summary>
+    /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-error-response-data"/>
+    public class WebDriverErrorCode
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverErrorCode"/> class.
+        /// </summary>
+        /// <param name="jsonErrorCode">
+        /// The JSON error code for this <see cref="WebDriverErrorCode"/>.
+        /// </param>
+        /// <param name="statusCode">
+        /// The <see cref="HttpStatusCode"/> for this <see cref="WebDriverErrorCode"/>.
+        /// </param>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        public WebDriverErrorCode(string jsonErrorCode, HttpStatusCode statusCode, string message)
+        {
+            this.JsonErrorCode = jsonErrorCode ?? throw new ArgumentNullException(nameof(jsonErrorCode));
+            this.HttpStatusCode = statusCode;
+            this.Message = message ?? throw new ArgumentNullException(nameof(message));
+        }
+
+        /// <summary>
+        /// Gets the Invalid Argument error.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-invalid-argument"/>
+        public static WebDriverErrorCode InvalidArgument { get; } =
+            new WebDriverErrorCode(
+                "invalid argument",
+                HttpStatusCode.BadRequest,
+                "The arguments passed to a command are either invalid or malformed.");
+
+        /// <summary>
+        /// Gets an error which occurs if the given session id is not in the list of active sessions,
+        /// meaning the session either does not exist or that it’s not active.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-invalid-session-id"/>
+        public static WebDriverErrorCode InvalidSessionId { get; }
+            = new WebDriverErrorCode(
+                "invalid session id",
+                HttpStatusCode.NotFound,
+                "The given session id is not in the list of active sessions.");
+
+        /// <summary>
+        /// Gets an error which occurs when a new session could not be created.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-session-not-created"/>
+        public static WebDriverErrorCode SessionNotCreated { get; }
+            = new WebDriverErrorCode(
+                "session not created",
+                HttpStatusCode.InternalServerError,
+                "A new session could not be created.");
+
+        /// <summary>
+        /// Gets the error which occurs when an operation did not complete before its timeout expired.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-timeout"/>
+        public static WebDriverErrorCode Timeout { get; }
+            = new WebDriverErrorCode(
+                "timeout",
+                HttpStatusCode.InternalServerError,
+                "An operation did not complete before its timeout expired.");
+
+        /// <summary>
+        /// Gets the error which occurs when a command could not be executed because the remote end is not aware of it.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-unknown-command"/>
+        public static WebDriverErrorCode UnknownCommand { get; }
+            = new WebDriverErrorCode(
+                "unknown command",
+                HttpStatusCode.NotFound,
+                "A command could not be executed because the remote end is not aware of it.");
+
+        /// <summary>
+        /// Gets the error which occurs when an unknown error occurred in the while processing the command.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-unknown-error"/>
+        public static WebDriverErrorCode UnknownError { get; }
+            = new WebDriverErrorCode(
+                "unknown error",
+                HttpStatusCode.InternalServerError,
+                "An unknown error occurred in the remote end while processing the command.");
+
+        /// <summary>
+        /// Gets an error which occurs when the requested command matched a known URL but did not match an method for that URL.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-unknown-method"/>
+        public static WebDriverErrorCode UnknownMethod { get; }
+            = new WebDriverErrorCode(
+                "unknown method",
+                HttpStatusCode.MethodNotAllowed,
+                "The requested command matched a known URL but did not match an method for that URL.");
+
+        /// <summary>
+        /// Gets an error which occurs when a command that should have executed properly cannot be supported for some reason.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-unsupported-operation"/>.
+        public static WebDriverErrorCode UnsupportedOperation { get; }
+            = new WebDriverErrorCode(
+                "unsupported operation",
+                HttpStatusCode.InternalServerError,
+                "The command that should have executed properly cannot be supported.");
+
+        /// <summary>
+        /// Gets the JSON error code for this <see cref="WebDriverErrorCode"/>.
+        /// </summary>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#dfn-error-code"/>
+        public string JsonErrorCode { get; }
+
+        /// <summary>
+        /// Gets the <see cref="HttpStatusCode"/> for this <see cref="WebDriverErrorCode"/>.
+        /// </summary>
+        public HttpStatusCode HttpStatusCode { get; }
+
+        /// <summary>
+        /// Gets a non-normative description of the error.
+        /// </summary>
+        public string Message { get; }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.JsonErrorCode;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            var other = obj as WebDriverErrorCode;
+
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.JsonErrorCode == this.JsonErrorCode
+                && other.HttpStatusCode == this.HttpStatusCode;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.JsonErrorCode, this.HttpStatusCode);
+        }
+    }
+}

--- a/src/Kaponata.Api/WebDriver/WebDriverErrorData.cs
+++ b/src/Kaponata.Api/WebDriver/WebDriverErrorData.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="WebDriverErrorData.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Api.WebDriver
+{
+    /// <summary>
+    /// The WebDriver error data used when an error occurs.
+    /// </summary>
+    public class WebDriverErrorData : WebDriverData
+    {
+        /// <summary>
+        /// Gets or sets the JSON error code which describes the error.
+        /// </summary>
+        public string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets an implementation-defined string with a human readable description of the kind of
+        /// error that occurred.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets an implementation-defined string with a stack trace report of the active stack frames at
+        /// the time when the error occurred.
+        /// </summary>
+        public string StackTrace { get; set; }
+    }
+}

--- a/src/Kaponata.Api/WebDriver/WebDriverErrorResult.cs
+++ b/src/Kaponata.Api/WebDriver/WebDriverErrorResult.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="WebDriverErrorResult.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace Kaponata.Api.WebDriver
+{
+    /// <summary>
+    /// An action results which returns a WebDriver errror to the client.
+    /// </summary>
+    public class WebDriverErrorResult : WebDriverResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverErrorResult"/>
+        /// class.
+        /// </summary>
+        /// <param name="errorCode">
+        /// The error code which describes the error.
+        /// </param>
+        public WebDriverErrorResult(WebDriverErrorCode errorCode)
+            : this(errorCode, errorCode?.Message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverErrorResult"/>
+        /// class.
+        /// </summary>
+        /// <param name="errorCode">
+        /// The error code which describes the error.
+        /// </param>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        public WebDriverErrorResult(WebDriverErrorCode errorCode, string message)
+            : base(new WebDriverErrorData())
+        {
+            if (errorCode == null)
+            {
+                throw new ArgumentNullException(nameof(errorCode));
+            }
+
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            var errorData = (WebDriverErrorData)this.Value;
+            errorData.Message = message;
+            errorData.Error = errorCode.JsonErrorCode;
+
+            this.StatusCode = (int)errorCode.HttpStatusCode;
+        }
+    }
+}

--- a/src/Kaponata.Api/WebDriver/WebDriverResult.cs
+++ b/src/Kaponata.Api/WebDriver/WebDriverResult.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="WebDriverResult.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+namespace Kaponata.Api.WebDriver
+{
+    /// <summary>
+    /// Sends the result of a WebDriver to a client.
+    /// </summary>
+    public class WebDriverResult : JsonResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverResult"/> class.
+        /// </summary>
+        /// <param name="data">
+        /// The result data which will be embedded in the <see cref="JsonResult.Value"/>
+        /// property.
+        /// </param>
+        public WebDriverResult(object data)
+            : this(new WebDriverData(data))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverResult"/> class.
+        /// </summary>
+        /// <param name="data">
+        /// The WebDriver-formatted result data.
+        /// </param>
+        public WebDriverResult(WebDriverData data)
+            : base(data ?? new WebDriverData())
+        {
+            this.SerializerSettings = new JsonSerializerOptions()
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            this.ContentType = "application/json; charset=utf-8";
+            this.StatusCode = 200;
+        }
+    }
+}

--- a/src/Kaponata.Api/WebDriver/WebDriverStatus.cs
+++ b/src/Kaponata.Api/WebDriver/WebDriverStatus.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="WebDriverStatus.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Api.WebDriver
+{
+    /// <summary>
+    /// Describes the readiness state of a WebDriver node.
+    /// </summary>
+    /// <seealso href="https://www.w3.org/TR/webdriver/#nodes"/>
+    public class WebDriverStatus
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether this node is ready.
+        /// </summary>
+        public bool Ready { get; set; }
+
+        /// <summary>
+        /// Gets or sets a message which describes the state.
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/src/Kaponata.Api/WebDriverController.cs
+++ b/src/Kaponata.Api/WebDriverController.cs
@@ -1,0 +1,99 @@
+﻿// <copyright file="WebDriverController.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.WebDriver;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Api
+{
+    /// <summary>
+    /// The <see cref="WebDriverController"/> handles WebDriver requests.
+    /// </summary>
+    [ApiController]
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None)]
+    public class WebDriverController : Controller
+    {
+        private readonly ILogger<WebDriverController> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDriverController"/> class.
+        /// </summary>
+        /// <param name="logger">
+        /// The logger to use when logging.
+        /// </param>
+        public WebDriverController(ILogger<WebDriverController> logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Asynchrounsly creates a new session.
+        /// </summary>
+        /// <param name="request">
+        /// The request parameters.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#new-session"/>
+        [HttpPost("/wd/hub/session")]
+        public Task<WebDriverResult> NewSessionAsync(object request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<WebDriverResult>(
+                new WebDriverErrorResult(
+                    WebDriverErrorCode.SessionNotCreated,
+                    "This version of Kaponata does not support creating any sessions."));
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a session.
+        /// </summary>
+        /// <param name="sessionId">
+        /// The ID of the session to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        /// <seealso href="https://www.w3.org/TR/webdriver/#delete-session"/>
+        [HttpDelete("/wd/hub/session/{sessionId}")]
+        public Task<WebDriverResult> DeleteAsync(string sessionId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<WebDriverResult>(
+                new WebDriverErrorResult(
+                    WebDriverErrorCode.InvalidSessionId,
+                    $"A session with session id '{sessionId}' could not be found"));
+        }
+
+        /// <summary>
+        /// Asynchronously returns the status of this node.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        [HttpGet("/wd/hub/status")]
+        public Task<WebDriverResult> StatusAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<WebDriverResult>(
+                new WebDriverResult(
+                    new WebDriverStatus()
+                    {
+                        Ready = false,
+                        Message = "This version of Kaponata does not support creating any sessions.",
+                    }));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following endpoints to the API server:

- `GET /wd/hub/status`
- `POST /wd/hub/session`
- `DELETE /wd/hub/session`

The new session and delete session commands always return an error; the main goal of this PR is to add the infrastructure required to handle WebDriver requests to the API server.