### PR TITLE
Add a generic NamespacedKubernetesClient<T>

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.MobileDevice.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.MobileDevice.cs
@@ -221,7 +221,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                         Content =
                             new StringContent(
                                 JsonConvert.SerializeObject(
-                                    new MobileDeviceList()
+                                    new ItemList<MobileDevice>()
                                     {
                                         Items = new MobileDevice[]
                                         {
@@ -412,9 +412,9 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(
-                p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
+                p => p.WatchNamespacedObjectAsync<MobileDevice, ItemList<MobileDevice>>(
                     device,
-                    It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
+                    It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(),
                     It.IsAny<WatchEventDelegate<MobileDevice>>(),
                     default))
                 .Returns(tcs.Task);
@@ -450,7 +450,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(), eventHandler, default))
+                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(), eventHandler, default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
@@ -539,12 +539,12 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             protocol
                 .Setup(
-                    p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
+                    p => p.WatchNamespacedObjectAsync<MobileDevice, ItemList<MobileDevice>>(
                         mobileDevice,
-                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
+                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(),
                         It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;
@@ -611,12 +611,12 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             protocol
                 .Setup(
-                    p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
+                    p => p.WatchNamespacedObjectAsync<MobileDevice, ItemList<MobileDevice>>(
                         mobileDevice,
-                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
+                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(),
                         It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;
@@ -674,12 +674,12 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             protocol
                 .Setup(
-                    p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
+                    p => p.WatchNamespacedObjectAsync<MobileDevice, ItemList<MobileDevice>>(
                         mobileDevice,
-                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
+                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(),
                         It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;
@@ -745,12 +745,12 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             protocol
                 .Setup(
-                    p => p.WatchNamespacedObjectAsync<MobileDevice, MobileDeviceList>(
+                    p => p.WatchNamespacedObjectAsync<MobileDevice, ItemList<MobileDevice>>(
                         mobileDevice,
-                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>>(),
+                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(),
                         It.IsAny<WatchEventDelegate<MobileDevice>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, MobileDeviceList>, WatchEventDelegate<MobileDevice>, CancellationToken>(
+                .Returns<MobileDevice, ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>, WatchEventDelegate<MobileDevice>, CancellationToken>(
                 (device, list, watcher, ct) =>
                 {
                     callback = watcher;

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.WebDriverSession.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientTests.WebDriverSession.cs
@@ -222,9 +222,9 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(
-                p => p.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                p => p.WatchNamespacedObjectAsync<WebDriverSession, ItemList<WebDriverSession>>(
                     session,
-                    It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>>(),
+                    It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, ItemList<WebDriverSession>>>(),
                     It.IsAny<WatchEventDelegate<WebDriverSession>>(),
                     default))
                 .Returns(tcs.Task);
@@ -260,7 +260,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>>(), eventHandler, default))
+                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, ItemList<WebDriverSession>>>(), eventHandler, default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
@@ -298,12 +298,12 @@ namespace Kaponata.Operator.Tests.Kubernetes
 
             protocol
                 .Setup(
-                    p => p.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
+                    p => p.WatchNamespacedObjectAsync<WebDriverSession, ItemList<WebDriverSession>>(
                         session,
-                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>>(),
+                        It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, ItemList<WebDriverSession>>>(),
                         It.IsAny<WatchEventDelegate<WebDriverSession>>(),
                         It.IsAny<CancellationToken>()))
-                .Returns<WebDriverSession, ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, WebDriverSessionList>, WatchEventDelegate<WebDriverSession>, CancellationToken>(
+                .Returns<WebDriverSession, ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, ItemList<WebDriverSession>>, WatchEventDelegate<WebDriverSession>, CancellationToken>(
                 (session, list, watcher, ct) =>
                 {
                     callback = watcher;

--- a/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
+++ b/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
@@ -72,7 +72,7 @@ namespace Kaponata.Operator.Tests.Operators
 
             client
                 .Setup(k => k.ListMobileDeviceAsync("default", null, null, labelSelector, null, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(
+                .Returns(Task.FromResult<ItemList<MobileDevice>>(
                     new MobileDeviceList()
                     {
                         Items = items,

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
@@ -17,7 +17,54 @@ namespace Kaponata.Operator.Kubernetes
     /// </summary>
     public partial class KubernetesClient
     {
-        private delegate Task<T> DeleteNamespacedObjectAsyncDelegate<T>(
+        /// <summary>
+        /// A delegate for operations which delete namespaced Kubernetes objects.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the Kubernetes object to delete.
+        /// </typeparam>
+        /// <param name="name">
+        /// The name of the object to delete.
+        /// </param>
+        /// <param name="namespaceParameter">
+        /// The namespace in which to delete the object.
+        /// </param>
+        /// <param name="body">
+        /// Specific delete options.
+        /// </param>
+        /// <param name="dryRun">
+        /// When present, indicates that modifications should not be persisted. An invalid
+        /// or unrecognized dryRun directive will result in an error response and no further
+        /// processing of the request. Valid values are: - All: all dry run stages will be
+        /// processed.
+        /// </param>
+        /// <param name="gracePeriodSeconds">
+        /// The duration in seconds before the object should be deleted. Value must be non-negative
+        /// integer. The value zero indicates delete immediately. If this value is nil, the
+        /// default grace period for the specified type will be used. Defaults to a per object
+        /// value if not specified. zero means delete immediately.
+        /// </param>
+        /// <param name="orphanDependents">
+        /// Deprecated: please use the PropagationPolicy, this field will be deprecated in
+        /// 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer
+        /// will be added to/removed from the object's finalizers list. Either this field
+        /// or PropagationPolicy may be set, but not both.
+        /// </param>
+        /// <param name="propagationPolicy">
+        /// Whether and how garbage collection will be performed. Either this field or OrphanDependents
+        /// may be set, but not both. The default policy is decided by the existing finalizer
+        /// set in the metadata.finalizers and the resource-specific default policy.
+        /// </param>
+        /// <param name="pretty">
+        /// A value indicating whether the output should be pretty-printed.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous request.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public delegate Task<T> DeleteNamespacedObjectAsyncDelegate<T>(
             string name,
             string namespaceParameter,
             V1DeleteOptions body = null,
@@ -39,7 +86,34 @@ namespace Kaponata.Operator.Kubernetes
             string pretty = null,
             CancellationToken cancellationToken = default);
 
-        private async Task DeleteNamespacedObjectAsync<T>(
+        /// <summary>
+        /// Asynchronously deletes a namespaced object, and waits for the delete operation
+        /// to complete.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the Kubernetes object to delete.
+        /// </typeparam>
+        /// <param name="value">
+        /// The object to delete.
+        /// </param>
+        /// <param name="deleteAction">
+        /// A delegate to a method which schedules the deletion.
+        /// </param>
+        /// <param name="watchAction">
+        /// A delegate to a method which creates a watcher for the object.
+        /// Used to monitor the progress of the delete operation.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time to wait for the object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the
+        /// asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public async Task DeleteNamespacedObjectAsync<T>(
             T value,
             DeleteNamespacedObjectAsyncDelegate<T> deleteAction,
             WatchObjectAsyncDelegate<T> watchAction,

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -4,6 +4,7 @@
 
 using k8s;
 using k8s.Models;
+using Kaponata.Operator.Kubernetes.Polyfill;
 using Microsoft.Rest;
 using Microsoft.Rest.Serialization;
 using Newtonsoft.Json;
@@ -91,7 +92,111 @@ namespace Kaponata.Operator.Kubernetes
             }
         }
 
-        private async Task<HttpOperationResponse<TList>> ListNamespacedObjectAsync<TObject, TList>(
+        /// <summary>
+        /// Asynchronously lists namespaced objects.
+        /// </summary>
+        /// <typeparam name="TObject">
+        /// The type of Kubernetes object to list.
+        /// </typeparam>
+        /// <typeparam name="TList">
+        /// The type of a list which contains the result.
+        /// </typeparam>
+        /// <param name="kind">
+        /// A <see cref="KindMetadata"/> object which describes the type of object to generate,
+        /// such as the API version or plural name.
+        /// </param>
+        /// <param name="namespaceParameter">
+        /// The namespace in which to list the objects.
+        /// </param>
+        /// <param name="allowWatchBookmarks">
+        /// allowWatchBookmarks requests watch events with type "BOOKMARK". Servers that
+        /// do not implement bookmarks may ignore this flag and bookmarks are sent at the
+        /// server's discretion. Clients should not assume bookmarks are returned at any
+        /// specific interval, nor may they assume the server will send any BOOKMARK event
+        /// during a session. If this is not a watch, this field is ignored. If the feature
+        /// gate WatchBookmarks is not enabled in apiserver, this field is ignored.
+        /// </param>
+        /// <param name="continueParameter">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from
+        /// a previous query result with identical query parameters (except for the value
+        /// of continue) and the server may reject a continue value it does not recognize.
+        /// If the specified continue value is no longer valid whether due to expiration
+        /// (generally five to fifteen minutes) or a configuration change on the server,
+        /// the server will respond with a 410 ResourceExpired error together with a continue
+        /// token. If the client needs a consistent list, it must restart their list without
+        /// the continue field. Otherwise, the client may send another list request with
+        /// the token received with the 410 error, the server will respond with a list starting
+        /// from the next key, but from the latest snapshot, which is inconsistent from the
+        /// previous list results - objects that are created, modified, or deleted after
+        /// the first list request will be included in the response, as long as their keys
+        /// are after the "next key". This field is not supported when watch is true. Clients
+        /// may start a watch from the last resourceVersion value returned by the server
+        /// and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call. If more items
+        /// exist, the server will set the `continue` field on the list metadata to a value
+        /// that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero
+        /// items) in the event all requested objects are filtered out and clients should
+        /// only use the presence of the continue field to determine whether more results
+        /// are available. Servers may choose not to support the limit argument and will
+        /// return all of the available results. If limit is specified and the continue field
+        /// is empty, clients may assume that no more results are available. This field is
+        /// not supported if watch is true. The server guarantees that the objects returned
+        /// when using continue will be identical to issuing a single list call without a
+        /// limit - that is, no objects created, modified, or deleted after the first request
+        /// is issued will be included in any subsequent continued requests. This is sometimes
+        /// referred to as a consistent snapshot, and ensures that a client that is using
+        /// limit to receive smaller chunks of a very large result can ensure they see all
+        /// possible objects. If objects are updated during a chunked list the version of
+        /// the object that was present at the time the first list result was calculated
+        /// is returned.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular
+        /// version of a resource. Defaults to changes from the beginning of history. When
+        /// specified for list: - if unset, then the result is returned from remote storage
+        /// based on quorum-read flag; - if it's 0, then we simply return what we currently
+        /// have in cache, no guarantee; - if set to non zero, then the result is at least
+        /// as fresh as given rv.
+        /// </param>
+        /// <param name="resourceVersionMatch">
+        /// Determines how resourceVersion is applied to list calls.
+        /// It is highly recommended that resourceVersionMatch be set for list calls where
+        /// resourceVersion is set. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to unset.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless
+        /// of any activity or inactivity.
+        /// </param>
+        /// <param name="watch">
+        /// Watch for changes to the described resources and return them as a stream of add,
+        /// update, and remove notifications.
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task<HttpOperationResponse<TList>> ListNamespacedObjectAsync<TObject, TList>(
             KindMetadata kind,
             string namespaceParameter,
             bool? allowWatchBookmarks = null,
@@ -150,7 +255,57 @@ namespace Kaponata.Operator.Kubernetes
             return typedOperationResponse;
         }
 
-        private async Task<T> DeleteNamespacedObjectAsync<T>(
+        /// <summary>
+        /// Deletes the specified namespace scoped custom object.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of object to delete.
+        /// </typeparam>
+        /// <param name="kind">
+        /// The group, version and kind information which represents the object type.
+        /// </param>
+        /// <param name="name">
+        /// The name of the object to delete.
+        /// </param>
+        /// <param name="namespaceParameter">
+        /// The namespace in which to delete the object.
+        /// </param>
+        /// <param name="body">
+        /// Specific delete options.
+        /// </param>
+        /// <param name="dryRun">
+        /// When present, indicates that modifications should not be persisted. An invalid
+        /// or unrecognized dryRun directive will result in an error response and no further
+        /// processing of the request. Valid values are: - All: all dry run stages will be
+        /// processed.
+        /// </param>
+        /// <param name="gracePeriodSeconds">
+        /// The duration in seconds before the object should be deleted. Value must be non-negative
+        /// integer. The value zero indicates delete immediately. If this value is nil, the
+        /// default grace period for the specified type will be used. Defaults to a per object
+        /// value if not specified. zero means delete immediately.
+        /// </param>
+        /// <param name="orphanDependents">
+        /// Deprecated: please use the PropagationPolicy, this field will be deprecated in
+        /// 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer
+        /// will be added to/removed from the object's finalizers list. Either this field
+        /// or PropagationPolicy may be set, but not both.
+        /// </param>
+        /// <param name="propagationPolicy">
+        /// Whether and how garbage collection will be performed. Either this field or OrphanDependents
+        /// may be set, but not both. The default policy is decided by the existing finalizer
+        /// set in the metadata.finalizers and the resource-specific default policy.
+        /// </param>
+        /// <param name="pretty">
+        /// A value indicating whether the output should be pretty-printed.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous request.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task<T> DeleteNamespacedObjectAsync<T>(
             KindMetadata kind,
             string name,
             string namespaceParameter,
@@ -196,6 +351,113 @@ namespace Kaponata.Operator.Kubernetes
                     throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
                 }
             }
+        }
+
+        /// <summary>
+        /// Asynchronously watches a namespaced object.
+        /// </summary>
+        /// <typeparam name="TObject">
+        /// The type of the object to watch.
+        /// </typeparam>
+        /// <typeparam name="TList">
+        /// The type of a list of <typeparamref name="TObject"/> objects.
+        /// </typeparam>
+        /// <param name="value">
+        /// The object to watch.
+        /// </param>
+        /// <param name="listOperation">
+        /// A delegate which lists all objects.
+        /// </param>
+        /// <param name="eventHandler">
+        /// An handler which processes a watch event, and lets the watcher know whether
+        /// to continue watching or not.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the watch operation. The task completes
+        /// when the watcher stops watching for events. The <see cref="WatchExitReason"/>
+        /// return value describes why the watcher stopped. The task errors if the watch
+        /// loop errors.
+        /// </returns>
+        public Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
+            TObject value,
+            ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
+            WatchEventDelegate<TObject> eventHandler,
+            CancellationToken cancellationToken)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>
+        {
+            return this.protocol.WatchNamespacedObjectAsync<TObject, TList>(
+                value,
+                listOperation,
+                eventHandler,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously watches namespaced objects.
+        /// </summary>
+        /// <typeparam name="TObject">
+        /// The type of the object to watch.
+        /// </typeparam>
+        /// <typeparam name="TList">
+        /// The type of a list of <typeparamref name="TObject"/> objects.
+        /// </typeparam>
+        /// <param name="namespace">
+        /// The namespace in which to watch for <typeparamref name="TObject"/> objects.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults
+        /// to everything.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// resourceVersion sets a constraint on what resource versions a request may be
+        /// served from. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to unset.
+        /// </param>
+        /// <param name="listOperation">
+        /// A delegate which lists all objects.
+        /// </param>
+        /// <param name="eventHandler">
+        /// An handler which processes a watch event, and lets the watcher know whether
+        /// to continue watching or not.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the watch operation. The task completes
+        /// when the watcher stops watching for events. The <see cref="WatchExitReason"/>
+        /// return value describes why the watcher stopped. The task errors if the watch
+        /// loop errors.
+        /// </returns>
+        public Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
+            string @namespace,
+            string fieldSelector,
+            string labelSelector,
+            string resourceVersion,
+            ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
+            WatchEventDelegate<TObject> eventHandler,
+            CancellationToken cancellationToken)
+            where TObject : IKubernetesObject<V1ObjectMeta>
+            where TList : IItems<TObject>
+        {
+            return this.protocol.WatchNamespacedObjectAsync<TObject, TList>(
+                @namespace,
+                fieldSelector,
+                labelSelector,
+                resourceVersion,
+                listOperation,
+                eventHandler,
+                cancellationToken);
         }
     }
 }

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.WebDriverSession.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.WebDriverSession.cs
@@ -2,13 +2,9 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using k8s.Models;
 using Kaponata.Operator.Kubernetes.Polyfill;
 using Kaponata.Operator.Models;
-using Microsoft.Rest;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,10 +30,7 @@ namespace Kaponata.Operator.Kubernetes
         /// </returns>
         public virtual Task<WebDriverSession> CreateWebDriverSessionAsync(WebDriverSession value, CancellationToken cancellationToken)
         {
-            return this.CreateNamespacedValueAsync<WebDriverSession>(
-                WebDriverSession.KubeMetadata,
-                value,
-                cancellationToken);
+            return this.webDriverSessionClient.CreateAsync(value, cancellationToken);
         }
 
         /// <summary>
@@ -98,17 +91,9 @@ namespace Kaponata.Operator.Kubernetes
         /// <returns>
         /// A <see cref="MobileDeviceList"/> which represents the mobile devices which match the query.
         /// </returns>
-        public async virtual Task<WebDriverSessionList> ListWebDriverSessionAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        public virtual Task<ItemList<WebDriverSession>> ListWebDriverSessionAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
         {
-            using (var operationResponse = await this.ListWebDriverSessionAsync(
-                namespaceParameter: @namespace,
-                continueParameter: @continue,
-                fieldSelector: fieldSelector,
-                labelSelector: labelSelector,
-                cancellationToken: cancellationToken))
-            {
-                return operationResponse.Body;
-            }
+            return this.webDriverSessionClient.ListAsync(@namespace, @continue, fieldSelector, labelSelector, limit, cancellationToken);
         }
 
         /// <summary>
@@ -127,10 +112,9 @@ namespace Kaponata.Operator.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested WebDriver session, or
         /// <see langword="null"/> if the WebDriver session does not exist.
         /// </returns>
-        public virtual async Task<WebDriverSession> TryReadWebDriverSessionAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual Task<WebDriverSession> TryReadWebDriverSessionAsync(string @namespace, string name, CancellationToken cancellationToken)
         {
-            var list = await this.RunTaskAsync(this.ListWebDriverSessionAsync(namespaceParameter: @namespace, fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
-            return list.Body.Items.SingleOrDefault();
+            return this.webDriverSessionClient.TryReadAsync(@namespace, name, cancellationToken);
         }
 
         /// <summary>
@@ -148,12 +132,7 @@ namespace Kaponata.Operator.Kubernetes
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public virtual Task DeleteWebDriverSessionAsync(WebDriverSession value, TimeSpan timeout, CancellationToken cancellationToken)
         {
-            return this.DeleteNamespacedObjectAsync<WebDriverSession>(
-                value,
-                this.DeleteNamespacedWebDriverSessionAsync,
-                this.WatchWebDriverSessionAsync,
-                timeout,
-                cancellationToken);
+            return this.webDriverSessionClient.DeleteAsync(value, timeout, cancellationToken);
         }
 
         /// <summary>
@@ -181,11 +160,7 @@ namespace Kaponata.Operator.Kubernetes
             WatchEventDelegate<WebDriverSession> eventHandler,
             CancellationToken cancellationToken)
         {
-            return this.protocol.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
-                 value,
-                 this.ListWebDriverSessionAsync,
-                 eventHandler,
-                 cancellationToken);
+            return this.webDriverSessionClient.WatchAsync(value, eventHandler, cancellationToken);
         }
 
         /// <summary>
@@ -229,70 +204,7 @@ namespace Kaponata.Operator.Kubernetes
             WatchEventDelegate<WebDriverSession> eventHandler,
             CancellationToken cancellationToken)
         {
-            return this.protocol.WatchNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
-                @namespace,
-                fieldSelector,
-                labelSelector,
-                resourceVersion,
-                this.ListWebDriverSessionAsync,
-                eventHandler,
-                cancellationToken);
-        }
-
-        private Task<HttpOperationResponse<WebDriverSessionList>> ListWebDriverSessionAsync(
-            string namespaceParameter,
-            bool? allowWatchBookmarks = null,
-            string continueParameter = null,
-            string fieldSelector = null,
-            string labelSelector = null,
-            int? limit = null,
-            string resourceVersion = null,
-            string resourceVersionMatch = null,
-            int? timeoutSeconds = null,
-            bool? watch = null,
-            string pretty = null,
-            Dictionary<string, List<string>> customHeaders = null,
-            CancellationToken cancellationToken = default)
-        {
-            return this.ListNamespacedObjectAsync<WebDriverSession, WebDriverSessionList>(
-                WebDriverSession.KubeMetadata,
-                namespaceParameter,
-                allowWatchBookmarks,
-                continueParameter,
-                fieldSelector,
-                labelSelector,
-                limit,
-                resourceVersion,
-                resourceVersionMatch,
-                timeoutSeconds,
-                watch,
-                pretty,
-                customHeaders,
-                cancellationToken);
-        }
-
-        private Task<WebDriverSession> DeleteNamespacedWebDriverSessionAsync(
-            string name,
-            string namespaceParameter,
-            V1DeleteOptions body = null,
-            string dryRun = null,
-            int? gracePeriodSeconds = null,
-            bool? orphanDependents = null,
-            string propagationPolicy = null,
-            string pretty = null,
-            CancellationToken cancellationToken = default)
-        {
-            return this.DeleteNamespacedObjectAsync<WebDriverSession>(
-                WebDriverSession.KubeMetadata,
-                name,
-                namespaceParameter,
-                body,
-                dryRun,
-                gracePeriodSeconds,
-                orphanDependents,
-                propagationPolicy,
-                pretty,
-                cancellationToken);
+            return this.webDriverSessionClient.WatchAsync(@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken);
         }
     }
 }

--- a/src/Kaponata.Operator/Models/ItemList.cs
+++ b/src/Kaponata.Operator/Models/ItemList.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="ItemList.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Kaponata.Operator.Models
+{
+    /// <summary>
+    /// A list of Kubernetes objects.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of objects stored in this list.
+    /// </typeparam>
+    public class ItemList<T> : IKubernetesObject<V1ListMeta>, IItems<T>
+        where T : IKubernetesObject<V1ObjectMeta>
+    {
+        /// <summary>
+        /// Gets or sets a value which defines the versioned schema of this
+        /// representation of an object. Servers should convert recognized
+        /// schemas to the latest internal value, and may reject unrecognized
+        /// values.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"/>
+        [JsonProperty(PropertyName = "apiVersion")]
+        public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of mobile devices.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md"/>
+        [JsonProperty(PropertyName = "items")]
+        public IList<T> Items { get; set; }
+
+        /// <summary>
+        /// Gets or sets a <see cref="string"/> value representing the REST resource
+        /// this object represents. Servers may infer this from the endpoint
+        /// the client submits requests to. Cannot be updated. In CamelCase.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+
+        /// <summary>
+        /// Gets or sets standard list metadata.
+        /// </summary>
+        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
+        [JsonProperty(PropertyName = "metadata")]
+        public V1ListMeta Metadata { get; set; }
+    }
+}

--- a/src/Kaponata.Operator/Models/MobileDeviceList.cs
+++ b/src/Kaponata.Operator/Models/MobileDeviceList.cs
@@ -2,49 +2,12 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using k8s;
-using k8s.Models;
-using Newtonsoft.Json;
-using System.Collections.Generic;
-
 namespace Kaponata.Operator.Models
 {
     /// <summary>
     /// A list of <see cref="MobileDevice" /> objects.
     /// </summary>
-    public class MobileDeviceList : IKubernetesObject<V1ListMeta>, IItems<MobileDevice>
+    public class MobileDeviceList : ItemList<MobileDevice>
     {
-        /// <summary>
-        /// Gets or sets a value which defines the versioned schema of this
-        /// representation of an object. Servers should convert recognized
-        /// schemas to the latest internal value, and may reject unrecognized
-        /// values.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"/>
-        [JsonProperty(PropertyName = "apiVersion")]
-        public string ApiVersion { get; set; }
-
-        /// <summary>
-        /// Gets or sets list of mobile devices.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md"/>
-        [JsonProperty(PropertyName = "items")]
-        public IList<MobileDevice> Items { get; set; }
-
-        /// <summary>
-        /// Gets or sets a <see cref="string"/> value representing the REST resource
-        /// this object represents. Servers may infer this from the endpoint
-        /// the client submits requests to. Cannot be updated. In CamelCase.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
-        [JsonProperty(PropertyName = "kind")]
-        public string Kind { get; set; }
-
-        /// <summary>
-        /// Gets or sets standard list metadata.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
-        [JsonProperty(PropertyName = "metadata")]
-        public V1ListMeta Metadata { get; set; }
     }
 }

--- a/src/Kaponata.Operator/Models/WebDriverSessionList.cs
+++ b/src/Kaponata.Operator/Models/WebDriverSessionList.cs
@@ -2,49 +2,12 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using k8s;
-using k8s.Models;
-using Newtonsoft.Json;
-using System.Collections.Generic;
-
 namespace Kaponata.Operator.Models
 {
     /// <summary>
     /// A list of <see cref="WebDriverSession"/> objects.
     /// </summary>
-    public class WebDriverSessionList : IKubernetesObject<V1ListMeta>, IItems<WebDriverSession>
+    public class WebDriverSessionList : ItemList<WebDriverSession>
     {
-        /// <summary>
-        /// Gets or sets a value which defines the versioned schema of this
-        /// representation of an object. Servers should convert recognized
-        /// schemas to the latest internal value, and may reject unrecognized
-        /// values.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"/>
-        [JsonProperty(PropertyName = "apiVersion")]
-        public string ApiVersion { get; set; }
-
-        /// <summary>
-        /// Gets or sets list of WebDriver sessions.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md"/>
-        [JsonProperty(PropertyName = "items")]
-        public IList<WebDriverSession> Items { get; set; }
-
-        /// <summary>
-        /// Gets or sets a <see cref="string"/> value representing the REST resource
-        /// this object represents. Servers may infer this from the endpoint
-        /// the client submits requests to. Cannot be updated. In CamelCase.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
-        [JsonProperty(PropertyName = "kind")]
-        public string Kind { get; set; }
-
-        /// <summary>
-        /// Gets or sets standard list metadata.
-        /// </summary>
-        /// <seealso href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"/>
-        [JsonProperty(PropertyName = "metadata")]
-        public V1ListMeta Metadata { get; set; }
     }
 }


### PR DESCRIPTION
The `KubernetesClient` methods for working with `Pods`, `WebDriverSession` and `MobileDevice` objects have _a lot_ of code in common.

This PR attempts to consolidate the implementations even further by creating a `NamespacedKubernetesClient<T>` class which allows you to interact with namespaced objects of any type.

This client needs to know the Group, Version and Kind ("GVK") information of type `T` to be able to construct the URLs, so that information is passed to its constructor.

It also helps making Kubernetes code more generic. For example, if you were to write code that lists pods or services, you'd need something like this:

```csharp
var podList = kubernetes.ListNamespacedV1PodAsync(....)
var serviceList = kubernetes.ListNamespacedV1ServiceAsync(...)
``` 

meaning you cannot write the code in a generic way (because the method names are different for every type).

With the generic client, you can just do:

```csharp
var podList = kubernetes.GetClient<V1Pod>.ListAsync(...)
var serviceList = kubernetes.GetClient<V1Service>.ListAsync(...)
```

This should eventually make writing the operators easier.