### PR TITLE
Minor ChildOperator refactorings

### DIFF
--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
@@ -97,7 +97,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="ChildOperatorBuilder{TParent, TChild}.PostsFeedback(ChildOperator{TParent, TChild}.FeedbackLoop)"/> validates
+        /// <see cref="ChildOperatorBuilder{TParent, TChild}.PostsFeedback"/> validates
         /// arguments passed to it.
         /// </summary>
         [Fact]

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -124,7 +124,7 @@ namespace Kaponata.Operator.Tests.Operators
                         },
                     };
                 },
-                new Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop>(),
+                new Collection<FeedbackLoop<WebDriverSession, V1Pod>>(),
                 this.host.Services.GetRequiredService<ILogger<ChildOperator<WebDriverSession, V1Pod>>>()))
             {
                 // Start the operator

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
@@ -30,7 +30,7 @@ namespace Kaponata.Operator.Tests.Operators
         private readonly Func<WebDriverSession, bool> filter = (session) => true;
         private readonly Action<WebDriverSession, V1Pod> factory = (session, pod) => { };
         private readonly ILogger<ChildOperator<WebDriverSession, V1Pod>> logger = NullLogger<ChildOperator<WebDriverSession, V1Pod>>.Instance;
-        private readonly Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop> feedbackLoops = new Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop>();
+        private readonly Collection<FeedbackLoop<WebDriverSession, V1Pod>> feedbackLoops = new Collection<FeedbackLoop<WebDriverSession, V1Pod>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildOperatorTests"/> class.
@@ -252,9 +252,9 @@ namespace Kaponata.Operator.Tests.Operators
                 .ReturnsAsync(parent)
                 .Verifiable();
 
-            var feedbackLoops = new Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop>()
+            var feedbackLoops = new Collection<FeedbackLoop<WebDriverSession, V1Pod>>()
             {
-                new ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop((context, cancellationToken) =>
+                new FeedbackLoop<WebDriverSession, V1Pod>((context, cancellationToken) =>
                 {
                     return Task.FromResult(patch);
                 }),
@@ -293,9 +293,9 @@ namespace Kaponata.Operator.Tests.Operators
             var parent = new WebDriverSession();
             var child = new V1Pod();
 
-            var feedbackLoops = new Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop>()
+            var feedbackLoops = new Collection<FeedbackLoop<WebDriverSession, V1Pod>>()
             {
-                new ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop((context, cancellationToken) =>
+                new FeedbackLoop<WebDriverSession, V1Pod>((context, cancellationToken) =>
                 {
                     return Task.FromResult(patch);
                 }),
@@ -903,7 +903,7 @@ namespace Kaponata.Operator.Tests.Operators
                 this.configuration,
                 this.filter,
                 (session, pod) => { },
-                new Collection<ChildOperator<WebDriverSession, V1Pod>.FeedbackLoop>(),
+                new Collection<FeedbackLoop<WebDriverSession, V1Pod>>(),
                 this.logger))
             {
                 // Wait for the operator to start and complete initialization

--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.cs
@@ -54,6 +54,8 @@ namespace Kaponata.Operator.Kubernetes
             this.knownTypes.Add(typeof(MobileDevice), MobileDevice.KubeMetadata);
             this.knownTypes.Add(typeof(WebDriverSession), WebDriverSession.KubeMetadata);
             this.knownTypes.Add(typeof(V1Pod), new KindMetadata("core", V1Pod.KubeApiVersion, "pods"));
+            this.knownTypes.Add(typeof(V1Service), new KindMetadata("core", V1Service.KubeApiVersion, "services"));
+            this.knownTypes.Add(typeof(V1Ingress), new KindMetadata(V1Ingress.KubeGroup, V1Ingress.KubeApiVersion, "ingresses"));
 
             this.mobileDeviceClient = this.GetClient<MobileDevice>();
             this.webDriverSessionClient = this.GetClient<WebDriverSession>();

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent,TChild}.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent,TChild}.cs
@@ -28,7 +28,7 @@ namespace Kaponata.Operator.Operators
     {
         private readonly ChildOperatorConfiguration configuration;
         private readonly Action<TParent, TChild> childFactory;
-        private readonly Collection<ChildOperator<TParent, TChild>.FeedbackLoop> feedbackLoops = new ();
+        private readonly Collection<FeedbackLoop<TParent, TChild>> feedbackLoops = new ();
         private readonly IHost host;
         private Func<TParent, bool> parentFilter;
 
@@ -66,7 +66,7 @@ namespace Kaponata.Operator.Operators
         /// An operator builder which can be used to further configure the operator.
         /// </returns>
         public ChildOperatorBuilder<TParent, TChild> PostsFeedback(
-            ChildOperator<TParent, TChild>.FeedbackLoop feedbackLoop)
+            FeedbackLoop<TParent, TChild> feedbackLoop)
         {
             if (feedbackLoop == null)
             {

--- a/src/Kaponata.Operator/Operators/ChildOperatorContext.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorContext.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="ChildOperatorContext.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using System;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// The <see cref="ChildOperatorContext{TParent, TChild}"/> represents a specific instance of objects (parent + child)
+    /// which need to be reconciled.
+    /// </summary>
+    /// <typeparam name="TParent">
+    /// The type of object to watch for (such as <see cref="V1Pod"/>).
+    /// </typeparam>
+    /// <typeparam name="TChild">
+    /// The type of object to create (such as <see cref="V1Service"/>).
+    /// </typeparam>
+    public struct ChildOperatorContext<TParent, TChild>
+        where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
+        where TChild : class, IKubernetesObject<V1ObjectMeta>, new()
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildOperatorContext{TParent, TChild}"/> struct.
+        /// </summary>
+        /// <param name="parent">
+        /// The parent object being reconciled.
+        /// </param>
+        /// <param name="child">
+        /// The child object being reconciled.
+        /// </param>
+        public ChildOperatorContext(TParent parent, TChild child)
+        {
+            this.Parent = parent ?? throw new ArgumentNullException(nameof(parent));
+            this.Child = child;
+        }
+
+        /// <summary>
+        /// Gets the parent for which the reconciliation is being executed.
+        /// </summary>
+        public TParent Parent { get; }
+
+        /// <summary>
+        /// Gets the child for which the reconciliation is being executed. Can be <see langword="null"/>
+        /// if no child exists.
+        /// </summary>
+        public TChild Child { get; }
+    }
+}

--- a/src/Kaponata.Operator/Operators/FeedbackLoop.cs
+++ b/src/Kaponata.Operator/Operators/FeedbackLoop.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="FeedbackLoop.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Microsoft.AspNetCore.JsonPatch;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// A common delegate for all feedback loops. Decides whether the operator should provide feedback to the parent
+    /// (by altering its state) and, if necessary, creates a patch document which represents the feedback.
+    /// </summary>
+    /// <param name="context">
+    /// A <see cref="ChildOperatorContext{TParent, TChild}"/> object which represents the parent and child objects being
+    /// evaluated.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+    /// </param>
+    /// <typeparam name="TParent">
+    /// The type of object to watch for (such as <see cref="V1Pod"/>).
+    /// </typeparam>
+    /// <typeparam name="TChild">
+    /// The type of object to create (such as <see cref="V1Service"/>).
+    /// </typeparam>
+    /// <returns>
+    /// A <see cref="Task"/> which represents the asynchronous operation, and returns a <see cref="JsonPatchDocument{TModel}"/>
+    /// which describes the feedback if the child provides feedback to the parent (and the parent state should be alterated);
+    /// otherwise, <see langword="null"/>.
+    /// </returns>
+    public delegate Task<JsonPatchDocument<TParent>> FeedbackLoop<TParent, TChild>(
+        ChildOperatorContext<TParent, TChild> context,
+        CancellationToken cancellationToken)
+        where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
+        where TChild : class, IKubernetesObject<V1ObjectMeta>, new();
+}


### PR DESCRIPTION
- Move FeedbackLoop delegate to its own file
- Move ChildOperatorContext to its own file, convert class to struct