### PR TITLE
ChildOperator: Add support for feedback loops

### DIFF
--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
@@ -122,6 +123,7 @@ namespace Kaponata.Operator.Tests.Operators
                         },
                     };
                 },
+                new Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop>(),
                 this.host.Services.GetRequiredService<ILogger<ChildOperator<WebDriverSession, V1Pod>>>()))
             {
                 // Start the operator


### PR DESCRIPTION
Feedback loops kick in whenever the ChildOperator detects a change in either the parent or child.
They can inspect the state of the parent and child object, and return a JSON patch (or `null`) which updates the parent with information from the child.

Examples of feedback loops are:

- When the WebDriverSession.Status.SessionId value is `null` and the pod which hosts the driver for that session is ready, create a new session and update the SessionId value
- Set the Phase of the WebDriverSession to Initializing when the pod which hosts the driver for that session is being created