### PR TITLE
Fake Operator: Enable by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -142,6 +142,7 @@ jobs:
       - name: Create k3d cluster
         run: |
           k3d cluster create --api-port 6433 -p "80:80@loadbalancer"
+          kubectl create namespace tests
 
       # We don't built Docker crossarch manifests during CI, so tag the {version}-amd64 image
       # as the {version} image. Then, import the image into k3d.

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.MobileDevice.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.MobileDevice.cs
@@ -58,6 +58,7 @@ namespace Kaponata.Kubernetes.Tests
                             Metadata = new V1ObjectMeta()
                             {
                                 Name = "test",
+                                NamespaceProperty = "my-namespace",
                             },
                         },
                         default)).ConfigureAwait(false);

--- a/src/Kaponata.Kubernetes.Tests/KubernetesServiceCollectionExtensionsTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesServiceCollectionExtensionsTests.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using Kaponata.Kubernetes;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using Xunit;
@@ -38,7 +37,37 @@ namespace Kaponata.Kubernetes.Tests
             {
                 var client = serviceProvider.GetRequiredService<KubernetesClient>();
                 Assert.NotNull(client);
+                Assert.Equal("default", client.Options.Namespace);
             }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesServiceCollectionExtensions.AddKubernetes"/> works correctly, and uses the correct
+        /// namespace.
+        /// </summary>
+        [Fact]
+        public void AddKubernetes_WithNamespace_Works()
+        {
+            var collection = new ServiceCollection();
+            collection.AddLogging();
+            collection.AddKubernetes(@namespace: "my-namespace");
+
+            using (var serviceProvider = collection.BuildServiceProvider())
+            {
+                var client = serviceProvider.GetRequiredService<KubernetesClient>();
+                Assert.NotNull(client);
+                Assert.Equal("my-namespace", client.Options.Namespace);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesServiceCollectionExtensions.AddKubernetes"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void AddKubernetes_WithNullNamespace_Throws()
+        {
+            var collection = new ServiceCollection();
+            Assert.Throws<ArgumentNullException>("namespace", () => collection.AddKubernetes(@namespace: null));
         }
     }
 }

--- a/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -435,9 +435,6 @@ namespace Kaponata.Kubernetes
         /// <param name="metadata">
         /// Metadata which describes the object type.
         /// </param>
-        /// <param name="namespace">
-        /// The namespace of the object to patch.
-        /// </param>
         /// <param name="name">
         /// The name of the object to patch.
         /// </param>

--- a/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -63,16 +63,18 @@ namespace Kaponata.Kubernetes
                 throw new ValidationException(ValidationRules.CannotBeNull, "value.Metadata.Name");
             }
 
