### PR TITLE
fake-driver: List on all addresses, not just localhost

### DIFF
--- a/src/fake-driver/Dockerfile
+++ b/src/fake-driver/Dockerfile
@@ -36,4 +36,4 @@ LABEL org.opencontainers.image.ref.name=$GIT_REF
 
 COPY --from=build /src/node_modules/ /app/
 
-CMD [ "/app/appium-fake-driver/build/index.js" ]
+CMD [ "/app/appium-fake-driver/build/index.js", "--host", "0.0.0.0" ]


### PR DESCRIPTION
By default, the fake driver will listen on `127.0.0.1`, which means the port is not accessible externally. Pass `--host 0.0.0.0` so the port is accessible via the cluster network.