### PR TITLE
Add WebDriverSesssion custom resource definition

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.MobileDevice.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.MobileDevice.cs
@@ -117,7 +117,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                             {
                                 Response = new HttpResponseMessage()
                                 {
-                                    Content = new StringContent(JsonConvert.SerializeObject(Assert.IsType<MobileDevice>(mobileDevice))),
+                                    Content = new StringContent(JsonConvert.SerializeObject(Assert.IsType<MobileDevice>(value))),
                                     StatusCode = HttpStatusCode.OK,
                                 },
                             });
@@ -347,8 +347,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadMobileDeviceAsync(string, string, CancellationToken)"/> returns <see langword="null"/>
-        /// if the requested device does not exist.
+        /// <see cref="KubernetesClient.TryReadMobileDeviceAsync(string, string, CancellationToken)"/> returns a <see cref="MobileDevice"/>
+        /// object if the requested device exists.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.WebDriverSession.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.WebDriverSession.cs
@@ -1,0 +1,346 @@
+﻿// <copyright file="KubernetesClientTests.WebDriverSession.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Kaponata.Operator.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Rest;
+using Moq;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the WebDriverSession-related code in <see cref="KubernetesClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// Because the WebDriverSession-related methods are small wrappers around custom object code,
+    /// only positive scenarios are tested.
+    /// </remarks>
+    public partial class KubernetesClientTests
+    {
+        /// <summary>
+        /// <see cref="KubernetesClient.CreateWebDriverSessionAsync(WebDriverSession, CancellationToken)"/> returns a <see cref="WebDriverSession"/> object
+        /// when the operation succeeds.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateWebDriverSessionAsync_Success_ReturnsObject_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol.Setup(p => p.DeserializationSettings).Returns(new JsonSerializerSettings());
+
+            var session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    NamespaceProperty = "default",
+                },
+            };
+
+            protocol.Setup(p => p.CreateNamespacedCustomObjectWithHttpMessagesAsync(
+                session,
+                "kaponata.io" /* group */,
+                "v1alpha1" /* version */,
+                "default" /* namespaceParameter */,
+                "webdriversessions" /* plural */,
+                null /* dryRun */,
+                null /* fieldManager */,
+                null /* pretty */,
+                null /* customHeaders */,
+                default /* cancellationToken */))
+                .Returns<object, string, string, string, string, string, string, string, Dictionary<string, List<string>>, CancellationToken>(
+                    (value, group, version, namespaceParameter, plural, dryDrun, fieldManager, pretty, customHeaders, cancellationToken) =>
+                    {
+                        return Task.FromResult(
+                            new HttpOperationResponse<object>()
+                            {
+                                Response = new HttpResponseMessage()
+                                {
+                                    Content = new StringContent(JsonConvert.SerializeObject(Assert.IsType<WebDriverSession>(value))),
+                                    StatusCode = HttpStatusCode.OK,
+                                },
+                            });
+                    });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var result = await client.CreateWebDriverSessionAsync(session, default).ConfigureAwait(false);
+                Assert.NotNull(result);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.ListWebDriverSessionAsync(string, string, string, string, int?, CancellationToken)"/> returns a typed object
+        /// when the operation completes successfully.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ListWebDriverSessionAsync_Success_ReturnsTypedResponse_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol.Setup(p => p.DeserializationSettings).Returns(new JsonSerializerSettings());
+
+            protocol.Setup(p => p.ListNamespacedCustomObjectWithHttpMessagesAsync(
+                "kaponata.io" /* group */,
+                "v1alpha1" /* version */,
+                "default" /* namespaceParameter */,
+                "webdriversessions" /* plural */,
+                null /* continueParameter */,
+                null /* fieldSelector */,
+                null /* labelSelector */,
+                null /* limit */,
+                null /* resourceVersion */,
+                null /* timeoutSeconds */,
+                null /* watch */,
+                null /* pretty */,
+                null /* customHeaders */,
+                default /* cancellationToken */))
+                .ReturnsAsync(
+                new HttpOperationResponse<object>()
+                {
+                    Response = new HttpResponseMessage()
+                    {
+                        Content =
+                            new StringContent(
+                                JsonConvert.SerializeObject(
+                                    new WebDriverSessionList()
+                                    {
+                                        Items = new WebDriverSession[]
+                                        {
+                                            new WebDriverSession()
+                                            {
+                                                Metadata = new V1ObjectMeta()
+                                                {
+                                                    Name = "session1",
+                                                },
+                                            },
+                                            new WebDriverSession()
+                                            {
+                                                Metadata = new V1ObjectMeta()
+                                                {
+                                                    Name = "session2",
+                                                },
+                                            },
+                                        },
+                                    })),
+                        StatusCode = HttpStatusCode.OK,
+                    },
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var list = await client.ListWebDriverSessionAsync("default").ConfigureAwait(false);
+                Assert.Collection(
+                    list.Items,
+                    d => { Assert.Equal("session1", d.Metadata.Name); },
+                    d => { Assert.Equal("session2", d.Metadata.Name); });
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.TryReadWebDriverSessionAsync(string, string, CancellationToken)"/> returns a <see cref="WebDriverSession"/>
+        /// object if the requested session exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryReadWebDriverSessionAsync_SessionFound_ReturnsObject_Async()
+        {
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+            protocol.Setup(p => p.DeserializationSettings).Returns(new JsonSerializerSettings());
+            protocol.Setup(p => p.ListNamespacedCustomObjectWithHttpMessagesAsync(
+                "kaponata.io" /* group */,
+                "v1alpha1" /* version */,
+                "default" /* namespaceParameter */,
+                "webdriversessions" /* plural */,
+                null /* continueParameter */,
+                "metadata.name=my-session" /* fieldSelector */,
+                null /* labelSelector */,
+                null /* limit */,
+                null /* resourceVersion */,
+                null /* timeoutSeconds */,
+                null /* watch */,
+                null /* pretty */,
+                null /* customHeaders */,
+                default /* cancellationToken */))
+                .ReturnsAsync(
+                new HttpOperationResponse<object>()
+                {
+                    Response = new HttpResponseMessage()
+                    {
+                        Content = new StringContent("{ \"Items\": [ { \"Metadata\": { \"Name\": \"my-session\" } } ] }"),
+                        StatusCode = HttpStatusCode.OK,
+                    },
+                });
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var device = await client.TryReadWebDriverSessionAsync("default", "my-session", default).ConfigureAwait(false);
+                Assert.Equal("my-session", device.Metadata.Name);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.WatchWebDriverSessionAsync(WebDriverSession, WatchEventDelegate{WebDriverSession}, CancellationToken)"/>
+        /// delegates its work to <see cref="IKubernetesProtocol.WatchNamespacedObjectAsync{TObject, TList}(TObject, ListNamespacedObjectWithHttpMessagesAsync{TObject, TList}, WatchEventDelegate{TObject}, CancellationToken)"/>.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WatchWebDriverSessionAsync_Works_Async()
+        {
+            WebDriverSession session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    NamespaceProperty = "default",
+                    Name = "my-session",
+                },
+            };
+
+            TaskCompletionSource<WatchExitReason> tcs = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(
+                p => p.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                    session,
+                    It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>>(),
+                    It.IsAny<WatchEventDelegate<WebDriverSession>>(),
+                    default))
+                .Returns(tcs.Task);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var task = client.WatchWebDriverSessionAsync(
+                    session,
+                    (eventType, device) =>
+                    {
+                        return Task.FromResult(WatchResult.Stop);
+                    },
+                    default);
+
+                Assert.False(task.IsCompleted);
+                tcs.SetResult(WatchExitReason.ClientDisconnected);
+
+                Assert.Equal(WatchExitReason.ClientDisconnected, await task);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// KubernetesClient.WatchWebDriverSessionAsync forwards requests to <see cref="IKubernetesProtocol"/>.
+        /// </summary>
+        [Fact]
+        public void WatchWebDriverSessionAsync_ForwardRequests()
+        {
+            var tcs = new TaskCompletionSource<WatchExitReason>();
+            var eventHandler = new WatchEventDelegate<WebDriverSession>((type, pod) => Task.FromResult(WatchResult.Continue));
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol
+                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>>(), eventHandler, default))
+                .Returns(tcs.Task);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                Assert.Same(tcs.Task, client.WatchWebDriverSessionAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesClient.DeleteWebDriverSessionAsync"/> returns when the WebDriver session is deleted.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteWebDriverSessionAsync_DeviceDeleted_Returns_Async()
+        {
+            var session =
+                new WebDriverSession()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-session",
+                        NamespaceProperty = "default",
+                    },
+                };
+
+            WatchEventDelegate<WebDriverSession> callback = null;
+            TaskCompletionSource<WatchExitReason> watchTask = new TaskCompletionSource<WatchExitReason>();
+
+            var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DeserializationSettings).Returns(new JsonSerializerSettings());
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            protocol
+                .Setup(
+                    p => p.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                        session,
+                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>>(),
+                        It.IsAny<WatchEventDelegate<WebDriverSession>>(),
+                        It.IsAny<CancellationToken>()))
+                .Returns<WebDriverSession, ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>, WatchEventDelegate<WebDriverSession>, CancellationToken>(
+                (session, list, watcher, ct) =>
+                {
+                    callback = watcher;
+                    return watchTask.Task;
+                });
+
+            protocol
+                .Setup(
+                    p => p.DeleteNamespacedCustomObjectWithHttpMessagesAsync(
+                        "kaponata.io",
+                        "v1alpha1",
+                        "default",
+                        "webdriversessions",
+                        "my-session",
+                        null, /* body */
+                        null, /* gracePeriodSeconds */
+                        null, /* orphanDependents */
+                        null, /* propagationPolicy */
+                        null, /* dryRun */
+                        null, /* customHeaders */
+                        default))
+                .Returns(Task.FromResult(new HttpOperationResponse<object>() { Body = session, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
+
+            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            {
+                var task = client.DeleteWebDriverSessionAsync(session, TimeSpan.FromMinutes(1), default);
+                Assert.NotNull(callback);
+
+                // The callback continues watching until the pod is deleted
+                Assert.Equal(WatchResult.Continue, await callback(WatchEventType.Modified, session).ConfigureAwait(false));
+                Assert.Equal(WatchResult.Stop, await callback(WatchEventType.Deleted, session).ConfigureAwait(false));
+                watchTask.SetResult(WatchExitReason.ClientDisconnected);
+
+                await task.ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Models/ModelDefinitionsTests.cs
+++ b/src/Kaponata.Operator.Tests/Models/ModelDefinitionsTests.cs
@@ -19,6 +19,17 @@ namespace Kaponata.Operator.Tests.Models
         public void MobileDevice_Works()
         {
             Assert.NotNull(ModelDefinitions.MobileDevice);
+            Assert.Equal("mobiledevices.kaponata.io", ModelDefinitions.MobileDevice.Metadata.Name);
+        }
+
+        /// <summary>
+        /// The <see cref="ModelDefinitions.WebDriverSession"/> property returns the correct value.
+        /// </summary>
+        [Fact]
+        public void WebDriverSession_Works()
+        {
+            Assert.NotNull(ModelDefinitions.WebDriverSession);
+            Assert.Equal("webdriversessions.kaponata.io", ModelDefinitions.WebDriverSession.Metadata.Name);
         }
     }
 }

--- a/src/Kaponata.Operator/ExtensionsInstaller.cs
+++ b/src/Kaponata.Operator/ExtensionsInstaller.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using k8s.Models;
 using Kaponata.Operator.Kubernetes;
 using Kaponata.Operator.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,14 +69,18 @@ namespace Kaponata.Operator
         /// </returns>
         public async Task InstallAsync(CancellationToken cancellationToken)
         {
-            var mobileDeviceCrd = ModelDefinitions.MobileDevice;
+            await this.InstallCrdAsync(ModelDefinitions.MobileDevice, cancellationToken).ConfigureAwait(false);
+            await this.InstallCrdAsync(ModelDefinitions.WebDriverSession, cancellationToken).ConfigureAwait(false);
+        }
 
-            this.logger.LogInformation("Installing the {crdName} custom resource definition", mobileDeviceCrd.Metadata.Name);
+        private async Task InstallCrdAsync(V1CustomResourceDefinition crd, CancellationToken cancellationToken)
+        {
+            this.logger.LogInformation("Installing the {crdName} custom resource definition", crd.Metadata.Name);
             await this.kubernetesClient.InstallOrUpgradeCustomResourceDefinitionAsync(
-                mobileDeviceCrd,
+                crd,
                 TimeSpan.FromMinutes(1),
                 cancellationToken).ConfigureAwait(false);
-            this.logger.LogInformation("Successfully installed the {crdName} custom resource definition.", mobileDeviceCrd.Metadata.Name);
+            this.logger.LogInformation("Successfully installed the {crdName} custom resource definition.", crd.Metadata.Name);
         }
     }
 }

