### PR TITLE
Publish container images to quay from master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,3 +226,17 @@ jobs:
           name: test
           path: |
             ${{ github.workspace }}/bin/Kaponata.TestResults/
+
+      - name: Login to quay.io
+        if: github.ref == 'refs/heads/master'
+        run: echo ${{ secrets.QUAY_ACCOUNT_NAME }} | docker login -u ${{ secrets.QUAY_ACCOUNT_TOKEN }} --password-stdin quay.io
+
+      - name: Publish Operator container image
+        if: github.ref == 'refs/heads/master'
+        run: make publish
+        working-directory: src/Kaponata.Operator/
+
+      - name: Publish API server container image
+        if: github.ref == 'refs/heads/master'
+        run: make publish
+        working-directory: src/Kaponata.Api/

--- a/src/Kaponata.Api/Dockerfile
+++ b/src/Kaponata.Api/Dockerfile
@@ -5,6 +5,7 @@ ARG GIT_COMMIT_ID
 ARG GIT_REF
 ARG GIT_REMOTE
 ARG VERSION
+ARG EXPIRES
 
 LABEL org.opencontainers.image.title="Kaponata API Server"
 LABEL org.opencontainers.image.description=""
@@ -18,6 +19,8 @@ LABEL org.opencontainers.image.source=$GIT_REMOTE
 LABEL org.opencontainers.image.version=$VERSION
 LABEL org.opencontainers.image.revision=$GIT_COMMIT_ID
 LABEL org.opencontainers.image.ref.name=$GIT_REF
+
+LABEL quay.expires-after=$EXPIRES
 
 WORKDIR /app
 

--- a/src/Kaponata.Api/Makefile
+++ b/src/Kaponata.Api/Makefile
@@ -2,6 +2,11 @@ registry=quay.io/kaponata
 image=api
 version=$(shell nbgv get-version -v SemVer2)
 
+# Set tags to expire in 2 weeks (duration of a sprint) in quay.io;
+# exception for tags built from release branches, which never expire.
+branch=$(shell git rev-parse --abbrev-ref HEAD)
+expires=$(if $(patsubst releases/,,$(branch)),2w,)
+
 all: .arm64.docker-id .amd64.docker-id
 
 clean:
@@ -31,6 +36,7 @@ bin/Release/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
 		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
 		--build-arg VERSION="$(version)" \
+		--build-arg EXPIRES=$(expires) \
 		. \
 		-t $(registry)/$(image):$(version)-amd64
 	docker images --no-trunc --quiet $(registry)/$(image):$(version)-amd64 > .amd64.docker-id
@@ -44,6 +50,7 @@ bin/Release/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
 		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
 		--build-arg VERSION="$(version)" \
+		--build-arg EXPIRES=$(expires) \
 		. \
 		-t $(registry)/$(image):$(version)-arm64
 	docker images --no-trunc --quiet $(registry)/$(image):$(version)-arm64 > .arm64.docker-id

--- a/src/Kaponata.Operator/Dockerfile
+++ b/src/Kaponata.Operator/Dockerfile
@@ -5,6 +5,7 @@ ARG GIT_COMMIT_ID
 ARG GIT_REF
 ARG GIT_REMOTE
 ARG VERSION
+ARG EXPIRES
 
 LABEL org.opencontainers.image.title="Kaponata Operator"
 LABEL org.opencontainers.image.description=""
@@ -18,6 +19,8 @@ LABEL org.opencontainers.image.source=$GIT_REMOTE
 LABEL org.opencontainers.image.version=$VERSION
 LABEL org.opencontainers.image.revision=$GIT_COMMIT_ID
 LABEL org.opencontainers.image.ref.name=$GIT_REF
+
+LABEL quay.expires-after=$EXPIRES
 
 WORKDIR /app
 

--- a/src/Kaponata.Operator/Makefile
+++ b/src/Kaponata.Operator/Makefile
@@ -2,6 +2,11 @@ registry=quay.io/kaponata
 image=operator
 version=$(shell nbgv get-version -v SemVer2)
 
+# Set tags to expire in 2 weeks (duration of a sprint) in quay.io;
+# exception for tags built from release branches, which never expire.
+branch=$(shell git rev-parse --abbrev-ref HEAD)
+expires=$(if $(patsubst releases/,,$(branch)),2w,)
+
 all: .arm64.docker-id .amd64.docker-id
 
 clean:
@@ -31,6 +36,7 @@ bin/Release/net5.0/publish/Kaponata.Operator.dll: $(shell find . -path ./bin -pr
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
 		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
 		--build-arg VERSION="$(version)" \
+		--build-arg EXPIRES=$(expires) \
 		. \
 		-t $(registry)/$(image):$(version)-amd64
 	docker images --no-trunc --quiet $(registry)/$(image):$(version)-amd64 > .amd64.docker-id
@@ -44,6 +50,7 @@ bin/Release/net5.0/publish/Kaponata.Operator.dll: $(shell find . -path ./bin -pr
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
 		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
 		--build-arg VERSION="$(version)" \
+		--build-arg EXPIRES=$(expires) \
 		. \
 		-t $(registry)/$(image):$(version)-arm64
 	docker images --no-trunc --quiet $(registry)/$(image):$(version)-arm64 > .arm64.docker-id


### PR DESCRIPTION
Publish images to quay.io when building from master, with expiry set to 2 weeks.