### PR TITLE
Avoid stale manifests by re-creating them

### DIFF
--- a/src/adb/Makefile
+++ b/src/adb/Makefile
@@ -5,6 +5,7 @@ all: .amd64.docker-id .version
 
 push: all
 	docker push $(registry)/$(image):latest-amd64
+	docker manifest rm $(registry)/$(image):$(shell cat .version) || echo "Manifest does not exist"
 	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 

--- a/src/fake-driver/Makefile
+++ b/src/fake-driver/Makefile
@@ -6,6 +6,7 @@ all: .arm64.docker-id .amd64.docker-id .version
 push: all
 	docker push $(registry)/$(image):latest-amd64
 	docker push $(registry)/$(image):latest-arm64
+	docker manifest rm $(registry)/$(image):$(shell cat .version) || echo "Manifest does not exist"
 	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64 $(registry)/$(image):latest-arm64
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 

--- a/src/iproxy/Makefile
+++ b/src/iproxy/Makefile
@@ -6,6 +6,7 @@ all: .arm64.docker-id .amd64.docker-id .version
 push: all
 	docker push $(registry)/$(image):latest-amd64
 	docker push $(registry)/$(image):latest-arm64
+	docker manifest rm $(registry)/$(image):$(shell cat .version) || echo "Manifest does not exist"
 	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64 $(registry)/$(image):latest-arm64
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 

--- a/src/usbmuxd/Makefile
+++ b/src/usbmuxd/Makefile
@@ -6,6 +6,7 @@ all: .arm64.docker-id .amd64.docker-id .amd64.udev.docker-id .version
 push: all
 	docker push $(registry)/$(image):latest-amd64
 	docker push $(registry)/$(image):latest-arm64
+	docker manifest rm $(registry)/$(image):$(shell cat .version) || echo "Manifest does not exist"
 	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64 $(registry)/$(image):latest-arm64
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 	


### PR DESCRIPTION
Running `make push` repeatedly in scenarios where the manifest tag did not change (not a best practice but something which happens during test cycles) would result in the `latest-amd64` and `latest-arm64` being updated on the registry, but the remote manifest itself would still point to older images.

Add a `docker manifest rm` to work around this.