--- a/src/Kaponata.Operator/Kaponata.Operator.csproj
+++ b/src/Kaponata.Operator/Kaponata.Operator.csproj
@@ -6,10 +6,12 @@
 
   <ItemGroup>
     <None Remove="Models\MobileDevice.yaml" />
+    <None Remove="Models\WebDriverSession.yaml" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Models\MobileDevice.yaml" />
+    <EmbeddedResource Include="Models\WebDriverSession.yaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.WebDriverSession.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.WebDriverSession.cs
@@ -1,0 +1,298 @@
+﻿// <copyright file="KubernetesClient.WebDriverSession.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Kaponata.Operator.Models;
+using Microsoft.Rest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Implements the <see cref="WebDriverSession"/> operations.
+    /// </summary>
+    public partial class KubernetesClient
+    {
+        /// <summary>
+        /// Asynchronously creates a new WebDriver session.
+        /// </summary>
+        /// <param name="value">
+        /// The WebDriver session object to create.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the newly created mobile device
+        /// when completed.
+        /// </returns>
+        public virtual Task<WebDriverSession> CreateWebDriverSessionAsync(WebDriverSession value, CancellationToken cancellationToken)
+        {
+            return this.CreateNamespacedValueAsync<WebDriverSession>(
+                WebDriverSession.KubeMetadata,
+                value,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously list or watch <see cref="WebDriverSession"/> objects.
+        /// </summary>
+        /// <param name="namespace">
+        /// The namespace in which to list or watch objects.
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from
+        /// a previous query result with identical query parameters (except for the value
+        /// of continue) and the server may reject a continue value it does not recognize.
+        /// If the specified continue value is no longer valid whether due to expiration
+        /// (generally five to fifteen minutes) or a configuration change on the server,
+        /// the server will respond with a 410 ResourceExpired error together with a continue
+        /// token. If the client needs a consistent list, it must restart their list without
+        /// the continue field. Otherwise, the client may send another list request with
+        /// the token received with the 410 error, the server will respond with a list starting
+        /// from the next key, but from the latest snapshot, which is inconsistent from the
+        /// previous list results - objects that are created, modified, or deleted after
+        /// the first list request will be included in the response, as long as their keys
+        /// are after the "next key". This field is not supported when watch is true. Clients
+        /// may start a watch from the last resourceVersion value returned by the server
+        /// and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call. If more items
+        /// exist, the server will set the `continue` field on the list metadata to a value
+        /// that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero
+        /// items) in the event all requested objects are filtered out and clients should
+        /// only use the presence of the continue field to determine whether more results
+        /// are available. Servers may choose not to support the limit argument and will
+        /// return all of the available results. If limit is specified and the continue field
+        /// is empty, clients may assume that no more results are available. This field is
+        /// not supported if watch is true. The server guarantees that the objects returned
+        /// when using continue will be identical to issuing a single list call without a
+        /// limit - that is, no objects created, modified, or deleted after the first request
+        /// is issued will be included in any subsequent continued requests. This is sometimes
+        /// referred to as a consistent snapshot, and ensures that a client that is using
+        /// limit to receive smaller chunks of a very large result can ensure they see all
+        /// possible objects. If objects are updated during a chunked list the version of
+        /// the object that was present at the time the first list result was calculated
+        /// is returned.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="MobileDeviceList"/> which represents the mobile devices which match the query.
+        /// </returns>
+        public async virtual Task<WebDriverSessionList> ListWebDriverSessionAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        {
+            using (var operationResponse = await this.ListWebDriverSessionAsync(
+                namespaceParameter: @namespace,
+                continueParameter: @continue,
+                fieldSelector: fieldSelector,
+                labelSelector: labelSelector,
+                cancellationToken: cancellationToken))
+            {
+                return operationResponse.Body;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously tries to read a WebDriver session.
+        /// </summary>
+        /// <param name="namespace">
+        /// The namespace in which the WebDriver session is located.
+        /// </param>
+        /// <param name="name">
+        /// The name which uniquely identifies the WebDriver session within the namespace.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested WebDriver session, or
+        /// <see langword="null"/> if the WebDriver session does not exist.
+        /// </returns>
+        public virtual async Task<WebDriverSession> TryReadWebDriverSessionAsync(string @namespace, string name, CancellationToken cancellationToken)
+        {
+            var list = await this.RunTaskAsync(this.ListWebDriverSessionAsync(namespaceParameter: @namespace, fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return list.Body.Items.SingleOrDefault();
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a WebDriver session.
+        /// </summary>
+        /// <param name="value">
+        /// The WebDriver session to delete.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time in which the WebDriver session should be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public virtual Task DeleteWebDriverSessionAsync(WebDriverSession value, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return this.DeleteNamespacedObjectAsync<WebDriverSession>(
+                value,
+                this.DeleteNamespacedWebDriverSessionAsync,
+                this.WatchWebDriverSessionAsync,
+                timeout,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously watches <see cref="WebDriverSession"/> objects.
+        /// </summary>
+        /// <param name="value">
+        /// The object to watch.
+        /// </param>
+        /// <param name="eventHandler">
+        /// An handler which processes a watch event, and lets the watcher know whether
+        /// to continue watching or not.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the watch operation. The task completes
+        /// when the watcher stops watching for events. The <see cref="WatchExitReason"/>
+        /// return value describes why the watcher stopped. The task errors if the watch
+        /// loop errors.
+        /// </returns>
+        public Task<WatchExitReason> WatchWebDriverSessionAsync(
+            WebDriverSession value,
+            WatchEventDelegate<WebDriverSession> eventHandler,
+            CancellationToken cancellationToken)
+        {
+            return this.protocol.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                 value,
+                 this.ListWebDriverSessionAsync,
+                 eventHandler,
+                 cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously watches <see cref="WebDriverSession"/> objects.
+        /// </summary>
+        /// <param name="namespace">
+        /// The namespace in which to watch for <see cref="WebDriverSession"/> objects.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// resourceVersion sets a constraint on what resource versions a request may be
+        /// served from. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to unset.
+        /// </param>
+        /// <param name="eventHandler">
+        /// An handler which processes a watch event, and lets the watcher know whether
+        /// to continue watching or not.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the watch operation. The task completes
+        /// when the watcher stops watching for events. The <see cref="WatchExitReason"/>
+        /// return value describes why the watcher stopped. The task errors if the watch
+        /// loop errors.
+        /// </returns>
+        public virtual Task<WatchExitReason> WatchWebDriverSessionAsync(
+            string @namespace,
+            string fieldSelector,
+            string labelSelector,
+            string resourceVersion,
+            WatchEventDelegate<WebDriverSession> eventHandler,
+            CancellationToken cancellationToken)
+        {
+            return this.protocol.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                @namespace,
+                fieldSelector,
+                labelSelector,
+                resourceVersion,
+                this.ListWebDriverSessionAsync,
+                eventHandler,
+                cancellationToken);
+        }
+
+        private Task<HttpOperationResponse<WebDriverSessionList>> ListWebDriverSessionAsync(
+            string namespaceParameter,
+            bool? allowWatchBookmarks = null,
+            string continueParameter = null,
+            string fieldSelector = null,
+            string labelSelector = null,
+            int? limit = null,
+            string resourceVersion = null,
+            string resourceVersionMatch = null,
+            int? timeoutSeconds = null,
+            bool? watch = null,
+            string pretty = null,
+            Dictionary<string, List<string>> customHeaders = null,
+            CancellationToken cancellationToken = default)
+        {
+            return this.ListNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                WebDriverSession.KubeMetadata,
+                namespaceParameter,
+                allowWatchBookmarks,
+                continueParameter,
+                fieldSelector,
+                labelSelector,
+                limit,
+                resourceVersion,
+                resourceVersionMatch,
+                timeoutSeconds,
+                watch,
+                pretty,
+                customHeaders,
+                cancellationToken);
+        }
+
+        private Task<WebDriverSession> DeleteNamespacedWebDriverSessionAsync(
+            string name,
+            string namespaceParameter,
+            V1DeleteOptions body = null,
+            string dryRun = null,
+            int? gracePeriodSeconds = null,
+            bool? orphanDependents = null,
+            string propagationPolicy = null,
+            string pretty = null,
+            CancellationToken cancellationToken = default)
+        {
+            return this.DeleteNamespacedObjectAsync<WebDriverSession>(
+                WebDriverSession.KubeMetadata,
+                name,
+                namespaceParameter,
+                body,
+                dryRun,
+                gracePeriodSeconds,
+                orphanDependents,
+                propagationPolicy,
+                pretty,
+                cancellationToken);
+        }
+    }
+}

--- a/src/Kaponata.Operator/Models/ModelDefinitions.cs
+++ b/src/Kaponata.Operator/Models/ModelDefinitions.cs
@@ -27,5 +27,20 @@ namespace Kaponata.Operator.Models
                 }
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="V1CustomResourceDefinition"/> for the WebDriverSession type.
+        /// </summary>
+        public static V1CustomResourceDefinition WebDriverSession
+        {
+            get
+            {
+                using (Stream stream = typeof(ModelDefinitions).Assembly.GetManifestResourceStream("Kaponata.Operator.Models.WebDriverSession.yaml"))
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    return Yaml.LoadFromString<V1CustomResourceDefinition>(reader.ReadToEnd());
+                }
+            }
+        }
     }
 }

--- a/src/Kaponata.Operator/Models/WebDriverSession.cs
+++ b/src/Kaponata.Operator/Models/WebDriverSession.cs
@@ -1,0 +1,85 @@
+﻿// <copyright file="WebDriverSession.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Newtonsoft.Json;
+
+namespace Kaponata.Operator.Models
+{
+    /// <summary>
+    /// A WebDriverSession object represents a WebDriver session which is currently running on
+    /// a Kaponata device.It is typically created by a request to the Kaponata API server. An
+    /// operator then picks up the session request and setting up the infrastructure to host
+    /// the session.
+    /// </summary>
+    public class WebDriverSession : IKubernetesObject<V1ObjectMeta>, IMetadata<V1ObjectMeta>, ISpec<WebDriverSessionSpec>
+    {
+        /// <summary>
+        /// The API version used by Kubernetes to identify the object.
+        /// </summary>
+        public const string KubeApiVersion = KubeGroup + "/" + KubeVersion;
+
+        /// <summary>
+        /// The Kind used by Kubernetes to identify the object.
+        /// </summary>
+        public const string KubeKind = "WebDriverSession";
+
+        /// <summary>
+        /// The Group used by Kubernetes to identify the object.
+        /// </summary>
+        public const string KubeGroup = "kaponata.io";
+
+        /// <summary>
+        /// The Version used by Kubernetes to identify the object.
+        /// </summary>
+        public const string KubeVersion = "v1alpha1";
+
+        /// <summary>
+        /// The plural name of the object type, used by Kubernetes to identify the object.
+        /// </summary>
+        public const string KubePlural = "webdriversessions";
+
+        /// <summary>
+        /// Gets <see cref="KindMetadata"/> which describes the <see cref="WebDriverSession"/> object type.
+        /// </summary>
+        public static KindMetadata KubeMetadata { get; } = new KindMetadata(KubeGroup, KubeVersion, KubePlural);
+
+        /// <summary>
+        /// Gets or sets the API version, which defines the versioned schema of this representation of
+        /// an object. Servers should convert recognized schemas to the latest internal value,
+        /// and may reject unrecognized values.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources" />
+        [JsonProperty(PropertyName = "apiVersion")]
+        public string ApiVersion { get; set; } = KubeApiVersion;
+
+        /// <summary>
+        /// Gets or sets the object kind, which is a string value representing the REST resource this object
+        /// represents. Servers may infer this from the endpoint the client submits requests
+        /// Cannot be updated. In CamelCase.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"  />
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; } = KubeKind;
+
+        /// <summary>
+        /// Gets or sets standard object's metadata.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata" />
+        [JsonProperty(PropertyName = "metadata")]
+        public V1ObjectMeta Metadata { get; set; }
+
+        /// <inheritdoc/>
+        [JsonProperty(PropertyName = "spec")]
+        public WebDriverSessionSpec Spec { get; set; }
+
+        /// <summary>
+        /// Gets or sets an object which describes the status of the WebDriver session.
+        /// </summary>
+        [JsonProperty(PropertyName = "status")]
+        public WebDriverSessionStatus Status { get; set; }
+    }
+}

