### PR TITLE
Support expression field selectors and label selectors as lambda expressions

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/FieldSelectorTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/FieldSelectorTests.cs
@@ -1,0 +1,88 @@
+﻿// <copyright file="FieldSelectorTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Models;
+using System;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="FieldSelector"/> class.
+    /// </summary>
+    public class FieldSelectorTests
+    {
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> returns <see langword="null"/> when passed <see langword="null"/>.
+        /// </summary>
+        [Fact]
+        public void Create_Null_ReturnsNull()
+        {
+            Assert.Null(FieldSelector.Create<V1Pod>(null));
+        }
+
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> returns <see langword="null"/> when passed a constant <see langword="true"/>
+        /// expression (i.e. all objects match).
+        /// </summary>
+        [Fact]
+        public void Create_True_ReturnsNull()
+        {
+            Assert.Null(FieldSelector.Create<V1Pod>(p => true));
+        }
+
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> returns <see langword="null"/> when passed a constant <see langword="true"/>
+        /// expression (i.e. all objects match).
+        /// </summary>
+        [Fact]
+        public void Create_Complex_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => FieldSelector.Create<V1Pod>(p => p.HasFinalizer("test")));
+        }
+
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> returns <see langword="null"/> when passed a constant <see langword="true"/>
+        /// expression (i.e. all objects match).
+        /// </summary>
+        [Fact]
+        public void Create_Complex2_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => FieldSelector.Create<V1Pod>(p => p.HasFinalizer("test") == p.HasFinalizer("foo")));
+        }
+
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> works when passed a single value.
+        /// </summary>
+        [Fact]
+        public void Create_SingleField_Works()
+        {
+            Assert.Equal(".spec.serviceAccountName=fake", FieldSelector.Create<V1Pod>(p => p.Spec.ServiceAccountName == "fake"));
+        }
+
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> works when passed a single value.
+        /// </summary>
+        [Fact]
+        public void Create_TwoFields_Or_Fails()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => FieldSelector.Create<V1Pod>(p => p.Spec.ServiceAccountName == "fake" || p.Spec.Subdomain == null));
+        }
+
+        /// <summary>
+        /// <see cref="FieldSelector.Create"/> works when passed a two values.
+        /// </summary>
+        [Fact]
+        public void Create_TwoFields_Works()
+        {
+            Assert.Equal(
+                ".status.phase=Running,.metadata.name=my-pod",
+                FieldSelector.Create<V1Pod>(
+                    p => p.Status.Phase == "Running"
+                    && p.Metadata.Name == "my-pod"));
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/LabelSelectorTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/LabelSelectorTests.cs
@@ -1,0 +1,158 @@
+﻿// <copyright file="LabelSelectorTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using System;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="LabelSelector"/> class.
+    /// </summary>
+    public class LabelSelectorTests
+    {
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when <see langword="null"/> is passed.
+        /// </summary>
+        [Fact]
+        public void Create_Null_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(null));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an expression is passed when
+        /// always returns <see langword="true"/>.
+        /// </summary>
+        [Fact]
+        public void Create_AlwaysTrue_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(s => true));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an expression is passed when
+        /// always returns <see langword="true"/>.
+        /// </summary>
+        [Fact]
+        public void Create_AlwaysFalse_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => LabelSelector.Create<V1Pod>(s => false));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an expression is passed when
+        /// always returns <see langword="true"/>.
+        /// </summary>
+        [Fact]
+        public void Create_Complex_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => LabelSelector.Create<V1Pod>(s => s.HasFinalizer("test")));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when no label is embedded in the expression.
+        /// </summary>
+        [Fact]
+        public void Create_NoLabel_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(p => p.Spec.Subdomain == "fake"));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns a correct label selector when a single label is present.
+        /// </summary>
+        [Fact]
+        public void Create_SingleLabel_Works()
+        {
+            Assert.Equal("kubernetes.io/os=android", LabelSelector.Create<V1Pod>(p => p.Metadata.Labels[Annotations.Os] == Annotations.OperatingSystem.Android));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns a correct label selector when a two labels are present.
+        /// </summary>
+        [Fact]
+        public void Create_TwoLabels_Works()
+        {
+            Assert.Equal("kubernetes.io/os=android,kubernetes.io/arch=arm64", LabelSelector.Create<V1Pod>(
+                p => p.Metadata.Labels[Annotations.Os] == Annotations.OperatingSystem.Android
+                && p.Metadata.Labels[Annotations.Arch] == Annotations.Architecture.Arm64));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns a correct label selector when a three labels are present.
+        /// </summary>
+        [Fact]
+        public void Create_ThreeLabels_Works()
+        {
+            Assert.Equal("kubernetes.io/os=android,kubernetes.io/arch=arm64,app.kubernetes.io/managed-by=my-operator", LabelSelector.Create<V1Pod>(
+                p => p.Metadata.Labels[Annotations.Os] == Annotations.OperatingSystem.Android
+                && p.Metadata.Labels[Annotations.Arch] == Annotations.Architecture.Arm64
+                && p.Metadata.Labels[Annotations.ManagedBy] == "my-operator"));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> throws an exception when the label value is not a constant.
+        /// </summary>
+        [Fact]
+        public void Create_ValueNotConstant_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => LabelSelector.Create<V1Pod>(
+                    p => p.Metadata.Labels[Annotations.Os] == p.ToString()));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an incorrect method is being called
+        /// on the Labels property.
+        /// </summary>
+        [Fact]
+        public void Create_MethodCallOnWrongType_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(p => p.Metadata.Labels.ToString() == "a"));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an dictionary indexer is being called
+        /// on the Labels property.
+        /// </summary>
+        [Fact]
+        public void Create_MethodCallOnWrongProperty_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(p => p.Spec.NodeSelector["a"] == "a"));
+        }
+
+        /// <summary>
+        /// Calling <see cref="LabelSelector.Create"/> on a pod object which is not the parameter returns
+        /// <see langword="null"/>.
+        /// </summary>
+        [Fact]
+        public void Create_LabelOnNonParam_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(p => new V1Pod().Metadata.Labels["a"] == "b"));
+        }
+
+        /// <summary>
+        /// Calling <see cref="LabelSelector.Create"/> which reads a wrong property returns
+        /// <see langword="null"/>.
+        /// </summary>
+        [Fact]
+        public void Create_MethodCallOnWrongProperty2_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(p => p.Metadata.ManagedFields.ToString() == "b"));
+        }
+
+        /// <summary>
+        /// Calling <see cref="LabelSelector.Create"/> which reads a label using a non-constant
+        /// expression returns <see langword="null"/>.
+        /// </summary>
+        [Fact]
+        public void Create_LabelNameNotConstant_ReturnsNull()
+        {
+            Assert.Null(LabelSelector.Create<V1Pod>(p => p.Metadata.Labels["a".ToString()] == "b"));
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/FieldSelector.cs
+++ b/src/Kaponata.Operator/Kubernetes/FieldSelector.cs
@@ -1,0 +1,121 @@
+﻿// <copyright file="FieldSelector.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Provides methods for creating field selectors from lambda expressions.
+    /// </summary>
+    public static class FieldSelector
+    {
+        /// <summary>
+        /// The default resolver to use when converting .NET object property names to JSON object property names.
+        /// </summary>
+        private static readonly IContractResolver DefaultResolver = new CamelCasePropertyNamesContractResolver();
+
+        /// <summary>
+        /// Converts a labmda expression to a field selector.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of Kubernetes object to which the field selector applies.
+        /// </typeparam>
+        /// <param name="predicate">
+        /// The predicate which represents the field selector.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> which represents the field selector.
+        /// </returns>
+        public static string Create<T>(Expression<Func<T, bool>> predicate)
+            where T : IKubernetesObject<V1ObjectMeta>
+        {
+            if (predicate == null)
+            {
+                return null;
+            }
+
+            return ToFieldSelector(predicate.Body);
+        }
+
+        // Converts an generic expression. This should be a binary expression; either Equal
+        // (e.g. pod.Status.Phase == "Running") or AndAlso (pod.Status.Phase == "Running" && pod.Metadata.Name == "a")
+        private static string ToFieldSelector(Expression expression)
+        {
+            switch (expression)
+            {
+                case ConstantExpression constantExpression when object.Equals(constantExpression.Value, true):
+                    return null;
+
+                case BinaryExpression binaryExpression:
+                    switch (binaryExpression.NodeType)
+                    {
+                        case ExpressionType.Equal:
+                            return ToSingleFieldSelector(binaryExpression);
+
+                        case ExpressionType.AndAlso:
+                            var left = ToFieldSelector(binaryExpression.Left);
+                            var right = ToFieldSelector(binaryExpression.Right);
+                            return $"{left},{right}";
+                    }
+
+                    break;
+            }
+
+            throw new ArgumentOutOfRangeException($"The {expression.NodeType} expressions are not supported");
+        }
+
+        // Converts a single binary expression of type Equal (e.g. pod.Status.Phase == "Running") to a
+        // single field expression (pod.status.phase=Running).
+        private static string ToSingleFieldSelector(BinaryExpression binaryExpression)
+        {
+            Debug.Assert(binaryExpression.NodeType == ExpressionType.Equal, "Only Equal expressions are supported");
+
+            var valueExpression = binaryExpression.Right as ConstantExpression;
+
+            if (valueExpression == null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(binaryExpression), "Only Equal expressions which compare to constant values are supported");
+            }
+
+            var value = valueExpression.Value as string;
+
+            var propertyExpression = binaryExpression.Left as MemberExpression;
+
+            var path = GetPath(propertyExpression);
+            return $"{path}={value}";
+        }
+
+        // Gets the path of an property. Recurses up the parent properties until the root object
+        // (a parameter) is found.
+        private static string GetPath(MemberExpression expression)
+        {
+            var name = GetJsonPropertyName(expression.Member.DeclaringType, expression.Member.Name);
+
+            if (expression.Expression.NodeType == ExpressionType.Parameter)
+            {
+                return $".{name}";
+            }
+            else
+            {
+                var child = expression.Expression as MemberExpression;
+                return $"{GetPath(child)}.{name}";
+            }
+        }
+
+        // Gets the JSON property name for a .NET object property name.
+        private static string GetJsonPropertyName(Type type, string propertyName)
+        {
+            var contract = DefaultResolver.ResolveContract(type) as JsonObjectContract;
+            var property = contract.Properties.Single(p => p.UnderlyingName == propertyName);
+            return property.PropertyName;
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/LabelSelector.cs
+++ b/src/Kaponata.Operator/Kubernetes/LabelSelector.cs
@@ -1,0 +1,173 @@
+﻿// <copyright file="LabelSelector.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// Supports converting lambda expressions to label selectors.
+    /// </summary>
+    /// <seealso href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"/>
+    public static class LabelSelector
+    {
+        /// <summary>
+        /// Converts a lambda expression to a label selector.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of Kubernetes object to which the label selector applies.
+        /// </typeparam>
+        /// <param name="predicate">
+        /// The label selector, as a lambda expression.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> which represents the label selector.
+        /// </returns>
+        public static string Create<T>(Expression<Func<T, bool>> predicate)
+            where T : IKubernetesObject<V1ObjectMeta>
+        {
+            if (predicate == null)
+            {
+                return null;
+            }
+
+            return ToLabelSelector(predicate.Body);
+        }
+
+        // Operates on the root expression. We support either a binary Equal expression
+        // (e.g. label = value) or an AndAlso expression. (label1 = value1 && label2 = value2)
+        private static string ToLabelSelector(Expression expression)
+        {
+            switch (expression)
+            {
+                case ConstantExpression constantExpression when object.Equals(constantExpression.Value, true):
+                    return null;
+
+                case BinaryExpression binaryExpression when binaryExpression.NodeType == ExpressionType.Equal:
+                    return ToSingleLabelSelector(binaryExpression);
+
+                case BinaryExpression binaryExpression when binaryExpression.NodeType == ExpressionType.AndAlso:
+                    var left = ToLabelSelector(binaryExpression.Left);
+                    var right = ToLabelSelector(binaryExpression.Right);
+                    return $"{left},{right}";
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(expression), "Only binary expressions of type Equal and AndAlso are supported");
+        }
+
+        // Operates on a binary Equal expression (label = value). Extracts the name of the
+        // label from the left part of the expression and the constant value from the
+        // right part of the expression.
+        private static string ToSingleLabelSelector(BinaryExpression binaryExpression)
+        {
+            Debug.Assert(binaryExpression.NodeType == ExpressionType.Equal, "Only equal expressions are supported");
+
+            if (!IsLabelExpression(binaryExpression.Left, out var labelName))
+            {
+                return null;
+            }
+
+            if (!IsLabelValue(binaryExpression.Right, out var labelValue))
+            {
+                throw new ArgumentOutOfRangeException(nameof(binaryExpression));
+            }
+
+            return $"{labelName}={labelValue}";
+        }
+
+        // Extracts a label value from a constant string expression.
+        private static bool IsLabelValue(Expression expression, out string labelValue)
+        {
+            labelValue = null;
+            var constant = expression as ConstantExpression;
+
+            if (constant == null)
+            {
+                return false;
+            }
+
+            labelValue = constant.Value as string;
+            return true;
+        }
+
+        // Extracts a label name from a method call expression. Labels are typically
+        // assigned like this:
+        // p.Metadata.Labels["name"] = "value",
+        // and this method is concerned with p.Metadata.Labels["name"].
+        //
+        // This method makes sure the expression is indeed correct:
+        // * The ["name"] part is syntactic sugar for get_Item("name"), so the top level
+        //   expression should be a MethodCallExpression
+        // * .Metadata.Labels are property accessors, and these are also verified.
+        // * Finally, the root object,  'p' is a parameter.
+        private static bool IsLabelExpression(Expression expression, out string labelName)
+        {
+            labelName = null;
+            var methodCall = expression as MethodCallExpression;
+
+            if (methodCall == null)
+            {
+                return false;
+            }
+
+            if (methodCall.Object.Type != typeof(IDictionary<string, string>))
+            {
+                return false;
+            }
+
+            if (methodCall.Method.Name != "get_Item")
+            {
+                return false;
+            }
+
+            if (!IsProperty(methodCall.Object, typeof(V1ObjectMeta), nameof(V1ObjectMeta.Labels), out var metadataCall))
+            {
+                return false;
+            }
+
+            if (!IsProperty(metadataCall, typeof(V1Pod), nameof(V1Pod.Metadata), out var root))
+            {
+                return false;
+            }
+
+            if (root.NodeType != ExpressionType.Parameter)
+            {
+                return false;
+            }
+
+            var labelExpression = methodCall.Arguments[0] as ConstantExpression;
+
+            if (labelExpression == null)
+            {
+                return false;
+            }
+
+            labelName = labelExpression.Value as string;
+            return true;
+        }
+
+        // Determines whether an expression is a property reference expression.
+        private static bool IsProperty(Expression expression, Type type, string name, out Expression parent)
+        {
+            parent = null;
+            var memberExpression = expression as MemberExpression;
+
+            bool isProperty = memberExpression != null
+                && memberExpression.Member.ReflectedType == type
+                && memberExpression.Member.Name == name;
+
+            if (isProperty)
+            {
+                parent = memberExpression.Expression;
+            }
+
+            return isProperty;
+        }
+    }
+}


### PR DESCRIPTION
This PR supports using lambda expressions for defining field selectors and label selectors.


For example, you could express the label selector `kubernetes.io/os=android,kubernetes.io/arch=arm64,app.kubernetes.io/managed-by=my-operator` as:

```csharp
LabelSelector.Create<V1Pod>(
    p => p.Metadata.Labels[Annotations.Os] == Annotations.OperatingSystem.Android
    && p.Metadata.Labels[Annotations.Arch] == Annotations.Architecture.Arm64
    && p.Metadata.Labels[Annotations.ManagedBy] == "my-operator")
```

And the field selector `.status.phase=Running` as:

```csharp
FieldSelector.Create<V1Pod>(p => p.Status.Phase == "Running")
```

The main reason for doing is to provide some level of type safety.