### PR TITLE
NamespaceKubernetesClient: Add TryDeleteAsync method

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/NamespacedKubernetesClientTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/NamespacedKubernetesClientTests.cs
@@ -1,0 +1,125 @@
+﻿// <copyright file="NamespacedKubernetesClientTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Models;
+using Microsoft.Rest;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="NamespacedKubernetesClient{T}"/> class.
+    /// </summary>
+    public class NamespacedKubernetesClientTests
+    {
+        /// <summary>
+        /// The <see cref="NamespacedKubernetesClient{T}"/> constructor validates the arguments passed to it.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("parent", () => new NamespacedKubernetesClient<V1Pod>(null, new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "core")));
+            Assert.Throws<ArgumentNullException>("metadata", () => new NamespacedKubernetesClient<V1Pod>(Mock.Of<KubernetesClient>(), null));
+        }
+
+        /// <summary>
+        /// <see cref="NamespacedKubernetesClient{T}.TryDeleteAsync"/> validates the arguments passed to it.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryDeleteAsync_ValidatesArguments_Async()
+        {
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
+
+            var client = new NamespacedKubernetesClient<V1Pod>(parent.Object, metadata);
+
+            await Assert.ThrowsAsync<ArgumentNullException>("namespace", () => client.TryDeleteAsync(null, "test", TimeSpan.Zero, default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ArgumentNullException>("name", () => client.TryDeleteAsync("test", null, TimeSpan.Zero, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="NamespacedKubernetesClient{T}.TryDeleteAsync"/> returns <see langword="null"/> if the requested object does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryDeleteAsync_DoesNotExist_DoesNothing_Async()
+        {
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
+
+            // Return an empty list when searching for the requested pod.
+            parent
+                .Setup(l => l.ListNamespacedObjectAsync<V1Pod, ItemList<V1Pod>>(metadata, "default", null, null, "metadata.name=my-name", null, null, null, null, null, null, null, null, default))
+                .ReturnsAsync(
+                    new HttpOperationResponse<ItemList<V1Pod>>()
+                    {
+                        Body = new ItemList<V1Pod>()
+                        {
+                            Items = new V1Pod[] { },
+                        },
+                    });
+
+            var client = new NamespacedKubernetesClient<V1Pod>(parent.Object, metadata);
+            Assert.Null(await client.TryDeleteAsync("default", "my-name", TimeSpan.FromMinutes(1), default).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// <see cref="NamespacedKubernetesClient{T}.TryDeleteAsync"/> deletes the object and returns the deleted object if the requested
+        /// object exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TryDeleteAsync_DoesExist_DoesDelete_Async()
+        {
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
+
+            // Return the requested pod when searching for the requested pod.
+            var pod = new V1Pod()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-pod",
+                    NamespaceProperty = "default",
+                },
+            };
+
+            parent
+                .Setup(l => l.ListNamespacedObjectAsync<V1Pod, ItemList<V1Pod>>(metadata, "default", null, null, "metadata.name=my-name", null, null, null, null, null, null, null, null, default))
+                .ReturnsAsync(
+                    new HttpOperationResponse<ItemList<V1Pod>>()
+                    {
+                        Body = new ItemList<V1Pod>()
+                        {
+                            Items = new V1Pod[]
+                            {
+                                pod,
+                            },
+                        },
+                    });
+
+            parent
+                .Setup(l => l.DeleteNamespacedObjectAsync<V1Pod>(
+                    pod,
+                    It.IsAny<V1DeleteOptions>(),
+                    It.IsAny<KubernetesClient.DeleteNamespacedObjectAsyncDelegate<V1Pod>>(),
+                    It.IsAny<KubernetesClient.WatchObjectAsyncDelegate<V1Pod>>(),
+                    TimeSpan.FromMinutes(1),
+                    default))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var client = new NamespacedKubernetesClient<V1Pod>(parent.Object, metadata);
+            Assert.Equal(pod, await client.TryDeleteAsync("default", "my-name", TimeSpan.FromMinutes(1), default).ConfigureAwait(false));
+
+            parent.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Delete.cs
@@ -113,8 +113,56 @@ namespace Kaponata.Operator.Kubernetes
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// </returns>
-        public async Task DeleteNamespacedObjectAsync<T>(
+        public Task DeleteNamespacedObjectAsync<T>(
             T value,
+            DeleteNamespacedObjectAsyncDelegate<T> deleteAction,
+            WatchObjectAsyncDelegate<T> watchAction,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+            where T : IKubernetesObject<V1ObjectMeta>
+        {
+            return this.DeleteNamespacedObjectAsync(
+                value,
+                options: null,
+                deleteAction,
+                watchAction,
+                timeout,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a namespaced object, and waits for the delete operation
+        /// to complete.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the Kubernetes object to delete.
+        /// </typeparam>
+        /// <param name="value">
+        /// The object to delete.
+        /// </param>
+        /// <param name="options">
+        /// Additional options which specify how the delete operation should be processed.
+        /// </param>
+        /// <param name="deleteAction">
+        /// A delegate to a method which schedules the deletion.
+        /// </param>
+        /// <param name="watchAction">
+        /// A delegate to a method which creates a watcher for the object.
+        /// Used to monitor the progress of the delete operation.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time to wait for the object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the
+        /// asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public virtual async Task DeleteNamespacedObjectAsync<T>(
+            T value,
+            V1DeleteOptions options,
             DeleteNamespacedObjectAsyncDelegate<T> deleteAction,
             WatchObjectAsyncDelegate<T> watchAction,
             TimeSpan timeout,
@@ -162,6 +210,7 @@ namespace Kaponata.Operator.Kubernetes
             await deleteAction(
                 value.Metadata.Name,
                 value.Metadata.NamespaceProperty,
+                body: options,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (await Task.WhenAny(watchTask, Task.Delay(timeout)).ConfigureAwait(false) != watchTask)

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -196,7 +196,7 @@ namespace Kaponata.Operator.Kubernetes
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        public async Task<HttpOperationResponse<TList>> ListNamespacedObjectAsync<TObject, TList>(
+        public async virtual Task<HttpOperationResponse<TList>> ListNamespacedObjectAsync<TObject, TList>(
             KindMetadata kind,
             string namespaceParameter,
             bool? allowWatchBookmarks = null,


### PR DESCRIPTION
When writing integration tests, it's often useful to make sure the objects which are created during the test do not exist.

While integration tests should clean up after themselves, they may sometimes fail to do so, and this should not impact the next test run.