-            if (value.Metadata.NamespaceProperty == null)
+            // Null values will default to the namespace configured in the options. If the caller was explicit about the
+            // namespace, accept it if it is the configured namespace, and throw if it was not.
+            if (value.Metadata.NamespaceProperty != null && value.Metadata.NamespaceProperty != this.Options.Namespace)
             {
-                throw new ValidationException(ValidationRules.CannotBeNull, "value.Metadata.NamespaceProperty");
+                throw new ValidationException(ValidationRules.Pattern, "value.Metadata.NamespaceProperty must match the namespace in the Kubernetes options.");
             }
 
             using (var operationResponse = await this.RunTaskAsync(this.protocol.CreateNamespacedCustomObjectWithHttpMessagesAsync(
                 value,
                 kind.Group,
                 kind.Version,
-                value.Metadata.NamespaceProperty,
+                this.Options.Namespace,
                 kind.Plural,
                 cancellationToken: cancellationToken)).ConfigureAwait(false))
             {
@@ -450,7 +452,6 @@ namespace Kaponata.Kubernetes
         /// </returns>
         public async Task<T> PatchNamespacedObjectAsync<T>(
             KindMetadata metadata,
-            string @namespace,
             string name,
             V1Patch patch,
             CancellationToken cancellationToken)
@@ -459,7 +460,7 @@ namespace Kaponata.Kubernetes
                 patch,
                 metadata.Group,
                 metadata.Version,
-                @namespace,
+                this.Options.Namespace,
                 metadata.Plural,
                 name,
                 null,
@@ -503,7 +504,7 @@ namespace Kaponata.Kubernetes
                 patch,
                 metadata.Group,
                 metadata.Version,
-                this.options.Value.Namespace,
+                this.Options.Namespace,
                 metadata.Plural,
                 name,
                 null,

--- a/src/Kaponata.Kubernetes/KubernetesServiceCollectionExtensions.cs
+++ b/src/Kaponata.Kubernetes/KubernetesServiceCollectionExtensions.cs
@@ -20,19 +20,29 @@ namespace Kaponata.Kubernetes
         /// <param name="services">
         /// The <see cref="IServiceCollection"/> to add services to.
         /// </param>
+        /// <param name="namespace">
+        /// The namespace in which to operate. The default value is <c>default</c>.
+        /// </param>
         /// <returns>
         /// The <see cref="IServiceCollection"/> so that additional calls can be chained.
         /// </returns>
-        public static IServiceCollection AddKubernetes(this IServiceCollection services)
+        public static IServiceCollection AddKubernetes(this IServiceCollection services, string @namespace = "default")
         {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
+            if (@namespace == null)
+            {
+                throw new ArgumentNullException(nameof(@namespace));
+            }
+
             services.AddSingleton<KubernetesClientConfiguration>(KubernetesClientConfiguration.BuildDefaultConfig());
             services.AddSingleton<IKubernetesProtocol, KubernetesProtocol>();
             services.AddSingleton<KubernetesClient>();
+
+            services.AddOptions<KubernetesOptions>().Configure(c => c.Namespace = @namespace);
             return services;
         }
     }

--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
@@ -378,7 +378,6 @@ namespace Kaponata.Kubernetes
 
             return this.parent.PatchNamespacedObjectAsync<T>(
                 this.metadata,
-                value.Metadata.NamespaceProperty,
                 value.Metadata.Name,
                 new V1Patch(patch, V1Patch.PatchType.JsonPatch),
                 cancellationToken);

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
@@ -56,7 +56,7 @@ namespace Kaponata.Operator.Tests.Operators
         [Fact]
         public void Builder1_Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("host", () => new ChildOperatorBuilder(null));
+            Assert.Throws<ArgumentNullException>("services", () => new ChildOperatorBuilder(null));
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace Kaponata.Operator.Tests.Operators
         [Fact]
         public void Builder2_Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("host", () => new ChildOperatorBuilder<WebDriverSession>(null, new ChildOperatorConfiguration(string.Empty)));
-            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperatorBuilder<WebDriverSession>(Mock.Of<IHost>(), null));
+            Assert.Throws<ArgumentNullException>("services", () => new ChildOperatorBuilder<WebDriverSession>(null, new ChildOperatorConfiguration(string.Empty)));
+            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperatorBuilder<WebDriverSession>(Mock.Of<IServiceProvider>(), null));
         }
 
         /// <summary>
@@ -75,15 +75,15 @@ namespace Kaponata.Operator.Tests.Operators
         [Fact]
         public void Builder3_Constructor_ValidatesArguments()
         {
-            var host = Mock.Of<IHost>();
+            var serviceProvider = Mock.Of<IServiceProvider>();
             var configuration = new ChildOperatorConfiguration(string.Empty);
             Func<WebDriverSession, bool> parentFilter = (session) => true;
             Action<WebDriverSession, V1Pod> childFactory = (session, pod) => { };
 
-            Assert.Throws<ArgumentNullException>("host", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(null, configuration, parentFilter, childFactory));
-            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(host, null, parentFilter, childFactory));
-            Assert.Throws<ArgumentNullException>("parentFilter", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(host, configuration, null, childFactory));
-            Assert.Throws<ArgumentNullException>("childFactory", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(host, configuration, parentFilter, null));
+            Assert.Throws<ArgumentNullException>("services", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(null, configuration, parentFilter, childFactory));
+            Assert.Throws<ArgumentNullException>("configuration", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(serviceProvider, null, parentFilter, childFactory));
+            Assert.Throws<ArgumentNullException>("parentFilter", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(serviceProvider, configuration, null, childFactory));
+            Assert.Throws<ArgumentNullException>("childFactory", () => new ChildOperatorBuilder<WebDriverSession, V1Pod>(serviceProvider, configuration, parentFilter, null));
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Kaponata.Operator.Tests.Operators
         [Fact]
         public void Where_ValidatesArguments()
         {
-            var builder = new ChildOperatorBuilder<WebDriverSession>(Mock.Of<IHost>(), new ChildOperatorConfiguration(string.Empty));
+            var builder = new ChildOperatorBuilder<WebDriverSession>(Mock.Of<IServiceProvider>(), new ChildOperatorConfiguration(string.Empty));
             Assert.Throws<ArgumentNullException>("parentFilter", () => builder.Where(null));
         }
 
