### PR TITLE
WebDriverSession: Add Session, Ingress and Service status fields

### DIFF
--- a/src/Kaponata.Operator/Models/WebDriverSession.yaml
+++ b/src/Kaponata.Operator/Models/WebDriverSession.yaml
@@ -9,7 +9,7 @@ metadata:
     # operator to determine whether the CRD should be reinstalled or not.
     # Use the following command to determine that version:
     # nbgv get-version $(git rev-list -1 HEAD) -v NuGetPackageVersion
-    app.kubernetes.io/version: "0.2.17"
+    app.kubernetes.io/version: "0.2.23"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kaponata.io
@@ -44,6 +44,15 @@ spec:
                 capabilities:
                   description: The session capabilities, as determined by the server.
                   type: string
+                sessionReady:
+                  description: A value indicating whether the session is ready on the back-end pod.
+                  type: boolean
+                ingressReady:
+                  description: A value indicating whether the ingress rules are ready.
+                  type: boolean
+                serviceReady:
+                  description: A value indicating whether the service is ready.
+                  type: boolean
       # Shown in kubectl get
       additionalPrinterColumns:
       - name: URL

--- a/src/Kaponata.Operator/Models/WebDriverSessionStatus.cs
+++ b/src/Kaponata.Operator/Models/WebDriverSessionStatus.cs
@@ -22,5 +22,23 @@ namespace Kaponata.Operator.Models
         /// </summary>
         [JsonProperty("capabilities")]
         public string Capabilities { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the session is ready on the back-end pod.
+        /// </summary>
+        [JsonProperty("sessionReady")]
+        public bool SessionReady { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the ingress rules are ready.
+        /// </summary>
+        [JsonProperty("ingressReady")]
+        public bool IngressReady { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether service is ready.
+        /// </summary>
+        [JsonProperty("serviceReady")]
+        public bool ServiceReady { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the `WebDriverSession.Status.SessionReady`, `WebDriverSession.Status.ServiceReady` and `WebDriverSession.Status.IngressReady` fields.

The operators which take care of provisioning the sesssion, service and ingress populate these fields when they have completed.

Obeservers can use these fields to determine whether the session is ready (it is when all three fields are `true`).