--- a/src/Kaponata.Operator/Models/WebDriverSession.yaml
+++ b/src/Kaponata.Operator/Models/WebDriverSession.yaml
@@ -1,0 +1,53 @@
+﻿apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: webdriversessions.kaponata.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: kaponata.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: |
+            A WebDriverSession object represents a WebDriver session which is currently running on
+            a Kaponata device. It is typically created by a request to the Kaponata API server. An
+            operator then picks up the session request and setting up the infrastructure to host
+            the session.
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                desiredCapabilities:
+                  description: The desired capabilities, as requested by the client.
+                  type: string
+            status:
+              type: object
+              properties:
+                url:
+                  description: The URL of the WebDriver session.
+                  type: string
+      # Shown in kubectl get
+      additionalPrinterColumns:
+      - name: URL
+        type: string
+        jsonPath: .status.url
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: webdriversessions
+    # singular name to be used as an alias on the CLI and for display
+    singular: webdriversession
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: WebDriverSession
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - session

--- a/src/Kaponata.Operator/Models/WebDriverSession.yaml
+++ b/src/Kaponata.Operator/Models/WebDriverSession.yaml
@@ -3,12 +3,19 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: webdriversessions.kaponata.io
+  labels:
+    app.kubernetes.io/managed-by: Kaponata
+    # Set this to the version number of the last commit which modified this file. It's used by the
+    # operator to determine whether the CRD should be reinstalled or not.
+    # Use the following command to determine that version:
+    # nbgv get-version $(git rev-list -1 HEAD) -v NuGetPackageVersion
+    app.kubernetes.io/version: "0.1.133"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kaponata.io
   # list of versions supported by this CustomResourceDefinition
   versions:
-    - name: v1
+    - name: v1alpha1
       # Each version can be enabled/disabled by Served flag.
       served: true
       # One and only one version must be marked as the storage version.

--- a/src/Kaponata.Operator/Models/WebDriverSessionList.cs
+++ b/src/Kaponata.Operator/Models/WebDriverSessionList.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="WebDriverSessionList.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Kaponata.Operator.Models
+{
+    /// <summary>
+    /// A list of <see cref="WebDriverSession"/> objects.
+    /// </summary>
+    public class WebDriverSessionList : IKubernetesObject<V1ListMeta>, IItems<WebDriverSession>
+    {
+        /// <summary>
+        /// Gets or sets a value which defines the versioned schema of this
+        /// representation of an object. Servers should convert recognized
+        /// schemas to the latest internal value, and may reject unrecognized
+        /// values.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"/>
+        [JsonProperty(PropertyName = "apiVersion")]
+        public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of WebDriver sessions.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md"/>
+        [JsonProperty(PropertyName = "items")]
+        public IList<WebDriverSession> Items { get; set; }
+
+        /// <summary>
+        /// Gets or sets a <see cref="string"/> value representing the REST resource
+        /// this object represents. Servers may infer this from the endpoint
+        /// the client submits requests to. Cannot be updated. In CamelCase.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+
+        /// <summary>
+        /// Gets or sets standard list metadata.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
+        [JsonProperty(PropertyName = "metadata")]
+        public V1ListMeta Metadata { get; set; }
+    }
+}

