### PR TITLE
Kaponata.Kubernetes: Enable nullable annotations

### DIFF
--- a/src/Kaponata.Kubernetes/FieldSelector.cs
+++ b/src/Kaponata.Kubernetes/FieldSelector.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/Kaponata.Kubernetes.csproj
+++ b/src/Kaponata.Kubernetes/Kaponata.Kubernetes.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Kubernetes/KubernetesClient.Crd.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.Crd.cs
@@ -54,7 +54,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested custom resource definition., or
         /// <see langword="null"/> if the custom resource definition does not exist.
         /// </returns>
-        public virtual async Task<V1CustomResourceDefinition> TryReadCustomResourceDefinitionAsync(string name, CancellationToken cancellationToken)
+        public virtual async Task<V1CustomResourceDefinition?> TryReadCustomResourceDefinitionAsync(string name, CancellationToken cancellationToken)
         {
             var list = await this.RunTaskAsync(this.protocol.ListCustomResourceDefinitionAsync(fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
             return list.Items.SingleOrDefault();

--- a/src/Kaponata.Kubernetes/KubernetesClient.Delete.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.Delete.cs
@@ -64,15 +64,15 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        public delegate Task<T> DeleteNamespacedObjectAsyncDelegate<T>(
+        public delegate Task<T?> DeleteNamespacedObjectAsyncDelegate<T>(
             string name,
             string namespaceParameter,
-            V1DeleteOptions body = null,
-            string dryRun = null,
+            V1DeleteOptions? body = null,
+            string? dryRun = null,
             int? gracePeriodSeconds = null,
             bool? orphanDependents = null,
-            string propagationPolicy = null,
-            string pretty = null,
+            string? propagationPolicy = null,
+            string? pretty = null,
             CancellationToken cancellationToken = default)
             where T : IKubernetesObject<V1ObjectMeta>;
 
@@ -162,7 +162,7 @@ namespace Kaponata.Kubernetes
         /// </returns>
         public virtual async Task DeleteNamespacedObjectAsync<T>(
             T value,
-            V1DeleteOptions options,
+            V1DeleteOptions? options,
             DeleteNamespacedObjectAsyncDelegate<T> deleteAction,
             WatchObjectAsyncDelegate<T> watchAction,
             TimeSpan timeout,

--- a/src/Kaponata.Kubernetes/KubernetesClient.MobileDevice.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.MobileDevice.cs
@@ -91,7 +91,13 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="MobileDeviceList"/> which represents the mobile devices which match the query.
         /// </returns>
-        public virtual Task<ItemList<MobileDevice>> ListMobileDeviceAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        public virtual Task<ItemList<MobileDevice>> ListMobileDeviceAsync(
+            string @namespace,
+            string? @continue = null,
+            string? fieldSelector = null,
+            string? labelSelector = null,
+            int? limit = null,
+            CancellationToken cancellationToken = default)
         {
             return this.mobileDeviceClient.ListAsync(
                 @namespace: @namespace,
@@ -118,7 +124,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested mobile device, or
         /// <see langword="null"/> if the mobile device does not exist.
         /// </returns>
-        public virtual Task<MobileDevice> TryReadMobileDeviceAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual Task<MobileDevice?> TryReadMobileDeviceAsync(string @namespace, string name, CancellationToken cancellationToken)
         {
             return this.mobileDeviceClient.TryReadAsync(@namespace, name, cancellationToken);
         }

--- a/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -188,16 +188,16 @@ namespace Kaponata.Kubernetes
             KindMetadata kind,
             string namespaceParameter,
             bool? allowWatchBookmarks = null,
-            string continueParameter = null,
-            string fieldSelector = null,
-            string labelSelector = null,
+            string? continueParameter = null,
+            string? fieldSelector = null,
+            string? labelSelector = null,
             int? limit = null,
-            string resourceVersion = null,
-            string resourceVersionMatch = null,
+            string? resourceVersion = null,
+            string? resourceVersionMatch = null,
             int? timeoutSeconds = null,
             bool? watch = null,
-            string pretty = null,
-            Dictionary<string, List<string>> customHeaders = null,
+            string? pretty = null,
+            Dictionary<string, List<string>>? customHeaders = null,
             CancellationToken cancellationToken = default)
             where TList : IItems<TObject>
             where TObject : IKubernetesObject<V1ObjectMeta>
@@ -293,16 +293,16 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        public async Task<T> DeleteNamespacedObjectAsync<T>(
+        public async Task<T?> DeleteNamespacedObjectAsync<T>(
             KindMetadata kind,
             string name,
             string namespaceParameter,
-            V1DeleteOptions body = null,
-            string dryRun = null,
+            V1DeleteOptions? body = null,
+            string? dryRun = null,
             int? gracePeriodSeconds = null,
             bool? orphanDependents = null,
-            string propagationPolicy = null,
-            string pretty = null,
+            string? propagationPolicy = null,
+            string? pretty = null,
             CancellationToken cancellationToken = default)
             where T : IKubernetesObject<V1ObjectMeta>
         {

--- a/src/Kaponata.Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.Pods.cs
@@ -8,6 +8,7 @@ using Kaponata.Kubernetes.Polyfill;
 using Microsoft.Extensions.Logging;
 using Microsoft.Rest;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -65,7 +66,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested pod, or
         /// <see langword="null"/> if the pod does not exist.
         /// </returns>
-        public virtual async Task<V1Pod> TryReadPodAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual async Task<V1Pod?> TryReadPodAsync(string @namespace, string name, CancellationToken cancellationToken)
         {
             var list = await this.RunTaskAsync(this.protocol.ListNamespacedPodAsync(@namespace, fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
             return list.Items.SingleOrDefault();
@@ -129,7 +130,7 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="V1PodList"/> which represents the mobile devices which match the query.
         /// </returns>
-        public async virtual Task<V1PodList> ListPodAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        public async virtual Task<V1PodList> ListPodAsync(string @namespace, string? @continue = null, string? fieldSelector = null, string? labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             using (var operationResponse = await this.RunTaskAsync(this.protocol.ListNamespacedPodWithHttpMessagesAsync(
                 namespaceParameter: @namespace,
@@ -253,7 +254,7 @@ namespace Kaponata.Kubernetes
                 return value;
             }
 
-            if (HasFailed(value, out Exception ex))
+            if (HasFailed(value, out Exception? ex))
             {
                 throw ex;
             }
@@ -279,7 +280,7 @@ namespace Kaponata.Kubernetes
                         return Task.FromResult(WatchResult.Stop);
                     }
 
-                    if (HasFailed(value, out Exception ex))
+                    if (HasFailed(value, out Exception? ex))
                     {
                         throw ex;
                     }
@@ -401,7 +402,7 @@ namespace Kaponata.Kubernetes
                 && value.Status.ContainerStatuses.All(c => c.Ready);
         }
 
-        private static bool HasFailed(V1Pod value, out Exception ex)
+        private static bool HasFailed(V1Pod value, [NotNullWhen(true)] out Exception? ex)
         {
             if (value.Status.Phase == "Failed")
             {

--- a/src/Kaponata.Kubernetes/KubernetesClient.WebDriverSession.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.WebDriverSession.cs
@@ -91,7 +91,13 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="MobileDeviceList"/> which represents the mobile devices which match the query.
         /// </returns>
-        public virtual Task<ItemList<WebDriverSession>> ListWebDriverSessionAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        public virtual Task<ItemList<WebDriverSession>> ListWebDriverSessionAsync(
+            string @namespace,
+            string? @continue = null,
+            string? fieldSelector = null,
+            string? labelSelector = null,
+            int? limit = null,
+            CancellationToken cancellationToken = default)
         {
             return this.webDriverSessionClient.ListAsync(@namespace, @continue, fieldSelector, labelSelector, limit, cancellationToken);
         }
@@ -112,7 +118,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested WebDriver session, or
         /// <see langword="null"/> if the WebDriver session does not exist.
         /// </returns>
-        public virtual Task<WebDriverSession> TryReadWebDriverSessionAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual Task<WebDriverSession?> TryReadWebDriverSessionAsync(string @namespace, string name, CancellationToken cancellationToken)
         {
             return this.webDriverSessionClient.TryReadAsync(@namespace, name, cancellationToken);
         }

--- a/src/Kaponata.Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.cs
@@ -61,6 +61,7 @@ namespace Kaponata.Kubernetes
             this.webDriverSessionClient = this.GetClient<WebDriverSession>();
         }
 
+#nullable disable
         /// <summary>
         /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
         /// </summary>
@@ -72,6 +73,7 @@ namespace Kaponata.Kubernetes
             this.logger = NullLogger<KubernetesClient>.Instance;
             this.loggerFactory = NullLoggerFactory.Instance;
         }
+#nullable restore
 
         /// <summary>
         /// A delegate for a method which asynchronously watches a (namespaced) object.

--- a/src/Kaponata.Kubernetes/LabelSelector.cs
+++ b/src/Kaponata.Kubernetes/LabelSelector.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/Models/ItemList.cs
+++ b/src/Kaponata.Kubernetes/Models/ItemList.cs
@@ -7,6 +7,8 @@ using k8s.Models;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes.Models
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/Models/MobileDevice.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDevice.cs
@@ -4,8 +4,9 @@
 
 using k8s;
 using k8s.Models;
-using Kaponata.Kubernetes;
 using Newtonsoft.Json;
+
+#nullable disable
 
 namespace Kaponata.Kubernetes.Models
 {

--- a/src/Kaponata.Kubernetes/Models/MobileDeviceSpec.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDeviceSpec.cs
@@ -4,6 +4,8 @@
 
 using Newtonsoft.Json;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes.Models
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/Models/MobileDeviceStatus.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDeviceStatus.cs
@@ -4,6 +4,8 @@
 
 using Newtonsoft.Json;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes.Models
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/Models/ModelDefinitions.cs
+++ b/src/Kaponata.Kubernetes/Models/ModelDefinitions.cs
@@ -20,7 +20,7 @@ namespace Kaponata.Kubernetes.Models
         {
             get
             {
-                using (Stream stream = typeof(ModelDefinitions).Assembly.GetManifestResourceStream("Kaponata.Kubernetes.Models.MobileDevice.yaml"))
+                using (Stream stream = typeof(ModelDefinitions).Assembly.GetManifestResourceStream("Kaponata.Kubernetes.Models.MobileDevice.yaml") !)
                 using (StreamReader reader = new StreamReader(stream))
                 {
                     return Yaml.LoadFromString<V1CustomResourceDefinition>(reader.ReadToEnd());
@@ -35,7 +35,7 @@ namespace Kaponata.Kubernetes.Models
         {
             get
             {
-                using (Stream stream = typeof(ModelDefinitions).Assembly.GetManifestResourceStream("Kaponata.Kubernetes.Models.WebDriverSession.yaml"))
+                using (Stream stream = typeof(ModelDefinitions).Assembly.GetManifestResourceStream("Kaponata.Kubernetes.Models.WebDriverSession.yaml") !)
                 using (StreamReader reader = new StreamReader(stream))
                 {
                     return Yaml.LoadFromString<V1CustomResourceDefinition>(reader.ReadToEnd());

--- a/src/Kaponata.Kubernetes/Models/WebDriverSession.cs
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSession.cs
@@ -4,8 +4,9 @@
 
 using k8s;
 using k8s.Models;
-using Kaponata.Kubernetes;
 using Newtonsoft.Json;
+
+#nullable disable
 
 namespace Kaponata.Kubernetes.Models
 {

--- a/src/Kaponata.Kubernetes/Models/WebDriverSessionSpec.cs
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSessionSpec.cs
@@ -4,6 +4,8 @@
 
 using Newtonsoft.Json;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes.Models
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/Models/WebDriverSessionStatus.cs
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSessionStatus.cs
@@ -4,6 +4,8 @@
 
 using Newtonsoft.Json;
 
+#nullable disable
+
 namespace Kaponata.Kubernetes.Models
 {
     /// <summary>

--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
@@ -44,6 +44,7 @@ namespace Kaponata.Kubernetes
             this.metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
         }
 
+#nullable disable
         /// <summary>
         /// Initializes a new instance of the <see cref="NamespacedKubernetesClient{T}"/> class.
         /// </summary>
@@ -53,6 +54,7 @@ namespace Kaponata.Kubernetes
         protected NamespacedKubernetesClient()
         {
         }
+#nullable restore
 
         /// <summary>
         /// Asynchronously creates a new <typeparamref name="T"/> object.
@@ -133,7 +135,7 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="ItemList{T}"/> which represents the mobile devices which match the query.
         /// </returns>
-        public async virtual Task<ItemList<T>> ListAsync(string @namespace, string @continue = null, string fieldSelector = null, string labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        public async virtual Task<ItemList<T>> ListAsync(string @namespace, string? @continue = null, string? fieldSelector = null, string? labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             using (var operationResponse = await this.ListAsync(
                 namespaceParameter: @namespace,
@@ -162,7 +164,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested <typeparamref name="T"/> object, or
         /// <see langword="null"/> if the <typeparamref name="T"/> object does not exist.
         /// </returns>
-        public virtual Task<T> TryReadAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual Task<T?> TryReadAsync(string @namespace, string name, CancellationToken cancellationToken)
         {
             return this.TryReadAsync(@namespace, name, labelSelector: null, cancellationToken);
         }
@@ -186,7 +188,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested <typeparamref name="T"/> object, or
         /// <see langword="null"/> if the <typeparamref name="T"/> object does not exist.
         /// </returns>
-        public virtual async Task<T> TryReadAsync(string @namespace, string name, string labelSelector, CancellationToken cancellationToken)
+        public virtual async Task<T?> TryReadAsync(string @namespace, string name, string? labelSelector, CancellationToken cancellationToken)
         {
             if (@namespace == null)
             {
@@ -199,7 +201,7 @@ namespace Kaponata.Kubernetes
             }
 
             var list = await this.parent.RunTaskAsync(this.ListAsync(namespaceParameter: @namespace, fieldSelector: $"metadata.name={name}", labelSelector: labelSelector, cancellationToken: cancellationToken)).ConfigureAwait(false);
-            return list.Body.Items.SingleOrDefault();
+            return list.Body?.Items?.SingleOrDefault();
         }
 
         /// <summary>
@@ -218,7 +220,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation, and which returns the deleted object if an object was deleted.</returns>
-        public virtual async Task<T> TryDeleteAsync(string @namespace, string name, TimeSpan timeout, CancellationToken cancellationToken)
+        public virtual async Task<T?> TryDeleteAsync(string @namespace, string name, TimeSpan timeout, CancellationToken cancellationToken)
         {
             if (@namespace == null)
             {
@@ -280,7 +282,7 @@ namespace Kaponata.Kubernetes
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual Task DeleteAsync(T value, V1DeleteOptions options, TimeSpan timeout, CancellationToken cancellationToken)
+        public virtual Task DeleteAsync(T value, V1DeleteOptions? options, TimeSpan timeout, CancellationToken cancellationToken)
         {
             return this.parent.DeleteNamespacedObjectAsync<T>(
                 value,
@@ -470,16 +472,16 @@ namespace Kaponata.Kubernetes
         private Task<HttpOperationResponse<ItemList<T>>> ListAsync(
             string namespaceParameter,
             bool? allowWatchBookmarks = null,
-            string continueParameter = null,
-            string fieldSelector = null,
-            string labelSelector = null,
+            string? continueParameter = null,
+            string? fieldSelector = null,
+            string? labelSelector = null,
             int? limit = null,
-            string resourceVersion = null,
-            string resourceVersionMatch = null,
+            string? resourceVersion = null,
+            string? resourceVersionMatch = null,
             int? timeoutSeconds = null,
             bool? watch = null,
-            string pretty = null,
-            Dictionary<string, List<string>> customHeaders = null,
+            string? pretty = null,
+            Dictionary<string, List<string>>? customHeaders = null,
             CancellationToken cancellationToken = default)
         {
             return this.parent.ListNamespacedObjectAsync<T, ItemList<T>>(
@@ -499,15 +501,15 @@ namespace Kaponata.Kubernetes
                 cancellationToken);
         }
 
-        private Task<T> DeleteAsync(
+        private Task<T?> DeleteAsync(
             string name,
             string namespaceParameter,
-            V1DeleteOptions body = null,
-            string dryRun = null,
+            V1DeleteOptions? body = null,
+            string? dryRun = null,
             int? gracePeriodSeconds = null,
             bool? orphanDependents = null,
-            string propagationPolicy = null,
-            string pretty = null,
+            string? propagationPolicy = null,
+            string? pretty = null,
             CancellationToken cancellationToken = default)
         {
             return this.parent.DeleteNamespacedObjectAsync<T>(

--- a/src/Kaponata.Kubernetes/Polyfill/CoreApiHandler.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/CoreApiHandler.cs
@@ -33,7 +33,7 @@ namespace Kaponata.Kubernetes.Polyfill
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (request.RequestUri.AbsolutePath.StartsWith("/apis/core/v1/"))
+            if (request.RequestUri != null && request.RequestUri.AbsolutePath.StartsWith("/apis/core/v1/"))
             {
                 var builder = new UriBuilder(request.RequestUri);
                 builder.Path = builder.Path.Replace("/apis/core/v1/", "/api/v1/");

--- a/src/Kaponata.Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
@@ -92,9 +92,9 @@ namespace Kaponata.Kubernetes.Polyfill
         /// <inheritdoc/>
         public async Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
             string @namespace,
-            string fieldSelector,
-            string labelSelector,
-            string resourceVersion,
+            string? fieldSelector,
+            string? labelSelector,
+            string? resourceVersion,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
             WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
@@ -195,7 +195,7 @@ namespace Kaponata.Kubernetes.Polyfill
             using (var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
             using (var reader = new StreamReader(stream))
             {
-                string line;
+                string? line;
 
                 // ReadLineAsync will return null when we've reached the end of the stream.
                 try

--- a/src/Kaponata.Kubernetes/Polyfill/ListNamespacedObjectWithHttpMessagesAsyncDelegate.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/ListNamespacedObjectWithHttpMessagesAsyncDelegate.cs
@@ -112,16 +112,16 @@ namespace Kaponata.Kubernetes.Polyfill
         Task<HttpOperationResponse<TList>> ListNamespacedObjectWithHttpMessagesAsync<TObject, TList>(
         string namespaceParameter,
         bool? allowWatchBookmarks = null,
-        string continueParameter = null,
-        string fieldSelector = null,
-        string labelSelector = null,
+        string? continueParameter = null,
+        string? fieldSelector = null,
+        string? labelSelector = null,
         int? limit = null,
-        string resourceVersion = null,
-        string resourceVersionMatch = null,
+        string? resourceVersion = null,
+        string? resourceVersionMatch = null,
         int? timeoutSeconds = null,
         bool? watch = null,
-        string pretty = null,
-        Dictionary<string, List<string>> customHeaders = null,
+        string? pretty = null,
+        Dictionary<string, List<string>>? customHeaders = null,
         CancellationToken cancellationToken = default)
         where TObject : IKubernetesObject<V1ObjectMeta>
         where TList : IItems<TObject>;

--- a/src/Kaponata.Kubernetes/Polyfill/StreamReaderExtensions.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/StreamReaderExtensions.cs
@@ -25,9 +25,9 @@ namespace Kaponata.Kubernetes.Polyfill
         /// after which the method will return <see langword="null"/>.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task<string> ReadLineAsync(this StreamReader reader, CancellationToken cancellationToken)
+        public static async Task<string?> ReadLineAsync(this StreamReader reader, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<string>();
+            var tcs = new TaskCompletionSource<string?>();
             cancellationToken.Register(() => tcs.SetResult(null));
 
             var completedTask = await Task.WhenAny(reader.ReadLineAsync(), tcs.Task).ConfigureAwait(false);

--- a/src/Kaponata.Kubernetes/Polyfill/WatchHandler.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/WatchHandler.cs
@@ -34,7 +34,7 @@ namespace Kaponata.Kubernetes.Polyfill
             var originResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // all watches are GETs, so we can ignore others
-            if (originResponse.IsSuccessStatusCode && request.Method == HttpMethod.Get)
+            if (originResponse.IsSuccessStatusCode && request.Method == HttpMethod.Get && request.RequestUri != null)
             {
                 var query = request.RequestUri.Query;
                 var index = query.IndexOf("watch=true", StringComparison.InvariantCulture);

--- a/src/Kaponata.Kubernetes/Polyfill/WatchHttpContent.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/WatchHttpContent.cs
@@ -35,7 +35,7 @@ namespace Kaponata.Kubernetes.Polyfill
         { get; private set; }
 
         /// <inheritdoc/>
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
         {
             return Task.CompletedTask;
         }

--- a/src/Kaponata.Kubernetes/Selector.cs
+++ b/src/Kaponata.Kubernetes/Selector.cs
@@ -21,7 +21,7 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// The equivalent selector string.
         /// </returns>
-        public static string Create(Dictionary<string, string> values)
+        public static string? Create(Dictionary<string, string> values)
         {
             if (values == null || values.Count == 0)
             {


### PR DESCRIPTION
Notable exceptions are:
- Kubernetes models: Nullable annotations are disabled (in line with upstream KubernetesClient)
- LabelSelector and FieldSelector classes: annotations are disabled