### PR TITLE
Fix URL in code coverage report

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            The code coverage report for this pull request [is available online](https://ci.kaponata.io/${{ github.ref }}/index.html)
+            The code coverage report for this pull request [is available online](https://kaponataci.z6.web.core.windows.net/${{ github.ref }}/index.html)
 
       - name: Package operator
         run: |


### PR DESCRIPTION
https://ci.kaponata.io/ sits behind a CDN network, meaning the content is cached and you may get outdated results when a PR is updated.

A CDN was used because that's the only way to get SSL certificates on custom domains for websites hosted on Azure blob storage.

Replace the URL with https://kaponataci.z6.web.core.windows.net, which is the direct blob storage endpoint.