--- a/src/Kaponata.Operator/Models/WebDriverSessionSpec.cs
+++ b/src/Kaponata.Operator/Models/WebDriverSessionSpec.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="WebDriverSessionSpec.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json;
+
+namespace Kaponata.Operator.Models
+{
+    /// <summary>
+    /// Defines the specifications (invariant data) related to a <see cref="WebDriverSession"/> object.
+    /// </summary>
+    public class WebDriverSessionSpec
+    {
+        /// <summary>
+        /// Gets or sets the desired capabilities, as requested by the client.
+        /// </summary>
+        [JsonProperty(PropertyName = "desiredCapabilities")]
+        public string DesiredCapabilities { get; set; }
+    }
+}

--- a/src/Kaponata.Operator/Models/WebDriverSessionStatus.cs
+++ b/src/Kaponata.Operator/Models/WebDriverSessionStatus.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="WebDriverSessionStatus.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Operator.Models
+{
+    /// <summary>
+    /// Describes the status of a <see cref="WebDriverSession"/> object.
+    /// </summary>
+    public class WebDriverSessionStatus
+    {
+    }
+}


### PR DESCRIPTION
The `WebDriverSession` object will be used to handle user requests to start a new WebDriverSession.

- The API server creates these objects when the user requests a new session
- Operators are responsible for actually creating the WebDriver session
- Ingress rules will forward the session traffic to the pod hosting the session
- The API server deletes the session object, and the Operator deletes the session infrastructure