### PR TITLE
Add the ChildOperator operator

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,9 @@
     <PackageReference Include="Divergic.Logging.Xunit" Version="3.6.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Nerdbank.Streams" Version="2.6.81" />
+    <PackageReference Include="MELT" Version="0.6.0" />
+
+    <Content Include="$(MSBuildThisFileDirectory)\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorConfigurationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorConfigurationTests.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="ChildOperatorConfigurationTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Operators;
+using System;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Operators
+{
+    /// <summary>
+    /// Tests the <see cref="ChildOperatorConfiguration"/> class.
+    /// </summary>
+    public class ChildOperatorConfigurationTests
+    {
+        /// <summary>
+        /// The <see cref="ChildOperatorConfiguration"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("operatorName", () => new ChildOperatorConfiguration(null));
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperatorConfiguration"/> constructor adds the default labels.
+        /// </summary>
+        [Fact]
+        public void Constructor_AddsDefaultLabels()
+        {
+            var configuration = new ChildOperatorConfiguration("name");
+            Assert.Collection(
+                configuration.ChildLabels,
+                l =>
+                {
+                    Assert.Equal(Annotations.ManagedBy, l.Key);
+                    Assert.Equal("name", l.Value);
+                });
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -1,0 +1,188 @@
+﻿// <copyright file="ChildOperatorIntegrationTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Kaponata.Operator.Models;
+using Kaponata.Operator.Operators;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Operator.Tests.Operators
+{
+    /// <summary>
+    /// Integration tests for the <see cref="ChildOperator{TParent, TChild}"/> class.
+    /// </summary>
+    public class ChildOperatorIntegrationTests
+    {
+        private readonly IHost host;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorIntegrationTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// A <see cref="ITestOutputHelper"/> which captures test output.
+        /// </param>
+        public ChildOperatorIntegrationTests(ITestOutputHelper output)
+        {
+            var builder = new HostBuilder();
+            builder.ConfigureServices(
+                (services) =>
+                {
+                    services.AddKubernetes();
+                    services.AddLogging(
+                        (loggingBuilder) =>
+                        {
+                            loggingBuilder.AddXunit(output);
+                        });
+                });
+
+            this.host = builder.Build();
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperator{TParent, TChild}"/> creates a new child object for items which it monitors, but does not act
+        /// on items which do not match the label or field selectors.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task Session_CreatesAndDeletesPod_Async()
+        {
+            const string name = "session-createsanddeletespod-async";
+            Debug.Assert(FormatName(nameof(this.Session_CreatesAndDeletesPod_Async)) == name, "Use naming conventions");
+
+            var configuration = new ChildOperatorConfiguration(name)
+            {
+                ParentLabelSelector = LabelSelector.Create<WebDriverSession>(
+                    s => s.Metadata.Labels[Annotations.ManagedBy] == name
+                    && s.Metadata.Labels[Annotations.AutomationName] == Annotations.AutomationNames.Fake),
+            };
+
+            var podCreated = new TaskCompletionSource<V1Pod>();
+            var podDeleted = new TaskCompletionSource<V1Pod>();
+
+            var kubernetes = this.host.Services.GetRequiredService<KubernetesClient>();
+            var podClient = kubernetes.GetClient<V1Pod>();
+            var podWatcher =
+                podClient.WatchAsync(
+                    "default",
+                    fieldSelector: null,
+                    labelSelector: $"{Annotations.ManagedBy}={name}",
+                    null,
+                    (eventType, pod) =>
+                    {
+                        switch (eventType)
+                        {
+                            case k8s.WatchEventType.Added:
+                                podCreated.TrySetResult(pod);
+                                break;
+
+                            case k8s.WatchEventType.Deleted:
+                                podDeleted.TrySetResult(pod);
+                                return Task.FromResult(WatchResult.Stop);
+                        }
+
+                        return Task.FromResult(WatchResult.Continue);
+                    },
+                    default);
+
+            var sessionClient = kubernetes.GetClient<WebDriverSession>();
+
+            // Delete all objects which may have been created by this test.
+            await Task.WhenAll(
+                sessionClient.TryDeleteAsync("default", $"{name}-empty", TimeSpan.FromMinutes(1), default),
+                sessionClient.TryDeleteAsync("default", $"{name}-fake", TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync("default", $"{name}-empty", TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync("default", $"{name}-fake", TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes,
+                configuration,
+                (mobileDevice, pod) =>
+                {
+                    pod.Spec = new V1PodSpec()
+                    {
+                        Containers = new V1Container[]
+                        {
+                            new V1Container()
+                            {
+                                Name = "fake-driver",
+                                Image = "quay.io/kaponata/fake-driver:2.0.1",
+                            },
+                        },
+                    };
+                },
+                this.host.Services.GetRequiredService<ILogger<ChildOperator<WebDriverSession, V1Pod>>>()))
+            {
+                // Start the operator
+                await @operator.StartAsync(default).ConfigureAwait(false);
+
+                // Create two new sessions, one which uses the fake automation and another which uses dummy automation.
+                // A pod should be created for the fake session, but not the dummy session
+                var emptySession = await sessionClient.CreateAsync(
+                    new WebDriverSession()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = $"{name}-empty",
+                            NamespaceProperty = "default",
+                            Labels = new Dictionary<string, string>()
+                            {
+                                { Annotations.ManagedBy, name },
+                                { Annotations.AutomationName, "dummy" },
+                            },
+                        },
+                    },
+                    default).ConfigureAwait(false);
+
+                var fakeSession = await sessionClient.CreateAsync(
+                    new WebDriverSession()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = $"{name}-fake",
+                            NamespaceProperty = "default",
+                            Labels = new Dictionary<string, string>()
+                            {
+                                { Annotations.ManagedBy, name },
+                                { Annotations.AutomationName, Annotations.AutomationNames.Fake },
+                            },
+                        },
+                    },
+                    default).ConfigureAwait(false);
+
+                var createdPod = await podCreated.Task.ConfigureAwait(false);
+                Assert.Equal($"{name}-fake", createdPod.Metadata.Name);
+
+                // Deleting the sessions should result in the associated pod being deleted, too.
+                await sessionClient.DeleteAsync(emptySession, new V1DeleteOptions(propagationPolicy: "Foreground"), TimeSpan.FromMinutes(1), default).ConfigureAwait(false);
+                await sessionClient.DeleteAsync(fakeSession, new V1DeleteOptions(propagationPolicy: "Foreground"), TimeSpan.FromMinutes(1), default).ConfigureAwait(false);
+                var deletedPod = await podDeleted.Task.ConfigureAwait(false);
+                Assert.Equal($"{name}-fake", deletedPod.Metadata.Name);
+
+                // Stop the operator.
+                await @operator.StopAsync(default).ConfigureAwait(false);
+            }
+        }
+
+        private static string FormatNameCamelCase(string value)
+        {
+            return value.Replace("_", "-");
+        }
+
+        private static string FormatName(string value)
+        {
+            return value.ToLower().Replace("_", "-");
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
@@ -1,0 +1,734 @@
+﻿// <copyright file="ChildOperatorTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Kaponata.Operator.Models;
+using Kaponata.Operator.Operators;
+using MELT;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Operators
+{
+    /// <summary>
+    /// Tesets the <see cref="ChildOperator{TParent, TChild}"/> class.
+    /// </summary>
+    public class ChildOperatorTests
+    {
+        private readonly KubernetesClient kubernetes = Mock.Of<KubernetesClient>();
+        private readonly ChildOperatorConfiguration configuration;
+        private readonly Action<WebDriverSession, V1Pod> factory = (session, pod) => { };
+        private readonly ILogger<ChildOperator<WebDriverSession, V1Pod>> logger = NullLogger<ChildOperator<WebDriverSession, V1Pod>>.Instance;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorTests"/> class.
+        /// </summary>
+        public ChildOperatorTests()
+        {
+            this.configuration = new ChildOperatorConfiguration(nameof(ChildOperatorTests))
+            {
+                ParentLabelSelector = "parent-label-selector",
+            };
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperator{TParent, TChild}"/> constructor throws an exception
+        /// when passed <see langword="null"/> values.
+        /// </summary>
+        [Fact]
+        public void Constructor_ArgumentNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("kubernetes", () => new ChildOperator<WebDriverSession, V1Pod>(null, this.configuration, this.factory, this.logger));
+            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperator<WebDriverSession, V1Pod>(this.kubernetes, null, this.factory, this.logger));
+            Assert.Throws<ArgumentNullException>("factory", () => new ChildOperator<WebDriverSession, V1Pod>(this.kubernetes, this.configuration, null, this.logger));
+            Assert.Throws<ArgumentNullException>("logger", () => new ChildOperator<WebDriverSession, V1Pod>(this.kubernetes, this.configuration, this.factory, null));
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperator{TParent, TChild}.ReconcileAsync"/> method does nothing if the child object
+        /// exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReconcileAsync_Child_NoOp_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessions = kubernetes.WithClient<WebDriverSession>();
+            var pods = kubernetes.WithClient<V1Pod>();
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) =>
+                {
+                    pod.Spec = new V1PodSpec(
+                        new V1Container[]
+                        {
+                            new V1Container()
+                            {
+                                Name = "fake-driver",
+                                Image = "quay.io/kaponata/fake-driver:2.0.1",
+                            },
+                        });
+                },
+                this.logger))
+            {
+                var parent = new WebDriverSession()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-session",
+                        NamespaceProperty = "default",
+                        Uid = "my-uid",
+                    },
+                };
+
+                var child = new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-session",
+                        NamespaceProperty = "default",
+                    },
+                };
+
+                await @operator.ReconcileAsync(
+                    new (parent, child),
+                    default).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperator{TParent, TChild}.ReconcileAsync"/> method logs exceptions which
+        /// are encountered.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReconcileAsync_Exception_LogsError_Async()
+        {
+            var loggerFactory = TestLoggerFactory.Create();
+            var logger = loggerFactory.CreateLogger<ChildOperator<WebDriverSession, V1Pod>>();
+
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessions = kubernetes.WithClient<WebDriverSession>();
+            var pods = kubernetes.WithClient<V1Pod>();
+            pods.Setup(p => p.CreateAsync(It.IsAny<V1Pod>(), default)).ThrowsAsync(new NotSupportedException());
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                logger))
+            {
+                var parent = new WebDriverSession()
+                {
+                    Metadata = new V1ObjectMeta(),
+                };
+
+                await @operator.ReconcileAsync(
+                    new (parent, null),
+                    default).ConfigureAwait(false);
+            }
+
+            Assert.Collection(
+                loggerFactory.Sink.LogEntries,
+                e => Assert.Equal("Scheduling reconciliation for parent (null) and child (null) for operator ChildOperatorTests", e.Message),
+                e => Assert.Equal("Caught error Specified method is not supported. while executing reconciliation for operator ChildOperatorTests", e.Message));
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperator{TParent, TChild}.ReconcileAsync"/> method creates the child object if it
+        /// does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReconcileAsync_NoChild_CreatesChild_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessions = kubernetes.WithClient<WebDriverSession>();
+            var pods = kubernetes.WithClient<V1Pod>();
+            (var createdPods, var _) = pods.TrackCreatedItems();
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) =>
+                {
+                    pod.Spec = new V1PodSpec(
+                        new V1Container[]
+                        {
+                            new V1Container()
+                            {
+                                Name = "fake-driver",
+                                Image = "quay.io/kaponata/fake-driver:2.0.1",
+                            },
+                        });
+                },
+                this.logger))
+            {
+                var parent = new WebDriverSession()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-session",
+                        NamespaceProperty = "default",
+                        Uid = "my-uid",
+                    },
+                };
+
+                await @operator.ReconcileAsync(
+                    new (parent, null),
+                    default).ConfigureAwait(false);
+            }
+
+            Assert.Collection(
+                createdPods,
+                p =>
+                {
+                    // The name, namespace and owner references are initialized correctly
+                    Assert.Equal("my-session", p.Metadata.Name);
+                    Assert.Equal("default", p.Metadata.NamespaceProperty);
+
+                    Assert.Collection(
+                        p.Metadata.OwnerReferences,
+                        r =>
+                        {
+                            Assert.Equal("my-session", r.Name);
+                            Assert.Equal("WebDriverSession", r.Kind);
+                            Assert.Equal("kaponata.io/v1alpha1", r.ApiVersion);
+                            Assert.Equal("my-uid", r.Uid);
+                        });
+
+                    // The labels are copied from the configuration
+                    Assert.Collection(
+                        p.Metadata.Labels,
+                        p =>
+                        {
+                            Assert.Equal(Annotations.ManagedBy, p.Key);
+                            Assert.Equal(nameof(ChildOperatorTests), p.Value);
+                        });
+                });
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.InitializeAsync"/> schedules reconciliation
+        /// for a parent which does not have a child.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InitializeAsync_ParentWithoutChild_SchedulesReconciliation_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            var parent = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            sessionClient.WithList(
+                null,
+                "parent-label-selector",
+                parent);
+
+            podClient.WithList(
+                null,
+                labelSelector: "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            var createdPods = podClient.TrackCreatedItems();
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await @operator.InitializeAsync(default).ConfigureAwait(false);
+
+                Assert.True(@operator.ReconcilationBuffer.TryReceive(null, out var context));
+
+                Assert.Equal(parent, context.Parent);
+                Assert.Null(context.Child);
+
+                Assert.False(@operator.ReconcilationBuffer.TryReceive(null, out var _));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.InitializeAsync"/> schedules reconciliation
+        /// for a parent which does have a child.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task InitializeAsync_ParentWithChild_SchedulesReconciliation_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            var parent = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            var child = new V1Pod()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                    OwnerReferences = new V1OwnerReference[]
+                    {
+                        new V1OwnerReference()
+                        {
+                            ApiVersion = WebDriverSession.KubeApiVersion,
+                            Kind = WebDriverSession.KubeKind,
+                            Name = parent.Metadata.Name,
+                            Uid = parent.Metadata.Uid,
+                        },
+                    },
+                },
+            };
+
+            sessionClient.WithList(
+                null,
+                "parent-label-selector",
+                parent);
+
+            podClient.WithList(
+                null,
+                labelSelector: "app.kubernetes.io/managed-by=ChildOperatorTests",
+                child);
+
+            var createdPods = podClient.TrackCreatedItems();
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await @operator.InitializeAsync(default).ConfigureAwait(false);
+
+                Assert.True(@operator.ReconcilationBuffer.TryReceive(null, out var context));
+
+                Assert.Equal(parent, context.Parent);
+                Assert.Equal(child, context.Child);
+
+                Assert.False(@operator.ReconcilationBuffer.TryReceive(null, out var _));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.InitializeAsync(CancellationToken)"/> catches
+        /// and handles exceptions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task InitializeAsync_HandlesException_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            sessionClient
+                .Setup(s => s.ListAsync("default", null, null, "parent-label-selector", null, default))
+                .ThrowsAsync(new NotSupportedException());
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await @operator.InitializeAsync(default).ConfigureAwait(false);
+
+                await Assert.ThrowsAsync<NotSupportedException>(() => @operator.InitializationCompleted).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ScheduleReconciliationAsync(TParent, CancellationToken)"/>
+        /// validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ScheduleParentReconciliationAsync_ValidatesArgument_Async()
+        {
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                this.kubernetes,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("parent", () => @operator.ScheduleReconciliationAsync((WebDriverSession)null, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ScheduleReconciliationAsync(TParent, CancellationToken)"/> catches and logs errors.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ScheduleParentReconciliationAsync_HandlesException_Async()
+        {
+            var loggerFactory = TestLoggerFactory.Create();
+            var logger = loggerFactory.CreateLogger<ChildOperator<WebDriverSession, V1Pod>>();
+
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+            podClient
+                .Setup(p => p.ListAsync("default", null, "metadata.name=my-session", "app.kubernetes.io/managed-by=ChildOperatorTests", null, default))
+                .ThrowsAsync(new NotSupportedException());
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                logger))
+            {
+                await @operator.ScheduleReconciliationAsync(new WebDriverSession() { Metadata = new V1ObjectMeta() { Name = "my-session" } }, default).ConfigureAwait(false);
+
+                Assert.Collection(
+                    loggerFactory.Sink.LogEntries,
+                    e => Assert.Equal("ChildOperatorTests operator: scheduling reconciliation for parent my-session", e.Message),
+                    e => Assert.Equal("Caught error Specified method is not supported. while scheduling parent reconciliation for operator ChildOperatorTests", e.Message));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ScheduleReconciliationAsync(TParent, CancellationToken)"/>
+        /// posts a new item to to the queue.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ScheduleParentReconciliationAsync_PostsToQueue_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            var parent = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            var child = new V1Pod()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            podClient.WithList(
+                fieldSelector: "metadata.name=my-session",
+                labelSelector: "app.kubernetes.io/managed-by=ChildOperatorTests",
+                child);
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await @operator.ScheduleReconciliationAsync(parent, default).ConfigureAwait(false);
+
+                Assert.True(@operator.ReconcilationBuffer.TryReceive(null, out var context));
+
+                Assert.Equal(parent, context.Parent);
+                Assert.Equal(child, context.Child);
+
+                Assert.False(@operator.ReconcilationBuffer.TryReceive(null, out var _));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ScheduleReconciliationAsync(TChild, CancellationToken)"/>
+        /// validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ScheduleChildReconciliationAsync_ValidatesArgument_Async()
+        {
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                this.kubernetes,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>("child", () => @operator.ScheduleReconciliationAsync((V1Pod)null, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ScheduleReconciliationAsync(TChild, CancellationToken)"/> catches and logs errors.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ScheduleChildReconciliationAsync_HandlesException_Async()
+        {
+            var loggerFactory = TestLoggerFactory.Create();
+            var logger = loggerFactory.CreateLogger<ChildOperator<WebDriverSession, V1Pod>>();
+
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            sessionClient
+                .Setup(p => p.ListAsync("default", null, "metadata.name=my-session", "parent-label-selector", null, default))
+                .ThrowsAsync(new NotSupportedException());
+
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                logger))
+            {
+                await @operator.ScheduleReconciliationAsync(new V1Pod() { Metadata = new V1ObjectMeta() { Name = "my-session" } }, default).ConfigureAwait(false);
+
+                Assert.Collection(
+                    loggerFactory.Sink.LogEntries,
+                    e => Assert.Equal("ChildOperatorTests operator: scheduling reconciliation for child my-session", e.Message),
+                    e => Assert.Equal("Caught error Specified method is not supported. while scheduling child reconciliation for operator ChildOperatorTests", e.Message));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ScheduleReconciliationAsync(TChild, CancellationToken)"/>
+        /// posts a new item to to the queue.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ScheduleChildReconciliationAsync_PostsToQueue_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+
+            var parent = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            sessionClient.WithList(
+                fieldSelector: "metadata.name=my-session",
+                labelSelector: "parent-label-selector",
+                parent);
+
+            var child = new V1Pod()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                await @operator.ScheduleReconciliationAsync(child, default).ConfigureAwait(false);
+
+                Assert.True(@operator.ReconcilationBuffer.TryReceive(null, out var context));
+
+                Assert.Equal(parent, context.Parent);
+                Assert.Equal(child, context.Child);
+
+                Assert.False(@operator.ReconcilationBuffer.TryReceive(null, out var _));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ExecuteAsync(CancellationToken)"/> can stop and start correctly
+        /// when the watchers generate no events.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ExecuteAsync_StopStart_Succeeds_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            var sessionWatcher = sessionClient.WithWatcher(
+                null,
+                "parent-label-selector");
+
+            var podWatcher = podClient.WithWatcher(
+                null,
+                "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            sessionClient.WithList(null, "parent-label-selector");
+            podClient.WithList(null, "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                // Wait for the operator to start and complete initialization
+                await Task.WhenAll(
+                    @operator.StartAsync(default),
+                    @operator.InitializationCompleted,
+                    sessionWatcher.ClientRegistered.Task,
+                    podWatcher.ClientRegistered.Task).ConfigureAwait(false);
+
+                await @operator.StopAsync(default).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ExecuteAsync(CancellationToken)"/> reacts to parent
+        /// events and schedules reconciliation.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ExecuteAsync_ParentEvent_IsProcessed_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            var sessionWatcher = sessionClient.WithWatcher(
+                null,
+                "parent-label-selector");
+
+            var podWatcher = podClient.WithWatcher(
+                null,
+                "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            sessionClient.WithList(null, "parent-label-selector");
+            podClient.WithList(null, "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                // Wait for the operator to start and complete initialization
+                await @operator.StartAsync(default).ConfigureAwait(false);
+                await @operator.InitializationCompleted.ConfigureAwait(false);
+
+                // Similate a parent event, this should result in a child object being created.
+                var sessionWatchClient = await sessionWatcher.ClientRegistered.Task.ConfigureAwait(false);
+
+                var parent = new WebDriverSession()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-session",
+                        NamespaceProperty = "default",
+                    },
+                };
+
+                // Let's assume there's no child for this parent:
+                podClient.WithList(
+                    fieldSelector: "metadata.name=my-session",
+                    labelSelector: "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+                // And capture the creation of this new child:
+                (var _, var firstPodCreated) = podClient.TrackCreatedItems();
+
+                Assert.Equal(WatchResult.Continue, await sessionWatchClient(k8s.WatchEventType.Added, parent).ConfigureAwait(false));
+                var pod = await firstPodCreated.ConfigureAwait(false);
+
+                Assert.Equal("my-session", pod.Metadata.Name);
+
+                await @operator.StopAsync(default).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperator{TParent, TChild}.ExecuteAsync(CancellationToken)"/> reacts to child
+        /// events and schedules reconciliation.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ExecuteAsync_ChildEvent_IsProcessed_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var sessionClient = kubernetes.WithClient<WebDriverSession>();
+            var podClient = kubernetes.WithClient<V1Pod>();
+
+            var sessionWatcher = sessionClient.WithWatcher(
+                null,
+                "parent-label-selector");
+
+            var podWatcher = podClient.WithWatcher(
+                null,
+                "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            sessionClient.WithList(null, "parent-label-selector");
+            podClient.WithList(null, "app.kubernetes.io/managed-by=ChildOperatorTests");
+
+            using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
+                kubernetes.Object,
+                this.configuration,
+                (session, pod) => { },
+                this.logger))
+            {
+                // Wait for the operator to start and complete initialization
+                await @operator.StartAsync(default).ConfigureAwait(false);
+                await @operator.InitializationCompleted.ConfigureAwait(false);
+
+                // Similate a parent event, this should result in a child object being created.
+                var podWatchClient = await podWatcher.ClientRegistered.Task.ConfigureAwait(false);
+
+                var child = new V1Pod()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "my-session",
+                        NamespaceProperty = "default",
+                    },
+                };
+
+                // Let's assume there's a parent for this child.
+                sessionClient.WithList(
+                    fieldSelector: "metadata.name=my-session",
+                    labelSelector: "parent-label-selector",
+                    new WebDriverSession());
+
+                Assert.Equal(WatchResult.Continue, await podWatchClient(k8s.WatchEventType.Added, child).ConfigureAwait(false));
+
+                await @operator.StopAsync(default).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
+++ b/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
@@ -258,6 +258,29 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
+        /// Sets up a <see cref="NamespacedKubernetesClient{T}"/> which is a child of this <see cref="KubernetesClient"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of objects observed by the <see cref="NamespacedKubernetesClient{T}"/>.
+        /// </typeparam>
+        /// <param name="client">
+        /// The <see cref="KubernetesClient"/> for which to configure the <see cref="NamespacedKubernetesClient{T}"/>.
+        /// </param>
+        /// <returns>
+        /// A mock of the <see cref="NamespacedKubernetesClient{T}"/> class.
+        /// </returns>
+        public static Mock<NamespacedKubernetesClient<T>> WithClient<T>(this Mock<KubernetesClient> client)
+            where T : IKubernetesObject<V1ObjectMeta>, new()
+        {
+            Mock<NamespacedKubernetesClient<T>> typedClient = new Mock<NamespacedKubernetesClient<T>>(MockBehavior.Strict);
+
+            client.Setup(s => s.GetClient<T>())
+                .Returns(typedClient.Object);
+
+            return typedClient;
+        }
+
+        /// <summary>
         /// A client which subscribed to a watch operation.
         /// </summary>
         /// <typeparam name="T">

--- a/src/Kaponata.Operator.Tests/Operators/NamespacedKubernetesClientExtensions.cs
+++ b/src/Kaponata.Operator.Tests/Operators/NamespacedKubernetesClientExtensions.cs
@@ -1,0 +1,186 @@
+﻿// <copyright file="NamespacedKubernetesClientExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Kaponata.Operator.Models;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Tests.Operators
+{
+    /// <summary>
+    /// Extensions for mocks of the <see cref="NamespacedKubernetesClient{T}"/> class.
+    /// </summary>
+    public static class NamespacedKubernetesClientExtensions
+    {
+        /// <summary>
+        /// Mocks the value of the <see cref="NamespacedKubernetesClient{T}.ListAsync(string, string, string, string, int?, CancellationToken)"/> method.
+        /// </summary>
+        /// <param name="client">
+        /// The mock to configure.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// The field selector used to list the items.
+        /// </param>
+        /// <param name="labelSelector">
+        /// The label selector which will be used to list the items.
+        /// </param>
+        /// <param name="values">
+        /// The pods which should be returned.
+        /// </param>
+        /// <typeparam name="T">
+        /// The type of objects observed by the client.
+        /// </typeparam>
+        /// <returns>
+        /// The list of pods which will be returned to the client.
+        /// </returns>
+        public static List<T> WithList<T>(this Mock<NamespacedKubernetesClient<T>> client, string fieldSelector, string labelSelector, params T[] values)
+            where T : IKubernetesObject<V1ObjectMeta>, new()
+        {
+            var items = new List<T>(values);
+
+            client
+                .Setup(k => k.ListAsync("default", null, fieldSelector, labelSelector, null, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(
+                    new ItemList<T>()
+                    {
+                        Items = items,
+                    }));
+
+            return items;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="NamespacedKubernetesClient{T}.CreateAsync(T, CancellationToken)"/> method on the mock,
+        /// and tracks the newly created devices.
+        /// </summary>
+        /// <param name="client">
+        /// The mock to configure.
+        /// </param>
+        /// <typeparam name="T">
+        /// The type of objects observed by the client.
+        /// </typeparam>
+        /// <returns>
+        /// A collection to which newly created devices will be added.
+        /// </returns>
+        public static (Collection<T> items, Task<T> firstItemCreated) TrackCreatedItems<T>(this Mock<NamespacedKubernetesClient<T>> client)
+            where T : IKubernetesObject<V1ObjectMeta>, new()
+        {
+            var items = new Collection<T>();
+            var firstChildCreated = new TaskCompletionSource<T>();
+
+            client
+                .Setup(d => d.CreateAsync(It.IsAny<T>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync<T, CancellationToken, NamespacedKubernetesClient<T>, T>(
+                (item, cancellationToken) =>
+                {
+                    items.Add(item);
+                    firstChildCreated.TrySetResult(item);
+                    return item;
+                });
+
+            return (items, firstChildCreated.Task);
+        }
+
+        /// <summary>
+        /// Configures the <see cref="NamespacedKubernetesClient{T}.DeleteAsync(T, TimeSpan, CancellationToken)"/> method on the mock,
+        /// and tracks the deleted devices.
+        /// </summary>
+        /// <param name="client">
+        /// The mock to configure.
+        /// </param>
+        /// <typeparam name="T">
+        /// The type of objects observed by the client.
+        /// </typeparam>
+        /// <returns>
+        /// A collection to which deleted devices will be added.
+        /// </returns>
+        public static Collection<MobileDevice> TrackDeletedItems<T>(this Mock<NamespacedKubernetesClient<T>> client)
+            where T : IKubernetesObject<V1ObjectMeta>, new()
+        {
+            var devices = new Collection<MobileDevice>();
+
+            client
+                .Setup(d => d.DeleteAsync(It.IsAny<T>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .Callback<MobileDevice, TimeSpan, CancellationToken>(
+                (device, timeout, cancellationToken) =>
+                {
+                    devices.Add(device);
+                })
+                .Returns(Task.CompletedTask);
+
+            return devices;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="NamespacedKubernetesClient{T}.WatchAsync(string, string, string, string, WatchEventDelegate{T}, CancellationToken)"/> method
+        /// on the mock.
+        /// </summary>
+        /// <param name="client">
+        /// The mock to configure.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// The field selector used to watch th eitems.
+        /// </param>
+        /// <param name="labelSelector">
+        /// The label selector used to watch the items.
+        /// </param>
+        /// <typeparam name="T">
+        /// The type of objects observed by the client.
+        /// </typeparam>
+        /// <returns>
+        /// A <see cref="WatchClient{T}"/> which can be used to invoke the event handler (if set) and complete the watch operation.
+        /// </returns>
+        public static WatchClient<T> WithWatcher<T>(this Mock<NamespacedKubernetesClient<T>> client, string fieldSelector, string labelSelector)
+            where T : IKubernetesObject<V1ObjectMeta>, new()
+        {
+            var watchClient = new WatchClient<T>();
+
+            client
+                .Setup(k => k.WatchAsync(
+                    "default",
+                    fieldSelector /* fieldSelector */,
+                    labelSelector /* labelSelector */,
+                    null /* resourceVersion */,
+                    It.IsAny<WatchEventDelegate<T>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, string, string, WatchEventDelegate<T>, CancellationToken>(
+                (@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
+                {
+                    cancellationToken.Register(watchClient.TaskCompletionSource.SetCanceled);
+                    watchClient.ClientRegistered.SetResult(eventHandler);
+                })
+                .Returns(watchClient.TaskCompletionSource.Task);
+
+            return watchClient;
+        }
+
+        /// <summary>
+        /// A client which subscribed to a watch operation.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of object being watched.
+        /// </typeparam>
+        public class WatchClient<T>
+            where T : IKubernetesObject<V1ObjectMeta>
+        {
+            /// <summary>
+            /// Gets a <see cref="TaskCompletionSource"/> which returns the first client which registered.
+            /// </summary>
+            public TaskCompletionSource<WatchEventDelegate<T>> ClientRegistered { get; } = new TaskCompletionSource<WatchEventDelegate<T>>();
+
+            /// <summary>
+            /// Gets a <see cref="TaskCompletionSource"/> which can be used to complete the watch task.
+            /// </summary>
+            public TaskCompletionSource<WatchExitReason> TaskCompletionSource { get; } = new TaskCompletionSource<WatchExitReason>();
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Annotations.cs
+++ b/src/Kaponata.Operator/Kubernetes/Annotations.cs
@@ -58,6 +58,22 @@ namespace Kaponata.Operator.Kubernetes
         public const string Os = "kubernetes.io/os";
 
         /// <summary>
+        /// The name of the automation provider used for a WebDriver session.
+        /// </summary>
+        public const string AutomationName = "kaponata.io/automation-name";
+
+        /// <summary>
+        /// Enumerates all automation names available.
+        /// </summary>
+        public class AutomationNames
+        {
+            /// <summary>
+            /// The fake automation provider, implemented by the appium-fake-driver driver.
+            /// </summary>
+            public const string Fake = "fake";
+        }
+
+        /// <summary>
         /// Enumerates the values of well-known computer architectures, as used by the <see cref="Arch"/> annotation and the
         /// <c>GOARCH</c> environment variable.
         /// </summary>

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -105,7 +105,7 @@ namespace Kaponata.Operator.Kubernetes
         /// <returns>
         /// A <see cref="NamespacedKubernetesClient{T}"/> which allows you to operate on objects of <typeparamref name="T"/>.
         /// </returns>
-        public NamespacedKubernetesClient<T> GetClient<T>()
+        public virtual NamespacedKubernetesClient<T> GetClient<T>()
             where T : IKubernetesObject<V1ObjectMeta>, new()
         {
             return new NamespacedKubernetesClient<T>(

--- a/src/Kaponata.Operator/Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/NamespacedKubernetesClient.cs
@@ -44,6 +44,16 @@ namespace Kaponata.Operator.Kubernetes
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NamespacedKubernetesClient{T}"/> class.
+        /// </summary>
+        /// <remarks>
+        /// Used for mocking purposes only.
+        /// </remarks>
+        protected NamespacedKubernetesClient()
+        {
+        }
+
+        /// <summary>
         /// Asynchronously creates a new <typeparamref name="T"/> object.
         /// </summary>
         /// <param name="value">

--- a/src/Kaponata.Operator/Operators/ChildOperator.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperator.cs
@@ -1,0 +1,448 @@
+﻿// <copyright file="ChildOperator.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// A <see cref="ChildOperator{TParent, TChild}"/> watches for objects of type <typeparamref name="TParent"/>
+    /// and projects them into objects of type <typeparamref name="TChild"/>.
+    /// </summary>
+    /// <typeparam name="TParent">
+    /// The type of object to watch for (such as <see cref="V1Pod"/>).
+    /// </typeparam>
+    /// <typeparam name="TChild">
+    /// The type of object to create (such as <see cref="V1Service"/>).
+    /// </typeparam>
+    /// <remarks>
+    /// <para>
+    /// Only a subset of objects of type <typeparamref name="TParent"/> are watched. Use the <see cref="ChildOperatorConfiguration.ParentLabelSelector"/>
+    /// property to limit which <typeparamref name="TParent"/> objects are being considered by this operator.
+    /// </para>
+    /// <para>
+    /// This operator will pre-configure the child objects as follows:
+    /// <list type="bullet">
+    ///   <item>
+    ///     Add an entry in the  <see cref="V1ObjectMeta.OwnerReferences"/> table which references the parent object,
+    ///     causing it to be garbage-collected when the parent object has been deleted.
+    ///   </item>
+    ///   <item>
+    ///     Set the <see cref="V1ObjectMeta.Name"/> and <see cref="V1ObjectMeta.NamespaceProperty"/> values to match
+    ///     that of the parent object.
+    ///   </item>
+    ///   <item>
+    ///     Populate the <see cref="V1ObjectMeta.Labels"/> property with the value of the <see cref="ChildOperatorConfiguration.ChildLabels"/>
+    ///     property, and add a <see cref="Annotations.ManagedBy"/> label which matches the <see cref="ChildOperatorConfiguration.OperatorName"/>.
+    ///   </item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// This operator assumes that:
+    /// <list type="bullet">
+    ///   <item>
+    ///     The child and parent have the same <see cref="V1ObjectMeta.Name"/> and <see cref="V1ObjectMeta.NamespaceProperty"/> values,
+    ///     and these values are sufficient to correlate child with parent and vice versa.
+    ///   </item>
+    ///   <item>
+    ///     All parent objects have the <see cref="ChildOperatorConfiguration.ParentLabelSelector"/> and all child objects have the
+    ///     <see cref="ChildOperatorConfiguration.ChildLabels"/> labels.
+    ///   </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public class ChildOperator<TParent, TChild> : BackgroundService
+        where TParent : IKubernetesObject<V1ObjectMeta>, new()
+        where TChild : IKubernetesObject<V1ObjectMeta>, new()
+    {
+        private readonly ILogger<ChildOperator<TParent, TChild>> logger;
+        private readonly ChildOperatorConfiguration configuration;
+        private readonly KubernetesClient kubernetes;
+        private readonly Action<TParent, TChild> childFactory;
+
+        // Kubernetes clients which are used to watch and upated parent and child objects.
+        private readonly NamespacedKubernetesClient<TParent> parentClient;
+        private readonly NamespacedKubernetesClient<TChild> childClient;
+
+        // The queue to which items to reconcile are posted and from which they are read.
+        private readonly BufferBlock<ChildOperatorContext> reconciliationBuffer = new BufferBlock<ChildOperatorContext>();
+
+        // Task completion source backing the InitializationCompleted property.
+        private readonly TaskCompletionSource initializationCompletedTcs = new TaskCompletionSource();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperator{TParent, TChild}"/> class.
+        /// </summary>
+        /// <param name="kubernetes">
+        /// A connection to a Kubernetes cluster.
+        /// </param>
+        /// <param name="configuration">
+        /// The configuration for this operator.
+        /// </param>
+        /// <param name="factory">
+        /// A method which projects objects of type <typeparamref name="TParent"/> into objects of type
+        /// <typeparamref name="TChild"/>.
+        /// </param>
+        /// <param name="logger">
+        /// The logger to use when logging.
+        /// </param>
+        public ChildOperator(
+            KubernetesClient kubernetes,
+            ChildOperatorConfiguration configuration,
+            Action<TParent, TChild> factory,
+            ILogger<ChildOperator<TParent, TChild>> logger)
+        {
+            this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            this.childFactory = factory ?? throw new ArgumentNullException(nameof(factory));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            this.parentClient = this.kubernetes.GetClient<TParent>();
+            this.childClient = this.kubernetes.GetClient<TChild>();
+        }
+
+        /// <summary>
+        /// Gets a <see cref="BufferBlock{T}"/> which contains all currently scheduled reconciliations.
+        /// </summary>
+        public BufferBlock<ChildOperatorContext> ReconcilationBuffer => this.reconciliationBuffer;
+
+        /// <summary>
+        /// Gets a <see cref="Task"/> which completes when the initialization has completed.
+        /// </summary>
+        public Task InitializationCompleted => this.initializationCompletedTcs.Task;
+
+        /// <summary>
+        /// Runs the initial reconcilation loop. Lists all parents and schedules the initial reconcilation for
+        /// these objects.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task InitializeAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                this.logger.LogInformation("Initializing the {operator} operator.", this.configuration.OperatorName);
+
+                // List all parent and child objects
+                var parents = await this.parentClient.ListAsync(
+                    this.configuration.Namespace,
+                    fieldSelector: null,
+                    labelSelector: this.configuration.ParentLabelSelector,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                this.logger.LogInformation("Found {count} parents for the {operator} operator.", parents.Items.Count, this.configuration.OperatorName);
+
+                var children = await this.childClient.ListAsync(
+                    this.configuration.Namespace,
+                    labelSelector: Selector.Create(this.configuration.ChildLabels)).ConfigureAwait(false);
+                this.logger.LogInformation("Found {count} children for the {operator} operator.", children.Items.Count, this.configuration.OperatorName);
+
+                foreach (var parent in parents.Items)
+                {
+                    this.logger.LogInformation("Processing parent {parent} for the {operator} operator", parent.Metadata.Name, this.configuration.OperatorName);
+
+                    var child = children.Items.SingleOrDefault(c => c.IsOwnedBy(parent));
+                    this.logger.LogInformation("Found child {child} for parent {parent} for the {operator} operator", child?.Metadata?.Name, parent.Metadata.Name, this.configuration.OperatorName);
+
+                    this.reconciliationBuffer.Post(new ChildOperatorContext(parent, child));
+
+                    if (child != null)
+                    {
+                        children.Items.Remove(child);
+                    }
+
+                    this.logger.LogInformation("{parentCount} parents left, {childCount} chidren left for the {operator} operator.", parents.Items.Count, children.Items.Count, this.configuration.OperatorName);
+                }
+
+                // We don't care for children without parents; these should be child objects which are being deleted
+                // because of cascading background deletions.
+                this.initializationCompletedTcs.SetResult();
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Caught error {errorMessage} while scheduling initializing operator {operator}", ex.Message, this.configuration.OperatorName);
+                this.initializationCompletedTcs.SetException(ex);
+            }
+        }
+
+        /// <summary>
+        /// Schedules a reconciliation based on a parent object, but does not wait for the
+        /// reconciliation to actually be performed.
+        /// </summary>
+        /// <param name="parent">
+        /// A parent object, which has been modified.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation of scheduling
+        /// the reconciliation.
+        /// </returns>
+        public async Task ScheduleReconciliationAsync(TParent parent, CancellationToken cancellationToken)
+        {
+            if (parent == null)
+            {
+                throw new ArgumentNullException(nameof(parent));
+            }
+
+            try
+            {
+                this.logger.LogInformation("{operator} operator: scheduling reconciliation for parent {parent}", this.configuration.OperatorName, parent?.Metadata?.Name);
+
+                // Get the child
+                var children = await this.childClient.ListAsync(
+                    this.configuration.Namespace,
+                    null,
+                    $"metadata.name={parent.Metadata.Name}",
+                    Selector.Create(this.configuration.ChildLabels),
+                    null,
+                    cancellationToken).ConfigureAwait(false);
+                var child = children.Items.SingleOrDefault();
+
+                this.logger.LogInformation("{operator} operator: found child {child} for parent {parent}", this.configuration.OperatorName, child?.Metadata?.Name, parent?.Metadata?.Name);
+
+                this.reconciliationBuffer.Post(new ChildOperatorContext(parent, child));
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Caught error {errorMessage} while scheduling parent reconciliation for operator {operator}", ex.Message, this.configuration.OperatorName);
+            }
+        }
+
+        /// <summary>
+        /// Schedules a reconcilation based on a child object, but does not wait for
+        /// the reconciliation to be actually performed.
+        /// </summary>
+        /// <param name="child">
+        /// A child object, which has been modified.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public async Task ScheduleReconciliationAsync(TChild child, CancellationToken cancellationToken)
+        {
+            if (child == null)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
+
+            try
+            {
+                this.logger.LogInformation("{operator} operator: scheduling reconciliation for child {parent}", this.configuration.OperatorName, child?.Metadata?.Name);
+
+                // Get the parent
+                var parents = await this.parentClient.ListAsync(
+                    this.configuration.Namespace,
+                    null,
+                    $"metadata.name={child.Metadata.Name}",
+                    this.configuration.ParentLabelSelector,
+                    null,
+                    cancellationToken);
+                var parent = parents.Items.SingleOrDefault();
+
+                this.logger.LogInformation("{operator} operator: found parent {parent} for child {child}", this.configuration.OperatorName, parent?.Metadata?.Name, child?.Metadata?.Name);
+
+                if (parent != null)
+                {
+                    this.reconciliationBuffer.Post(new ChildOperatorContext(parent, child));
+                }
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Caught error {errorMessage} while scheduling child reconciliation for operator {operator}", ex.Message, this.configuration.OperatorName);
+            }
+        }
+
+        /// <summary>
+        /// Executes the queued reconciliations.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task ExecuteReconcilationsAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var context = await this.reconciliationBuffer.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                    await this.ReconcileAsync(context, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Caught error {errorMessage} while executing reconciliations for operator {operator}", ex.Message, this.configuration.OperatorName);
+            }
+        }
+
+        /// <summary>
+        /// Attempts to reconcile a child and parent object.
+        /// </summary>
+        /// <param name="context">
+        /// A <see cref="ChildOperatorContext"/> object which represents the parent and child object
+        /// being reconciled.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public async Task ReconcileAsync(ChildOperatorContext context, CancellationToken cancellationToken)
+        {
+            // Let's assume Kubernetes takes care of garbage collection, so the source
+            // object is always present.
+            //
+            // Although children with no parents are possible because of cascading background deletions:
+            // https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#background-cascading-deletion,
+            // they should never enter the reconcile loop.
+            Debug.Assert(context.Parent != null, "Cannot have a child object without a parent object");
+
+            try
+            {
+                this.logger.LogInformation(
+                    "Scheduling reconciliation for parent {parent} and child {child} for operator {operatorName}",
+                    context.Parent?.Metadata?.Name,
+                    context.Child?.Metadata?.Name,
+                    this.configuration.OperatorName);
+
+                if (context.Child == null)
+                {
+                    // Create a new object
+                    var child = new TChild()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Labels = this.configuration.ChildLabels,
+                            Name = context.Parent.Metadata.Name,
+                            NamespaceProperty = context.Parent.Metadata.NamespaceProperty,
+                            OwnerReferences = new V1OwnerReference[]
+                            {
+                            new V1OwnerReference()
+                            {
+                                Kind = context.Parent.Kind,
+                                ApiVersion = context.Parent.ApiVersion,
+                                BlockOwnerDeletion = false,
+                                Controller = false,
+                                Name = context.Parent.Metadata.Name,
+                                Uid = context.Parent.Metadata.Uid,
+                            },
+                            },
+                        },
+                    };
+
+                    child.SetLabel(Annotations.ManagedBy, this.configuration.OperatorName);
+
+                    this.childFactory(context.Parent, child);
+
+                    await this.childClient.CreateAsync(child, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    this.logger.LogInformation(
+                        "Skipping reconciliation for parent {parent} and child {child} for operator {operatorName} because child is null",
+                        context.Parent?.Metadata?.Name,
+                        context.Child?.Metadata?.Name,
+                        this.configuration.OperatorName);
+                }
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Caught error {errorMessage} while executing reconciliation for operator {operator}", ex.Message, this.configuration.OperatorName);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Watch child objects
+            var sourceWatch = this.parentClient.WatchAsync(
+                this.configuration.Namespace,
+                fieldSelector: null,
+                this.configuration.ParentLabelSelector,
+                null,
+                async (eventType, value) =>
+                {
+                    await this.ScheduleReconciliationAsync(value, stoppingToken).ConfigureAwait(false);
+                    return WatchResult.Continue;
+                },
+                stoppingToken);
+
+            var targetWatch = this.childClient.WatchAsync(
+                this.configuration.Namespace,
+                fieldSelector: null,
+                Selector.Create(this.configuration.ChildLabels),
+                null,
+                async (eventType, value) =>
+                {
+                    await this.ScheduleReconciliationAsync(value, stoppingToken).ConfigureAwait(false);
+                    return WatchResult.Continue;
+                },
+                stoppingToken);
+
+            // Schedule the initial reconciliations
+            await this.InitializeAsync(stoppingToken).ConfigureAwait(false);
+
+            var reconcilerTask = this.ExecuteReconcilationsAsync(stoppingToken);
+
+            await Task.WhenAny(
+                sourceWatch,
+                targetWatch,
+                reconcilerTask).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperatorContext"/> represents a specific instance of objects (parent + child)
+        /// which need to be reconciled.
+        /// </summary>
+        public class ChildOperatorContext
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ChildOperatorContext"/> class.
+            /// </summary>
+            /// <param name="parent">
+            /// The parent object being reconciled.
+            /// </param>
+            /// <param name="child">
+            /// The child object being reconciled.
+            /// </param>
+            public ChildOperatorContext(TParent parent, TChild child)
+            {
+                this.Parent = parent ?? throw new ArgumentNullException(nameof(parent));
+                this.Child = child;
+            }
+
+            /// <summary>
+            /// Gets the parent for which the reconciliation is being executed.
+            /// </summary>
+            public TParent Parent { get; }
+
+            /// <summary>
+            /// Gets the child for which the reconciliation is being executed. Can be <see langword="null"/>
+            /// if no child exists.
+            /// </summary>
+            public TChild Child { get; }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Operators/ChildOperatorConfiguration.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorConfiguration.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="ChildOperatorConfiguration.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes;
+using System;
+using System.Collections.Generic;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Represents the configuration of a <see cref="ChildOperator{TParent, TChild}"/> instance.
+    /// </summary>
+    public class ChildOperatorConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorConfiguration"/> class.
+        /// </summary>
+        /// <param name="operatorName">
+        /// The name of the operator.
+        /// </param>
+        public ChildOperatorConfiguration(string operatorName)
+        {
+            this.OperatorName = operatorName ?? throw new ArgumentNullException(nameof(operatorName));
+            this.ChildLabels.Add(Annotations.ManagedBy, this.OperatorName);
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the namespace in which the operator observes object.
+        /// </summary>
+        public string Namespace { get; set; } = "default";
+
+        /// <summary>
+        /// Gets the name of the operator.
+        /// </summary>
+        public string OperatorName { get; }
+
+        /// <summary>
+        /// Gets or sets the label selector used to find to parents which are considered for reconciliation.
+        /// </summary>
+        public string ParentLabelSelector { get; set; }
+
+        /// <summary>
+        /// Gets the labels appleid to children created by the operator.
+        /// </summary>
+        public Dictionary<string, string> ChildLabels
+        { get; } = new Dictionary<string, string>();
+    }
+}

--- a/src/xunit.runner.json
+++ b/src/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "longRunningTestSeconds": 60,
+  "diagnosticMessages": true,
+}


### PR DESCRIPTION
This `ChildOperator` is intended to be a generic operator which watches for objects and creates 'child' (or dependent) objects when new objects are created.

For example, when a `WebDriverSession` object with `automationType = fake` is created, a `ChildOperator` can be used to create a new `V1Pod` which hosts the fake driver.