### PR TITLE
ChildOperator: Have reconcilation be done based on name, not specific objects

### DIFF
--- a/src/Kaponata.Operator/Kubernetes/Annotations.cs
+++ b/src/Kaponata.Operator/Kubernetes/Annotations.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using Kaponata.Operator.Models;
+
 namespace Kaponata.Operator.Kubernetes
 {
     /// <summary>
@@ -61,6 +63,12 @@ namespace Kaponata.Operator.Kubernetes
         /// The name of the automation provider used for a WebDriver session.
         /// </summary>
         public const string AutomationName = "kaponata.io/automation-name";
+
+        /// <summary>
+        /// The name of the <see cref="WebDriverSession"/> object which owns
+        /// this object.
+        /// </summary>
+        public const string SessionName = "kaponata.io/session-name";
 
         /// <summary>
         /// Enumerates all automation names available.


### PR DESCRIPTION
The operator consists roughly of three concurrent tasks:
- Two watch tasks (one for parents and one for children), which detect changes to parents & children and schedule reconciliation whenever a change is detected
- A task which performs all reconciliations

The current implementation has the watch tasks post the state _at the moment the watch event is processed_ to the reconciliation queue.
If two events (e.g. an Added and a Modified event) come in shortly after each other, it is possible for the same (or similar) state to be pushed twice to the reconciliation queue, after which the reconcilation task will request the same change to be made. This results in a conflict.

This PR updates the reconciliation queue to consist only of the name of the parent/child pair to be reconciled. The reconciliation task will then fetch the _current_ state of the parent + child object and perform reconciliation, if needed.