### PR TITLE
Child Operator: Add fluent API for building and configuring child operators.

### DIFF
--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
@@ -1,0 +1,162 @@
+﻿// <copyright file="ChildOperatorBuilderTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Models;
+using Kaponata.Operator.Operators;
+using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Operator.Tests.Operators
+{
+    /// <summary>
+    /// Tests the <see cref="ChildOperatorBuilder"/> class.
+    /// </summary>
+    public class ChildOperatorBuilderTests
+    {
+        private readonly IHost host;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorBuilderTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// A <see cref="ITestOutputHelper"/> which captures test output.
+        /// </param>
+        public ChildOperatorBuilderTests(ITestOutputHelper output)
+        {
+            var builder = new HostBuilder();
+            builder.ConfigureServices(
+                (services) =>
+                {
+                    services.AddKubernetes();
+                    services.AddLogging(
+                        (loggingBuilder) =>
+                        {
+                            loggingBuilder.AddXunit(output);
+                        });
+                    services.AddScoped<ChildOperatorBuilder>();
+                });
+
+            this.host = builder.Build();
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperatorBuilder"/> constructor validates arguments passed to it.
+        /// </summary>
+        [Fact]
+        public void Builder1_Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("host", () => new ChildOperatorBuilder(null));
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperatorBuilder{TParent}"/> constructor validates arguments passed to it.
+        /// </summary>
+        [Fact]
+        public void Builder2_Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("host", () => new ChildOperatorBuilder<WebDriverSession>(null, new ChildOperatorConfiguration(string.Empty)));
+            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperatorBuilder<WebDriverSession>(Mock.Of<IHost>(), null));
+        }
+
+        /// <summary>
+        /// The <see cref="ChildOperatorBuilder{TParent, TChild}"/> constructor validates arguments passed to it.
+        /// </summary>
+        [Fact]
+        public void Builder3_Constructor_ValidatesArguments()
+        {
+            var host = Mock.Of<IHost>();
+            var configuration = new ChildOperatorConfiguration(string.Empty);
+            Func<WebDriverSession, bool> parentFilter = (session) => true;
+            Action<WebDriverSession, V1Pod> childFactory = (session, pod) => { };
+
+            Assert.Throws<ArgumentNullException>("host", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(null, configuration, parentFilter, childFactory));
+            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(host, null, parentFilter, childFactory));
+            Assert.Throws<ArgumentNullException>("parentFilter", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(host, configuration, null, childFactory));
+            Assert.Throws<ArgumentNullException>("childFactory", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(host, configuration, parentFilter, null));
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperatorBuilder{TParent}.Where(Func{TParent, bool})"/> validates the arguments passed to it.
+        /// </summary>
+        [Fact]
+        public void Where_ValidatesArguments()
+        {
+            var builder = new ChildOperatorBuilder<WebDriverSession>(Mock.Of<IHost>(), new ChildOperatorConfiguration(string.Empty));
+            Assert.Throws<ArgumentNullException>("parentFilter", () => builder.Where(null));
+        }
+
+        /// <summary>
+        /// <see cref="ChildOperatorBuilder{TParent, TChild}.PostsFeedback(ChildOperator{TParent, TChild}.FeedbackLoop)"/> validates
+        /// arguments passed to it.
+        /// </summary>
+        [Fact]
+        public void PostsFeedback_ValidatesArguments()
+        {
+            var builder = new ChildOperatorBuilder<WebDriverSession, V1Pod>(Mock.Of<IHost>(), new ChildOperatorConfiguration(string.Empty), (session) => true, (session, pod) => { });
+
+            Assert.Throws<ArgumentNullException>("feedbackLoop", () => builder.PostsFeedback(null));
+        }
+
+        /// <summary>
+        /// Simulates the building of a complex operator.
+        /// </summary>
+        [Fact]
+        public void CanBuildComplexOperator()
+        {
+            var builder = this.host.Services.GetRequiredService<ChildOperatorBuilder>();
+
+            var @operator = builder
+                .CreateOperator("my-operator")
+                .Watches<WebDriverSession>()
+                    .WithLabels((session) => session.Metadata.Annotations[Annotations.AutomationName] == Annotations.AutomationNames.Fake)
+                    .Where((session) => session.Status?.SessionId == null)
+                .Creates<V1Pod>((session, pod) =>
+                {
+                    pod.Spec = new V1PodSpec()
+                    {
+                        Containers = new V1Container[]
+                        {
+                            new V1Container()
+                            {
+                                Image = "quay.io/kaponata/fake-driver:2.0.1",
+                            },
+                        },
+                    };
+                })
+                .PostsFeedback((context, cancellationToken) =>
+                {
+                    var session = context.Parent;
+                    var pod = context.Child;
+
+                    JsonPatchDocument<WebDriverSession> patch;
+
+                    if (session.Status?.SessionId != null)
+                    {
+                        patch = null;
+                    }
+                    else if (pod.Status.Phase != "Running" || !pod.Status.ContainerStatuses.All(c => c.Ready))
+                    {
+                        patch = null;
+                    }
+                    else
+                    {
+                        patch = new JsonPatchDocument<WebDriverSession>();
+                        patch.Add(s => s.Status, new WebDriverSessionStatus() { SessionId = Guid.NewGuid().ToString() });
+                    }
+
+                    return Task.FromResult(patch);
+                }).Build();
+        }
+    }
+}

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="ChildOperatorBuilder.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Hosting;
+using System;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Builds <see cref="ChildOperator{TParent, TChild}"/> objects.
+    /// </summary>
+    public class ChildOperatorBuilder
+    {
+        private readonly IHost host;
+        private ChildOperatorConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorBuilder"/> class.
+        /// </summary>
+        /// <param name="host">
+        /// A host from which required services can be sourced.
+        /// </param>
+        public ChildOperatorBuilder(IHost host)
+        {
+            this.host = host ?? throw new ArgumentNullException(nameof(host));
+        }
+
+        /// <summary>
+        /// Configures the builder to create a new operator.
+        /// </summary>
+        /// <param name="operatorName">
+        /// The name of the operator to create.
+        /// </param>
+        /// <returns>
+        /// A builder which can be used to futher configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder CreateOperator(string operatorName)
+        {
+            this.configuration = new ChildOperatorConfiguration(operatorName);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the operator to watch objects of a given type.
+        /// </summary>
+        /// <typeparam name="TParent">
+        /// The type of parent objects to watch.
+        /// </typeparam>
+        /// <returns>
+        /// A builder which can be used to futher configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder<TParent> Watches<TParent>()
+            where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
+        {
+            return new ChildOperatorBuilder<TParent>(
+                this.host,
+                this.configuration);
+        }
+    }
+}

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent,TChild}.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent,TChild}.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="ChildOperatorBuilder{TParent,TChild}.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.ObjectModel;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Builds <see cref="ChildOperator{TParent, TChild}"/> objects.
+    /// </summary>
+    /// <typeparam name="TParent">
+    /// The parent object used by the <see cref="ChildOperator{TParent, TChild}"/>.
+    /// </typeparam>
+    /// <typeparam name="TChild">
+    /// The child object used by the <see cref="ChildOperator{TParent, TChild}"/>.
+    /// </typeparam>
+    public class ChildOperatorBuilder<TParent, TChild>
+            where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
+            where TChild : class, IKubernetesObject<V1ObjectMeta>, new()
+    {
+        private readonly ChildOperatorConfiguration configuration;
+        private readonly Action<TParent, TChild> childFactory;
+        private readonly Collection<ChildOperator<TParent, TChild>.FeedbackLoop> feedbackLoops = new ();
+        private readonly IHost host;
+        private Func<TParent, bool> parentFilter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorBuilder{TParent, TChild}"/> class.
+        /// </summary>
+        /// <param name="host">
+        /// The host from which to source required services.
+        /// </param>
+        /// <param name="configuration">
+        /// The configuration for the operator.
+        /// </param>
+        /// <param name="parentFilter">
+        /// A parent filter which defines which parent objects are considered, and which not.
+        /// </param>
+        /// <param name="childFactory">
+        /// A method which projects objects of type <typeparamref name="TParent"/> into objects of type
+        /// <typeparamref name="TChild"/>.
+        /// </param>
+        public ChildOperatorBuilder(IHost host, ChildOperatorConfiguration configuration, Func<TParent, bool> parentFilter, Action<TParent, TChild> childFactory)
+        {
+            this.host = host ?? throw new ArgumentNullException(nameof(host));
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            this.parentFilter = parentFilter ?? throw new ArgumentNullException(nameof(parentFilter));
+            this.childFactory = childFactory ?? throw new ArgumentNullException(nameof(childFactory));
+        }
+
+        /// <summary>
+        /// Adds a feedback loop to the operator.
+        /// </summary>
+        /// <param name="feedbackLoop">
+        /// The feedback loop to add to the operator.
+        /// </param>
+        /// <returns>
+        /// An operator builder which can be used to further configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder<TParent, TChild> PostsFeedback(
+            ChildOperator<TParent, TChild>.FeedbackLoop feedbackLoop)
+        {
+            if (feedbackLoop == null)
+            {
+                throw new ArgumentNullException(nameof(feedbackLoop));
+            }
+
+            this.feedbackLoops.Add(feedbackLoop);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Builds an operator.
+        /// </summary>
+        /// <returns>
+        /// A configured <see cref="ChildOperator{TParent, TChild}"/> object.
+        /// </returns>
+        public ChildOperator<TParent, TChild> Build()
+        {
+            var kubernetesClient = this.host.Services.GetRequiredService<KubernetesClient>();
+            var loggerFactory = this.host.Services.GetRequiredService<ILoggerFactory>();
+
+            return new ChildOperator<TParent, TChild>(
+                kubernetesClient,
+                this.configuration,
+                this.parentFilter,
+                this.childFactory,
+                this.feedbackLoops,
+                loggerFactory.CreateLogger<ChildOperator<TParent, TChild>>());
+        }
+    }
+}

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent}.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent}.cs
@@ -1,0 +1,108 @@
+﻿// <copyright file="ChildOperatorBuilder{TParent}.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Linq.Expressions;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Builds <see cref="ChildOperator{TParent, TChild}"/> objects.
+    /// </summary>
+    /// <typeparam name="TParent">
+    /// The parent object used by the <see cref="ChildOperator{TParent, TChild}"/>.
+    /// </typeparam>
+    public class ChildOperatorBuilder<TParent>
+            where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
+    {
+        private readonly IHost host;
+        private readonly ChildOperatorConfiguration configuration;
+        private Func<TParent, bool> parentFilter = (parent) => true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorBuilder{TParent}"/> class.
+        /// </summary>
+        /// <param name="host">
+        /// The host from which to source required services.
+        /// </param>
+        /// <param name="configuration">
+        /// The configuration to apply to the operator.
+        /// </param>
+        public ChildOperatorBuilder(IHost host, ChildOperatorConfiguration configuration)
+        {
+            this.host = host ?? throw new ArgumentNullException(nameof(host));
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        /// <summary>
+        /// Configures the operator to only consider parent items which have certain labels applied to them.
+        /// </summary>
+        /// <param name="labelSelector">
+        /// An expression which represents the label selector.
+        /// </param>
+        /// <returns>
+        /// A builder which can be used to further configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder<TParent> WithLabels(
+            Expression<Func<TParent, bool>> labelSelector)
+        {
+            return this.WithLabels(LabelSelector.Create(labelSelector));
+        }
+
+        /// <summary>
+        /// Configures the operator to only consider parent items which have certain labels applied to them.
+        /// </summary>
+        /// <param name="labelSelector">
+        /// The label selector.
+        /// </param>
+        /// <returns>
+        /// A builder which can be used to further configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder<TParent> WithLabels(
+            string labelSelector)
+        {
+            this.configuration.ParentLabelSelector = labelSelector;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the operator to filter parent object using a function.
+        /// </summary>
+        /// <param name="parentFilter">
+        /// A function which defines which parent object should be considered by the operator, and which not.
+        /// </param>
+        /// <returns>
+        /// A builder which can be used to further configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder<TParent> Where(Func<TParent, bool> parentFilter)
+        {
+            this.parentFilter = parentFilter ?? throw new ArgumentNullException(nameof(parentFilter));
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the operator to create child objects of a given type.
+        /// </summary>
+        /// <typeparam name="TChild">
+        /// The type of objects to create.
+        /// </typeparam>
+        /// <param name="childFactory">
+        /// An action which can be used to configure the newly created child objects.
+        /// </param>
+        /// <returns>
+        /// A builder which can be used to further configure the operator.
+        /// </returns>
+        public ChildOperatorBuilder<TParent, TChild> Creates<TChild>(
+            Action<TParent, TChild> childFactory)
+            where TChild : class, IKubernetesObject<V1ObjectMeta>, new()
+        {
+            return new ChildOperatorBuilder<TParent, TChild>(this.host, this.configuration, this.parentFilter, childFactory);
+        }
+    }
+}


### PR DESCRIPTION
For example:

```csharp
var @operator = builder
    .CreateOperator("my-operator")
    .Watches<WebDriverSession>()
        .WithLabels((session) => session.Metadata.Annotations[Annotations.AutomationName] == Annotations.AutomationNames.Fake)
        .Where((session) => session.Status?.SessionId == null)
    .Creates<V1Pod>((session, pod) =>
    {
        pod.Spec = new V1PodSpec()
        {
            Containers = new V1Container[]
            {
                new V1Container()
                {
                    Image = "quay.io/kaponata/fake-driver:2.0.1",
                },
            },
        };
    })
    .PostsFeedback((context, cancellationToken) =>
    {
        var session = context.Parent;
        var pod = context.Child;

        JsonPatchDocument<WebDriverSession> patch;

        if (session.Status?.SessionId != null)
        {
            patch = null;
        }
        else if (pod.Status.Phase != "Running" || !pod.Status.ContainerStatuses.All(c => c.Ready))
        {
            patch = null;
        }
        else
        {
            patch = new JsonPatchDocument<WebDriverSession>();
            patch.Add(s => s.Status, new WebDriverSessionStatus() { SessionId = Guid.NewGuid().ToString() });
        }

        return Task.FromResult(patch);
    }).Build();
```