### PR TITLE
KubernetesClient: Fix handling of objects in the "core" namespace

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesClientIntegrationTests.cs
@@ -466,6 +466,26 @@ namespace Kaponata.Operator.Tests.Kubernetes
             }
         }
 
+        /// <summary>
+        /// The <see cref="KubernetesClient.GetClient{T}"/> method returns a client which is properly configured to request objects
+        /// of the core API group, such as Pod objects.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task GenericClient_ListPod_UsesCorrectUrl_Async()
+        {
+            using (var client = this.CreateKubernetesClient())
+            {
+                var podClient = client.GetClient<V1Pod>();
+                var pods = await podClient.ListAsync("default").ConfigureAwait(false);
+                Assert.Equal("v1", pods.ApiVersion);
+                Assert.Equal("PodList", pods.Kind);
+            }
+        }
+
         private static string FormatNameCamelCase(string value)
         {
             return value.Replace("_", "-");

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/CoreApiHandlerTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/CoreApiHandlerTests.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="CoreApiHandlerTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes.Polyfill;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// Tests the <see cref="CoreApiHandler"/> class.
+    /// </summary>
+    public class CoreApiHandlerTests
+    {
+        /// <summary>
+        /// The <see cref="CoreApiHandler"/> intercepts requests for the Core API and patches the request URL.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task SendAsync_PatchedPodUrl_Async()
+        {
+            var innerHandler = new DummyHandler();
+            var expectedResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("test"),
+            };
+
+            innerHandler.Responses.Enqueue(expectedResponse);
+
+            var client = new HttpClient(new CoreApiHandler(innerHandler));
+            client.BaseAddress = new Uri("http://localhost");
+            var response = await client.GetAsync("/apis/core/v1/").ConfigureAwait(false);
+
+            Assert.Collection(
+                innerHandler.Requests,
+                r => Assert.Equal(new Uri("http://localhost/api/v1/"), r.RequestUri));
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.cs
@@ -49,6 +49,11 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
                     protocol.HttpMessageHandlers,
                     (h) =>
                     {
+                        var apiHandler = Assert.IsType<CoreApiHandler>(h);
+                        Assert.NotNull(apiHandler.InnerHandler);
+                    },
+                    (h) =>
+                    {
                         var watchHandler = Assert.IsType<WatchHandler>(h);
                         Assert.NotNull(watchHandler.InnerHandler);
                     },

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -53,6 +53,7 @@ namespace Kaponata.Operator.Kubernetes
 
             this.knownTypes.Add(typeof(MobileDevice), MobileDevice.KubeMetadata);
             this.knownTypes.Add(typeof(WebDriverSession), WebDriverSession.KubeMetadata);
+            this.knownTypes.Add(typeof(V1Pod), new KindMetadata("core", V1Pod.KubeApiVersion, "pods"));
 
             this.mobileDeviceClient = this.GetClient<MobileDevice>();
             this.webDriverSessionClient = this.GetClient<WebDriverSession>();

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/CoreApiHandler.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/CoreApiHandler.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="CoreApiHandler.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> which intercepts requests to the <c>/apis/core/v1</c> or <c>/apis/v1</c> route
+    /// and redirects them to <c>/api/v1</c>, so that "core" objects like <see cref="V1Pod"/> can be used
+    /// by the <see cref="NamespacedKubernetesClient{T}"/>.
+    /// </summary>
+    public class CoreApiHandler : DelegatingHandler
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CoreApiHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">
+        /// The inner handler.
+        /// </param>
+        public CoreApiHandler(HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri.AbsolutePath.StartsWith("/apis/core/v1/"))
+            {
+                var builder = new UriBuilder(request.RequestUri);
+                builder.Path = builder.Path.Replace("/apis/core/v1/", "/api/v1/");
+                request.RequestUri = builder.Uri;
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.cs
@@ -56,7 +56,7 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
 
             this.FirstMessageHandler = this.HttpClientHandler = CreateRootHandler();
-            this.FirstMessageHandler = new WatchHandler(this.HttpClientHandler);
+            this.FirstMessageHandler = new CoreApiHandler(new WatchHandler(this.HttpClientHandler));
 
             this.HttpClient = new HttpClient(this.FirstMessageHandler, false);
 


### PR DESCRIPTION
The `NamespacedKubernetesClient<T>` allows you to fetch any type of Kubernetes object in a generic way.

But when you create it for "core" types (like `V1Pod` objects), it will construct the request URL as `/apis/core/v1` instead of `/api/v1`. This is because the "core" API is special, and the KubernetesClient does not know about the core API.

This PR adds a request handler which rewrites the URL so that this scenario works.

Covered by a unit test and an integration test.