@@ -103,7 +103,7 @@ namespace Kaponata.Operator.Tests.Operators
         [Fact]
         public void PostsFeedback_ValidatesArguments()
         {
-            var builder = new ChildOperatorBuilder<WebDriverSession, V1Pod>(Mock.Of<IHost>(), new ChildOperatorConfiguration(string.Empty), (session) => true, (session, pod) => { });
+            var builder = new ChildOperatorBuilder<WebDriverSession, V1Pod>(Mock.Of<IServiceProvider>(), new ChildOperatorConfiguration(string.Empty), (session) => true, (session, pod) => { });
 
             Assert.Throws<ArgumentNullException>("feedbackLoop", () => builder.PostsFeedback(null));
         }

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
@@ -38,7 +38,7 @@ namespace Kaponata.Operator.Tests.Operators
             builder.ConfigureServices(
                 (services) =>
                 {
-                    services.AddKubernetes();
+                    services.AddKubernetes(@namespace: "tests");
                     services.AddLogging(
                         (loggingBuilder) =>
                         {

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -39,7 +39,7 @@ namespace Kaponata.Operator.Tests.Operators
             builder.ConfigureServices(
                 (services) =>
                 {
-                    services.AddKubernetes();
+                    services.AddKubernetes(@namespace: "tests");
                     services.AddLogging(
                         (loggingBuilder) =>
                         {
@@ -137,7 +137,6 @@ namespace Kaponata.Operator.Tests.Operators
                         Metadata = new V1ObjectMeta()
                         {
                             Name = $"{name}-empty",
-                            NamespaceProperty = "default",
                             Labels = new Dictionary<string, string>()
                             {
                                 { Annotations.ManagedBy, name },
@@ -153,7 +152,6 @@ namespace Kaponata.Operator.Tests.Operators
                         Metadata = new V1ObjectMeta()
                         {
                             Name = $"{name}-fake",
-                            NamespaceProperty = "default",
                             Labels = new Dictionary<string, string>()
                             {
                                 { Annotations.ManagedBy, name },

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
@@ -63,9 +63,9 @@ namespace Kaponata.Operator.Tests.Operators
             var loggerFactory = this.host.Services.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger(name);
 
-            var podOperator = FakeOperators.BuildPodOperator(this.host).Build();
-            var serviceOperator = FakeOperators.BuildServiceOperator(this.host).Build();
-            var ingressOperator = FakeOperators.BuildIngressOperator(this.host).Build();
+            var podOperator = FakeOperators.BuildPodOperator(this.host.Services).Build();
+            var serviceOperator = FakeOperators.BuildServiceOperator(this.host.Services).Build();
+            var ingressOperator = FakeOperators.BuildIngressOperator(this.host.Services).Build();
 
             // Create a session and monitor the progress of the session.
             var sessionClient = kubernetes.GetClient<WebDriverSession>();
@@ -178,9 +178,9 @@ namespace Kaponata.Operator.Tests.Operators
             var loggerFactory = this.host.Services.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger(name);
 
-            var podOperator = FakeOperators.BuildPodOperator(this.host).Build();
-            var serviceOperator = FakeOperators.BuildServiceOperator(this.host).Build();
-            var ingressOperator = FakeOperators.BuildIngressOperator(this.host).Build();
+            var podOperator = FakeOperators.BuildPodOperator(this.host.Services).Build();
+            var serviceOperator = FakeOperators.BuildServiceOperator(this.host.Services).Build();
+            var ingressOperator = FakeOperators.BuildIngressOperator(this.host.Services).Build();
 
             // Create a session and monitor the progress of the session.
             var sessionClient = kubernetes.GetClient<WebDriverSession>();

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
@@ -38,7 +38,7 @@ namespace Kaponata.Operator.Tests.Operators
             builder.ConfigureServices(
                 (services) =>
                 {
-                    services.AddKubernetes();
+                    services.AddKubernetes(@namespace: "tests");
                     services.AddLogging(
                         (loggingBuilder) =>
                         {
@@ -121,7 +121,6 @@ namespace Kaponata.Operator.Tests.Operators
                         {
                             { Annotations.AutomationName, Annotations.AutomationNames.Fake },
                         },
-                        NamespaceProperty = "default",
                         Name = name,
                     },
                     Spec = new WebDriverSessionSpec()
@@ -236,7 +235,6 @@ namespace Kaponata.Operator.Tests.Operators
                         {
                             { Annotations.AutomationName, Annotations.AutomationNames.Fake },
                         },
-                        NamespaceProperty = "default",
                         Name = name,
                     },
                     Spec = new WebDriverSessionSpec()

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -55,21 +55,21 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildIngressOperator(IHost)"/> throws when passed a <see langword="null"/> value.
+        /// <see cref="FakeOperators.BuildIngressOperator(IServiceProvider)"/> throws when passed a <see langword="null"/> value.
         /// </summary>
         [Fact]
         public void BuildIngressOperator_Null_Throws()
         {
-            Assert.Throws<ArgumentNullException>("host", () => FakeOperators.BuildIngressOperator(null));
+            Assert.Throws<ArgumentNullException>("services", () => FakeOperators.BuildIngressOperator(null));
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildIngressOperator(IHost)"/> correctly populates the standard properties.
+        /// <see cref="FakeOperators.BuildIngressOperator(IServiceProvider)"/> correctly populates the standard properties.
         /// </summary>
         [Fact]
         public void BuildIngressOperator_SimpleProperties_Test()
         {
-            var builder = FakeOperators.BuildIngressOperator(this.host);
+            var builder = FakeOperators.BuildIngressOperator(this.host.Services);
 
             // Name, namespace and labels
             Assert.Collection(
@@ -96,12 +96,12 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildIngressOperator(IHost)"/> correctly configures the child pod.
+        /// <see cref="FakeOperators.BuildIngressOperator(IServiceProvider)"/> correctly configures the child pod.
         /// </summary>
         [Fact]
         public void BuildIngressOperator_ConfiguresIngress_Test()
         {
-            var builder = FakeOperators.BuildIngressOperator(this.host);
+            var builder = FakeOperators.BuildIngressOperator(this.host.Services);
 
             var session = new WebDriverSession()
             {
@@ -128,7 +128,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildIngressOperator(IHost)"/> does nto provide any feedback when the sessions or pod are not ready.
+        /// <see cref="FakeOperators.BuildIngressOperator(IServiceProvider)"/> does nto provide any feedback when the sessions or pod are not ready.
         /// </summary>
         /// <param name="context">
         /// The context on which to operate.
@@ -138,19 +138,19 @@ namespace Kaponata.Operator.Tests.Operators
         [MemberData(nameof(BuildIngressOperator_NoFeedback_Data))]
         public async Task BuildIngressOperator_NoFeedback_Async(ChildOperatorContext<WebDriverSession, V1Ingress> context)
         {
-            var builder = FakeOperators.BuildIngressOperator(this.host);
+            var builder = FakeOperators.BuildIngressOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
             Assert.Null(await feedback(context, default).ConfigureAwait(false));
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildIngressOperator(IHost)"/> provides correct feedback when session creation fails.
+        /// <see cref="FakeOperators.BuildIngressOperator(IServiceProvider)"/> provides correct feedback when session creation fails.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         public async Task BuildIngressOperator_Feedback_Async()
         {
-            var builder = FakeOperators.BuildIngressOperator(this.host);
+            var builder = FakeOperators.BuildIngressOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
 
             var context = new ChildOperatorContext<WebDriverSession, V1Ingress>(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
@@ -55,21 +55,21 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildServiceOperator(IHost)"/> throws when passed a <see langword="null"/> value.
+        /// <see cref="FakeOperators.BuildServiceOperator(IServiceProvider)"/> throws when passed a <see langword="null"/> value.
         /// </summary>
         [Fact]
         public void BuildServiceOperator_Null_Throws()
         {
-            Assert.Throws<ArgumentNullException>("host", () => FakeOperators.BuildServiceOperator(null));
+            Assert.Throws<ArgumentNullException>("services", () => FakeOperators.BuildServiceOperator(null));
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildServiceOperator(IHost)"/> correctly populates the standard properties.
+        /// <see cref="FakeOperators.BuildServiceOperator(IServiceProvider)"/> correctly populates the standard properties.
         /// </summary>
         [Fact]
         public void BuildServiceOperator_SimpleProperties_Test()
         {
-            var builder = FakeOperators.BuildServiceOperator(this.host);
+            var builder = FakeOperators.BuildServiceOperator(this.host.Services);
 
             // Name, namespace and labels
             Assert.Collection(
@@ -96,12 +96,12 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildServiceOperator(IHost)"/> correctly configures the child pod.
+        /// <see cref="FakeOperators.BuildServiceOperator(IServiceProvider)"/> correctly configures the child pod.
         /// </summary>
         [Fact]
         public void BuildServiceOperator_ConfiguresService_Test()
         {
-            var builder = FakeOperators.BuildServiceOperator(this.host);
+            var builder = FakeOperators.BuildServiceOperator(this.host.Services);
 
             var session = new WebDriverSession()
             {
@@ -127,7 +127,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildServiceOperator(IHost)"/> does nto provide any feedback when the sessions or pod are not ready.
+        /// <see cref="FakeOperators.BuildServiceOperator(IServiceProvider)"/> does nto provide any feedback when the sessions or pod are not ready.
         /// </summary>
         /// <param name="context">
         /// The context on which to operate.
@@ -137,19 +137,19 @@ namespace Kaponata.Operator.Tests.Operators
         [MemberData(nameof(BuildServiceOperator_NoFeedback_Data))]
         public async Task BuildServiceOperator_NoFeedback_Async(ChildOperatorContext<WebDriverSession, V1Service> context)
         {
-            var builder = FakeOperators.BuildServiceOperator(this.host);
+            var builder = FakeOperators.BuildServiceOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
             Assert.Null(await feedback(context, default).ConfigureAwait(false));
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildServiceOperator(IHost)"/> provides correct feedback when session creation fails.
+        /// <see cref="FakeOperators.BuildServiceOperator(IServiceProvider)"/> provides correct feedback when session creation fails.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         public async Task BuildServiceOperator_Feedback_Async()
         {
-            var builder = FakeOperators.BuildServiceOperator(this.host);
+            var builder = FakeOperators.BuildServiceOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
 
             var context = new ChildOperatorContext<WebDriverSession, V1Service>(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
@@ -200,21 +200,21 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildPodOperator(IHost)"/> throws when passed a <see langword="null"/> value.
+        /// <see cref="FakeOperators.BuildPodOperator(IServiceProvider)"/> throws when passed a <see langword="null"/> value.
         /// </summary>
         [Fact]
         public void BuildPodOperator_Null_Throws()
         {
-            Assert.Throws<ArgumentNullException>("host", () => FakeOperators.BuildPodOperator(null));
+            Assert.Throws<ArgumentNullException>("services", () => FakeOperators.BuildPodOperator(null));
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildPodOperator(IHost)"/> correctly populates the standard properties.
+        /// <see cref="FakeOperators.BuildPodOperator(IServiceProvider)"/> correctly populates the standard properties.
         /// </summary>
         [Fact]
         public void BuildPodOperator_SimpleProperties_Test()
         {
-            var builder = FakeOperators.BuildPodOperator(this.host);
+            var builder = FakeOperators.BuildPodOperator(this.host.Services);
 
             // Name, namespace and labels
             Assert.Collection(
@@ -239,12 +239,12 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildPodOperator(IHost)"/> correctly configures the child pod.
+        /// <see cref="FakeOperators.BuildPodOperator(IServiceProvider)"/> correctly configures the child pod.
         /// </summary>
         [Fact]
         public void BuildPodOperator_ConfiguresPod_Test()
         {
-            var builder = FakeOperators.BuildPodOperator(this.host);
+            var builder = FakeOperators.BuildPodOperator(this.host.Services);
 
             var session = new WebDriverSession()
             {
@@ -278,7 +278,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildPodOperator(IHost)"/> does nto provide any feedback when the sessions or pod are not ready.
+        /// <see cref="FakeOperators.BuildPodOperator(IServiceProvider)"/> does nto provide any feedback when the sessions or pod are not ready.
         /// </summary>
         /// <param name="context">
         /// The context on which to operate.
@@ -288,19 +288,19 @@ namespace Kaponata.Operator.Tests.Operators
         [MemberData(nameof(BuildPodOperator_NoFeedback_Data))]
         public async Task BuildPodOperator_NoFeedback_Async(ChildOperatorContext<WebDriverSession, V1Pod> context)
         {
-            var builder = FakeOperators.BuildPodOperator(this.host);
+            var builder = FakeOperators.BuildPodOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
             Assert.Null(await feedback(context, default).ConfigureAwait(false));
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildPodOperator(IHost)"/> provides correct feedback when session creation succeeds.
+        /// <see cref="FakeOperators.BuildPodOperator(IServiceProvider)"/> provides correct feedback when session creation succeeds.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         public async Task BuildPodOperator_FeedbackSucceeds_Async()
         {
-            var builder = FakeOperators.BuildPodOperator(this.host);
+            var builder = FakeOperators.BuildPodOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
 
             var context = new ChildOperatorContext<WebDriverSession, V1Pod>(
@@ -374,13 +374,13 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// <see cref="FakeOperators.BuildPodOperator(IHost)"/> provides correct feedback when session creation fails.
+        /// <see cref="FakeOperators.BuildPodOperator(IServiceProvider)"/> provides correct feedback when session creation fails.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         public async Task BuildPodOperator_FeedbackFails_Async()
         {
-            var builder = FakeOperators.BuildPodOperator(this.host);
+            var builder = FakeOperators.BuildPodOperator(this.host.Services);
             var feedback = Assert.Single(builder.FeedbackLoops);
 
             var context = new ChildOperatorContext<WebDriverSession, V1Pod>(

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder.cs
@@ -4,7 +4,6 @@
 
 using k8s;
 using k8s.Models;
-using Microsoft.Extensions.Hosting;
 using System;
 
 namespace Kaponata.Operator.Operators
@@ -14,18 +13,18 @@ namespace Kaponata.Operator.Operators
     /// </summary>
     public class ChildOperatorBuilder
     {
-        private readonly IHost host;
+        private readonly IServiceProvider services;
         private ChildOperatorConfiguration configuration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildOperatorBuilder"/> class.
         /// </summary>
-        /// <param name="host">
+        /// <param name="services">
         /// A host from which required services can be sourced.
         /// </param>
-        public ChildOperatorBuilder(IHost host)
+        public ChildOperatorBuilder(IServiceProvider services)
         {
-            this.host = host ?? throw new ArgumentNullException(nameof(host));
+            this.services = services ?? throw new ArgumentNullException(nameof(services));
         }
 
         /// <summary>
@@ -56,7 +55,7 @@ namespace Kaponata.Operator.Operators
             where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
         {
             return new ChildOperatorBuilder<TParent>(
-                this.host,
+                this.services,
                 this.configuration);
         }
     }

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent}.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent}.cs
@@ -5,7 +5,6 @@
 using k8s;
 using k8s.Models;
 using Kaponata.Kubernetes;
-using Microsoft.Extensions.Hosting;
 using System;
 using System.Linq.Expressions;
 
@@ -20,22 +19,22 @@ namespace Kaponata.Operator.Operators
     public class ChildOperatorBuilder<TParent>
             where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
     {
-        private readonly IHost host;
+        private readonly IServiceProvider services;
         private readonly ChildOperatorConfiguration configuration;
         private Func<TParent, bool> parentFilter = (parent) => true;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildOperatorBuilder{TParent}"/> class.
         /// </summary>
-        /// <param name="host">
-        /// The host from which to source required services.
+        /// <param name="services">
+        /// The service collection from which to source required services.
         /// </param>
         /// <param name="configuration">
         /// The configuration to apply to the operator.
         /// </param>
-        public ChildOperatorBuilder(IHost host, ChildOperatorConfiguration configuration)
+        public ChildOperatorBuilder(IServiceProvider services, ChildOperatorConfiguration configuration)
         {
-            this.host = host ?? throw new ArgumentNullException(nameof(host));
+            this.services = services ?? throw new ArgumentNullException(nameof(services));
             this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
@@ -102,7 +101,7 @@ namespace Kaponata.Operator.Operators
             Action<TParent, TChild> childFactory)
             where TChild : class, IKubernetesObject<V1ObjectMeta>, new()
         {
-            return new ChildOperatorBuilder<TParent, TChild>(this.host, this.configuration, this.parentFilter, childFactory);
+            return new ChildOperatorBuilder<TParent, TChild>(this.services, this.configuration, this.parentFilter, childFactory);
         }
     }
 }

--- a/src/Kaponata.Operator/Operators/FakeOperatorExtensions.cs
+++ b/src/Kaponata.Operator/Operators/FakeOperatorExtensions.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="FakeOperatorExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Provides extension methods for adding the fake operator to a <see cref="ServiceCollection"/>.
+    /// </summary>
+    public static class FakeOperatorExtensions
+    {
+        /// <summary>
+        /// Adds the fake operators to the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to which to add the fake operators.
+        /// </param>
+        /// <returns>
+        /// The service collection.
+        /// </returns>
+        public static IServiceCollection AddFakeOperators(this IServiceCollection services)
+        {
+            services.AddHostedService((serviceProvider) => FakeOperators.BuildPodOperator(serviceProvider).Build());
+            services.AddHostedService((serviceProvider) => FakeOperators.BuildServiceOperator(serviceProvider).Build());
+            services.AddHostedService((serviceProvider) => FakeOperators.BuildIngressOperator(serviceProvider).Build());
+
+            return services;
+        }
+    }
+}

--- a/src/Kaponata.Operator/Operators/FakeOperators.cs
+++ b/src/Kaponata.Operator/Operators/FakeOperators.cs
@@ -32,24 +32,24 @@ namespace Kaponata.Operator.Operators
         /// Builds an operator which provides a Fake driver pod for each <see cref="WebDriverSession"/> which uses
         /// the Fake driver.
         /// </summary>
-        /// <param name="host">
-        /// A service host from which to host services.
+        /// <param name="services">
+        /// A service collection from which to host services.
         /// </param>
         /// <returns>
         /// A configured operator.
         /// </returns>
-        public static ChildOperatorBuilder<WebDriverSession, V1Pod> BuildPodOperator(IHost host)
+        public static ChildOperatorBuilder<WebDriverSession, V1Pod> BuildPodOperator(IServiceProvider services)
         {
-            if (host == null)
+            if (services == null)
             {
-                throw new ArgumentNullException(nameof(host));
+                throw new ArgumentNullException(nameof(services));
             }
 
-            var kubernetes = host.Services.GetRequiredService<KubernetesClient>();
-            var loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
+            var kubernetes = services.GetRequiredService<KubernetesClient>();
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger("FakeOperator");
 
-            return new ChildOperatorBuilder(host)
+            return new ChildOperatorBuilder(services)
                 .CreateOperator("WebDriverSession-FakeDriver-PodOperator")
                 .Watches<WebDriverSession>()
                 .WithLabels(s => s.Metadata.Labels[Annotations.AutomationName] == Annotations.AutomationNames.Fake)
@@ -182,24 +182,24 @@ namespace Kaponata.Operator.Operators
         /// Builds an operator which provisions ingress rules for <see cref="WebDriverSession"/> objects which
         /// use the Fake driver.
         /// </summary>
-        /// <param name="host">
-        /// A service host from which to host services.
+        /// <param name="services">
+        /// A service provider from which to host services.
         /// </param>
         /// <returns>
         /// A configured operator.
         /// </returns>
-        public static ChildOperatorBuilder<WebDriverSession, V1Ingress> BuildIngressOperator(IHost host)
+        public static ChildOperatorBuilder<WebDriverSession, V1Ingress> BuildIngressOperator(IServiceProvider services)
         {
-            if (host == null)
+            if (services == null)
             {
-                throw new ArgumentNullException(nameof(host));
+                throw new ArgumentNullException(nameof(services));
             }
 
-            var kubernetes = host.Services.GetRequiredService<KubernetesClient>();
-            var loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
+            var kubernetes = services.GetRequiredService<KubernetesClient>();
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger("FakeOperator");
 
-            return new ChildOperatorBuilder(host)
+            return new ChildOperatorBuilder(services)
                 .CreateOperator("WebDriverSession-IngressOperator")
                 .Watches<WebDriverSession>()
                 .Where(s => s.Status?.SessionId != null)
@@ -260,24 +260,24 @@ namespace Kaponata.Operator.Operators
         /// Builds an operator which provisions services for <see cref="WebDriverSession"/> objects which
         /// use the Fake driver.
         /// </summary>
-        /// <param name="host">
-        /// A service host from which to host services.
+        /// <param name="services">
+        /// A service provider from which to host services.
         /// </param>
         /// <returns>
         /// A configured operator.
         /// </returns>
-        public static ChildOperatorBuilder<WebDriverSession, V1Service> BuildServiceOperator(IHost host)
+        public static ChildOperatorBuilder<WebDriverSession, V1Service> BuildServiceOperator(IServiceProvider services)
         {
-            if (host == null)
+            if (services == null)
             {
-                throw new ArgumentNullException(nameof(host));
+                throw new ArgumentNullException(nameof(services));
             }
 
-            var kubernetes = host.Services.GetRequiredService<KubernetesClient>();
-            var loggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
+            var kubernetes = services.GetRequiredService<KubernetesClient>();
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger("WebDriverSession-ServiceOperator");
 
-            return new ChildOperatorBuilder(host)
+            return new ChildOperatorBuilder(services)
                 .CreateOperator("WebDriverSession-ServiceOperator")
                 .Watches<WebDriverSession>()
                 .Where(s => s.Status?.SessionId != null)

--- a/src/Kaponata.Operator/Startup.cs
+++ b/src/Kaponata.Operator/Startup.cs
@@ -30,6 +30,7 @@ namespace Kaponata.Operator
 
             services.AddKubernetes();
             services.AddHostedService<RedroidOperator>();
+            services.AddFakeOperators();
         }
 
         /// <summary>

--- a/src/chart/templates/operator-role.yaml
+++ b/src/chart/templates/operator-role.yaml
@@ -20,3 +20,11 @@ rules:
 - apiGroups: [ "networking.k8s.io" ]
   resources: [ "ingresses" ]
   verbs: [ "get", "list", "watch", "create", "delete" ]
+
+- apiGroups: [ "kaponata.io" ]
+  resources: [ "webdriversessions" ]
+  verbs: [ "get", "list", "watch", "create", "patch", "delete" ]
+
+- apiGroups: [ "kaponata.io" ]
+  resources: [ "mobiledevices" ]
+  verbs: [ "get", "list", "watch", "create", "patch", "delete" ]


### PR DESCRIPTION
This PR enables the fake operator by default, as part of the `Kaponata.Operator` project.
This means `Kaponata.Operator` now hosts the `RedroidOperator` and the `FakeOperator` infrastructure.
We may want to split this project into multiple, smaller projects when this project starts hosting multiple operators.

For this to work:
- There's a `AddFakeOperators(this IServiceCollection services)` extension method which allows you to add the fake operators to a service collection
- The various methods for building operators now operate on `IServiceProvider` instead of `IHost` to support the above extension method.

As a separate commit, this PR also grants the operator pod CRUD permissions to the `WebDriverSession` and `MobileDevice` objects.