### PR TITLE
Pod.IsRunning: Only consider a pod to be running when all containers are ready.

### DIFF
--- a/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesClient.Pods.cs
@@ -397,7 +397,8 @@ namespace Kaponata.Operator.Kubernetes
 
         private static bool IsRunning(V1Pod value)
         {
-            return value.Status.Phase == "Running";
+            return value.Status.Phase == "Running"
+                && value.Status.ContainerStatuses.All(c => c.Ready);
         }
 
         private static bool HasFailed(V1Pod value, out Exception ex)


### PR DESCRIPTION
For example, the integration test for `KubernetsClient.CreatePodHttpClient` will attempt to connect to a port on a pod running nginx. These attempts will only succeed if nginx is ready, so have `IsPodRunning` return `true` only if all containers in the pod are considered to be ready.