### PR TITLE
Update Yarn key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Provision CI environment
         run: |
+          # Workaround for https://github.com/yarnpkg/yarn/issues/7866
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+
           sudo apt-get update
 
           ansible-galaxy install geerlingguy.docker


### PR DESCRIPTION
The GPG key for Yarn is being renewed, but the GitHub runner images have not been updated. See https://github.com/yarnpkg/yarn/issues/7866