### PR TITLE
Watcher: Support exceptionless cancellations

### DIFF
--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.Watch.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/KubernetesProtocolTests.Watch.cs
@@ -164,10 +164,14 @@ namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
                 },
                 cts.Token);
 
-            Assert.True(!watchTask.IsCompleted);
+            Assert.False(watchTask.IsCompleted);
             cts.Cancel();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => watchTask).ConfigureAwait(false);
+            await Task.WhenAny(
+                watchTask,
+                Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+
+            Assert.True(watchTask.IsCompletedSuccessfully);
 
             stream.Verify();
         }

--- a/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/StreamReaderExtensionsTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/Polyfill/StreamReaderExtensionsTests.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="StreamReaderExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Operator.Kubernetes.Polyfill;
+using Nerdbank.Streams;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// Tests the <see cref="StreamReaderExtensions"/> class.
+    /// </summary>
+    public class StreamReaderExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="StreamReaderExtensions.ReadLineAsync(StreamReader, CancellationToken)"/> returns <see langword="null"/>
+        /// when the task has been cancelled.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task Read_Cancelled_ReturnsNull_Async()
+        {
+            var stream = new SimplexStream();
+
+            using (var streamReader = new StreamReader(stream))
+            {
+                var cts = new CancellationTokenSource();
+                var task = streamReader.ReadLineAsync(cts.Token);
+                cts.Cancel();
+
+                Assert.Null(await task.ConfigureAwait(false));
+            }
+        }
+
+        /// <summary>
+        /// <see cref="StreamReaderExtensions.ReadLineAsync(StreamReader, CancellationToken)"/> returns the underlying data
+        /// when data is available.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReadLine_HasData_ReturnsValue_Async()
+        {
+            var stream = new SimplexStream();
+
+            using (var streamReader = new StreamReader(stream))
+            using (var streamWriter = new StreamWriter(stream))
+            {
+                var cts = new CancellationTokenSource();
+                var task = streamReader.ReadLineAsync(cts.Token);
+
+                await streamWriter.WriteLineAsync("Hello, World!".ToCharArray(), default).ConfigureAwait(false);
+                await streamWriter.FlushAsync().ConfigureAwait(false);
+
+                Assert.Equal("Hello, World!", await task.ConfigureAwait(false));
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
@@ -195,14 +195,12 @@ namespace Kaponata.Operator.Kubernetes.Polyfill
             using (var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
             using (var reader = new StreamReader(stream))
             {
-                cancellationToken.Register(watchContent.Dispose);
-
                 string line;
 
                 // ReadLineAsync will return null when we've reached the end of the stream.
                 try
                 {
-                    while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
+                    while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) != null)
                     {
                         var genericEvent =
                             SafeJsonConvert.DeserializeObject<Watcher<KubernetesObject>.WatchEvent>(line);

--- a/src/Kaponata.Operator/Kubernetes/Polyfill/StreamReaderExtensions.cs
+++ b/src/Kaponata.Operator/Kubernetes/Polyfill/StreamReaderExtensions.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="StreamReaderExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Kubernetes.Polyfill
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="StreamReader"/> class.
+    /// </summary>
+    public static class StreamReaderExtensions
+    {
+        /// <summary>
+        /// Asynchronously read a line, or returns <see langword="null"/> when the operation is being
+        /// cancelled.
+        /// </summary>
+        /// <param name="reader">
+        /// The reader from which to read the data.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation;
+        /// after which the method will return <see langword="null"/>.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static async Task<string> ReadLineAsync(this StreamReader reader, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<string>();
+            cancellationToken.Register(() => tcs.SetResult(null));
+
+            var completedTask = await Task.WhenAny(reader.ReadLineAsync(), tcs.Task).ConfigureAwait(false);
+            return await completedTask.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
Currently, when a Watch operation is cancelled, the HttpResponse is disposed off. This causes an IOException in `ReadLineAsync`.

Avoid this exception by adding an `ReadLineAsync(cancellationToken)` instead, which will return `null` when a cancellation is requested.