### PR TITLE
Make the Kubernetes namespace in which to operate an option

### DIFF
--- a/src/Kaponata.Chart.Tests/ApiTests.cs
+++ b/src/Kaponata.Chart.Tests/ApiTests.cs
@@ -58,6 +58,7 @@ namespace Kaponata.Chart.Tests
                 this.loggerFactory))
             using (var client = new KubernetesClient(
                 kubernetes,
+                KubernetesOptions.Default,
                 this.output.BuildLoggerFor<KubernetesClient>(),
                 this.loggerFactory))
             {

--- a/src/Kaponata.Chart.Tests/OperatorTests.cs
+++ b/src/Kaponata.Chart.Tests/OperatorTests.cs
@@ -57,6 +57,7 @@ namespace Kaponata.Chart.Tests
                 this.loggerFactory))
             using (var client = new KubernetesClient(
                 kubernetes,
+                KubernetesOptions.Default,
                 this.output.BuildLoggerFor<KubernetesClient>(),
                 this.loggerFactory))
             {

--- a/src/Kaponata.Chart.Tests/UsbmuxdTests.cs
+++ b/src/Kaponata.Chart.Tests/UsbmuxdTests.cs
@@ -59,6 +59,7 @@ namespace Kaponata.Chart.Tests
                 this.loggerFactory))
             using (var client = new KubernetesClient(
                 kubernetes,
+                KubernetesOptions.Default,
                 this.output.BuildLoggerFor<KubernetesClient>(),
                 this.loggerFactory))
             {

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientIntegrationTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientIntegrationTests.cs
@@ -51,7 +51,7 @@ namespace Kaponata.Kubernetes.Tests
             {
                 V1Pod pod;
 
-                if ((pod = await client.TryReadPodAsync("default", FormatName(nameof(this.WaitForPodRunning_IntegrationTest_Async)), default).ConfigureAwait(false)) != null)
+                if ((pod = await client.TryReadPodAsync(FormatName(nameof(this.WaitForPodRunning_IntegrationTest_Async)), default).ConfigureAwait(false)) != null)
                 {
                     await client.DeletePodAsync(pod, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
@@ -94,7 +94,7 @@ namespace Kaponata.Kubernetes.Tests
             {
                 V1Pod pod;
 
-                if ((pod = await client.TryReadPodAsync("default", FormatName(nameof(this.CreatePodHttpClient_IntegrationTest_Async)), default).ConfigureAwait(false)) != null)
+                if ((pod = await client.TryReadPodAsync(FormatName(nameof(this.CreatePodHttpClient_IntegrationTest_Async)), default).ConfigureAwait(false)) != null)
                 {
                     await client.DeletePodAsync(pod, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
@@ -337,7 +337,7 @@ namespace Kaponata.Kubernetes.Tests
             {
                 MobileDevice currentDevice = null;
 
-                if ((currentDevice = await client.TryReadMobileDeviceAsync("default", name, default).ConfigureAwait(false)) != null)
+                if ((currentDevice = await client.TryReadMobileDeviceAsync(name, default).ConfigureAwait(false)) != null)
                 {
                     await client.DeleteMobileDeviceAsync(currentDevice, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
@@ -354,12 +354,12 @@ namespace Kaponata.Kubernetes.Tests
                 var newDevice = await client.CreateMobileDeviceAsync(device, default).ConfigureAwait(false);
                 Assert.NotNull(newDevice);
 
-                var readDevice = await client.TryReadMobileDeviceAsync("default", name, default).ConfigureAwait(false);
+                var readDevice = await client.TryReadMobileDeviceAsync(name, default).ConfigureAwait(false);
                 Assert.NotNull(readDevice);
 
                 await client.DeleteMobileDeviceAsync(newDevice, TimeSpan.FromMinutes(1), default).ConfigureAwait(false);
 
-                Assert.Null(await client.TryReadMobileDeviceAsync("default", name, default).ConfigureAwait(false));
+                Assert.Null(await client.TryReadMobileDeviceAsync(name, default).ConfigureAwait(false));
             }
         }
 
@@ -378,7 +378,7 @@ namespace Kaponata.Kubernetes.Tests
                 Collection<(WatchEventType, MobileDevice)> watchEvents = new Collection<(WatchEventType, MobileDevice)>();
                 MobileDevice currentDevice = null;
 
-                if ((currentDevice = await client.TryReadMobileDeviceAsync("default", name, default).ConfigureAwait(false)) != null)
+                if ((currentDevice = await client.TryReadMobileDeviceAsync(name, default).ConfigureAwait(false)) != null)
                 {
                     await client.DeleteMobileDeviceAsync(currentDevice, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
@@ -435,7 +435,7 @@ namespace Kaponata.Kubernetes.Tests
             {
                 WebDriverSession currentDevice = null;
 
-                if ((currentDevice = await client.TryReadWebDriverSessionAsync("default", name, default).ConfigureAwait(false)) != null)
+                if ((currentDevice = await client.TryReadWebDriverSessionAsync(name, default).ConfigureAwait(false)) != null)
                 {
                     await client.DeleteWebDriverSessionAsync(currentDevice, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
@@ -452,12 +452,12 @@ namespace Kaponata.Kubernetes.Tests
                 var newSession = await client.CreateWebDriverSessionAsync(session, default).ConfigureAwait(false);
                 Assert.NotNull(newSession);
 
-                var readSession = await client.TryReadWebDriverSessionAsync("default", name, default).ConfigureAwait(false);
+                var readSession = await client.TryReadWebDriverSessionAsync(name, default).ConfigureAwait(false);
                 Assert.NotNull(readSession);
 
                 await client.DeleteWebDriverSessionAsync(newSession, TimeSpan.FromMinutes(1), default).ConfigureAwait(false);
 
-                Assert.Null(await client.TryReadWebDriverSessionAsync("default", name, default).ConfigureAwait(false));
+                Assert.Null(await client.TryReadWebDriverSessionAsync(name, default).ConfigureAwait(false));
             }
         }
 
@@ -476,7 +476,7 @@ namespace Kaponata.Kubernetes.Tests
                 var watchEvents = new Collection<(WatchEventType, WebDriverSession)>();
                 WebDriverSession currentSession = null;
 
-                if ((currentSession = await client.TryReadWebDriverSessionAsync("default", name, default).ConfigureAwait(false)) != null)
+                if ((currentSession = await client.TryReadWebDriverSessionAsync(name, default).ConfigureAwait(false)) != null)
                 {
                     await client.DeleteWebDriverSessionAsync(currentSession, TimeSpan.FromSeconds(100), default).ConfigureAwait(false);
                 }
@@ -533,7 +533,7 @@ namespace Kaponata.Kubernetes.Tests
             using (var client = this.CreateKubernetesClient())
             {
                 var podClient = client.GetClient<V1Pod>();
-                var pods = await podClient.ListAsync("default").ConfigureAwait(false);
+                var pods = await podClient.ListAsync().ConfigureAwait(false);
                 Assert.Equal("v1", pods.ApiVersion);
                 Assert.Equal("PodList", pods.Kind);
             }
@@ -556,6 +556,7 @@ namespace Kaponata.Kubernetes.Tests
                     KubernetesClientConfiguration.BuildDefaultConfig(),
                     this.loggerFactory.CreateLogger<KubernetesProtocol>(),
                     this.loggerFactory),
+                KubernetesOptions.Default,
                 this.loggerFactory.CreateLogger<KubernetesClient>(),
                 this.loggerFactory);
         }

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.CustomResourceDefinition.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.CustomResourceDefinition.cs
@@ -35,7 +35,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.CreateCustomResourceDefinitionAsync(null, default)).ConfigureAwait(false);
             }
@@ -55,7 +55,7 @@ namespace Kaponata.Kubernetes.Tests
                 .ReturnsAsync(new HttpOperationResponse<V1CustomResourceDefinition>() { Body = crd });
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var result = await client.CreateCustomResourceDefinitionAsync(crd, default).ConfigureAwait(false);
                 Assert.Same(crd, result);
@@ -78,14 +78,14 @@ namespace Kaponata.Kubernetes.Tests
 
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 Assert.Equal(crd, await client.TryReadCustomResourceDefinitionAsync("my-crd", default).ConfigureAwait(false));
             }
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns the <see langword="null"/> if the pod does exist.
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, CancellationToken)"/> returns the <see langword="null"/> if the pod does exist.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -98,7 +98,7 @@ namespace Kaponata.Kubernetes.Tests
 
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 Assert.Null(await client.TryReadCustomResourceDefinitionAsync("my-crd", default).ConfigureAwait(false));
             }
@@ -114,7 +114,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.DeleteCustomResourceDefinitionAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
@@ -158,7 +158,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteCustomResourceDefinitionAsync(customResourceDefinition, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -208,7 +208,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteCustomResourceDefinitionAsync(customResourceDefinition, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -261,7 +261,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteCustomResourceDefinitionAsync(customResourceDefinition, TimeSpan.Zero, default);
                 Assert.NotNull(callback);
@@ -536,7 +536,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.WaitForCustomResourceDefinitionEstablishedAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
@@ -554,7 +554,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await client.WaitForCustomResourceDefinitionEstablishedAsync(
                     new V1CustomResourceDefinition()
@@ -607,7 +607,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -653,7 +653,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -740,7 +740,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -785,7 +785,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForCustomResourceDefinitionEstablishedAsync(crd, TimeSpan.Zero, default);
                 Assert.NotNull(callback);

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.MobileDevice.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.MobileDevice.cs
@@ -37,7 +37,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.CreateMobileDeviceAsync(null, default)).ConfigureAwait(false);
                 await Assert.ThrowsAsync<ValidationException>(
@@ -122,7 +122,7 @@ namespace Kaponata.Kubernetes.Tests
                             });
                     });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var result = await client.CreateMobileDeviceAsync(mobileDevice, default).ConfigureAwait(false);
                 Assert.NotNull(result);
@@ -177,7 +177,7 @@ namespace Kaponata.Kubernetes.Tests
                             });
                     });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<SerializationException>(() => client.CreateMobileDeviceAsync(mobileDevice, default)).ConfigureAwait(false);
             }
@@ -186,7 +186,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.ListMobileDeviceAsync(string, string, string, string, int?, CancellationToken)"/> returns a typed object
+        /// <see cref="KubernetesClient.ListMobileDeviceAsync(string, string, string, int?, CancellationToken)"/> returns a typed object
         /// when the operation completes successfully.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -244,9 +244,9 @@ namespace Kaponata.Kubernetes.Tests
                     },
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                var list = await client.ListMobileDeviceAsync("default").ConfigureAwait(false);
+                var list = await client.ListMobileDeviceAsync().ConfigureAwait(false);
                 Assert.Collection(
                     list.Items,
                     d => { Assert.Equal("device1", d.Metadata.Name); },
@@ -257,7 +257,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.ListMobileDeviceAsync(string, string, string, string, int?, CancellationToken)"/> throws a <see cref="JsonException"/>
+        /// <see cref="KubernetesClient.ListMobileDeviceAsync(string, string, string, int?, CancellationToken)"/> throws a <see cref="JsonException"/>
         /// when invalid data is returned by the server.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -293,16 +293,16 @@ namespace Kaponata.Kubernetes.Tests
                     },
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                await Assert.ThrowsAsync<SerializationException>(() => client.ListMobileDeviceAsync("default")).ConfigureAwait(false);
+                await Assert.ThrowsAsync<SerializationException>(() => client.ListMobileDeviceAsync()).ConfigureAwait(false);
             }
 
             protocol.Verify();
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadMobileDeviceAsync(string, string, CancellationToken)"/> returns <see langword="null"/>
+        /// <see cref="KubernetesClient.TryReadMobileDeviceAsync(string, CancellationToken)"/> returns <see langword="null"/>
         /// if the requested device does not exist.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -337,16 +337,16 @@ namespace Kaponata.Kubernetes.Tests
                     },
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Null(await client.TryReadMobileDeviceAsync("default", "my-device", default).ConfigureAwait(false));
+                Assert.Null(await client.TryReadMobileDeviceAsync("my-device", default).ConfigureAwait(false));
             }
 
             protocol.Verify();
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadMobileDeviceAsync(string, string, CancellationToken)"/> returns a <see cref="MobileDevice"/>
+        /// <see cref="KubernetesClient.TryReadMobileDeviceAsync(string, CancellationToken)"/> returns a <see cref="MobileDevice"/>
         /// object if the requested device exists.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -381,9 +381,9 @@ namespace Kaponata.Kubernetes.Tests
                     },
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                var device = await client.TryReadMobileDeviceAsync("default", "my-device", default).ConfigureAwait(false);
+                var device = await client.TryReadMobileDeviceAsync("my-device", default).ConfigureAwait(false);
                 Assert.Equal("my-device", device.Metadata.Name);
             }
 
@@ -419,7 +419,7 @@ namespace Kaponata.Kubernetes.Tests
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WatchMobileDeviceAsync(
                     device,
@@ -449,13 +449,13 @@ namespace Kaponata.Kubernetes.Tests
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(), eventHandler, default))
+                .Setup(p => p.WatchNamespacedObjectAsync("default", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<MobileDevice, ItemList<MobileDevice>>>(), eventHandler, default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Same(tcs.Task, client.WatchMobileDeviceAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
+                Assert.Same(tcs.Task, client.WatchMobileDeviceAsync("fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
             }
 
             protocol.Verify();
@@ -473,7 +473,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteMobileDeviceAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
                 await Assert.ThrowsAsync<ValidationException>(() => client.DeleteMobileDeviceAsync(new MobileDevice() { }, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
@@ -567,7 +567,7 @@ namespace Kaponata.Kubernetes.Tests
                         default))
                 .Returns(Task.FromResult(new HttpOperationResponse<object>() { Body = mobileDevice, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteMobileDeviceAsync(mobileDevice, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -639,7 +639,7 @@ namespace Kaponata.Kubernetes.Tests
                         default))
                 .Returns(Task.FromResult(new HttpOperationResponse<object>() { Body = mobileDevice, Response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("--") } })).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<SerializationException>(() => client.DeleteMobileDeviceAsync(mobileDevice, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
@@ -702,7 +702,7 @@ namespace Kaponata.Kubernetes.Tests
                         default))
                 .Returns(Task.FromResult(new HttpOperationResponse<object>() { Body = mobileDevice, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteMobileDeviceAsync(mobileDevice, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -773,7 +773,7 @@ namespace Kaponata.Kubernetes.Tests
                         default))
                 .Returns(Task.FromResult(new HttpOperationResponse<object>() { Body = mobileDevice, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteMobileDeviceAsync(mobileDevice, TimeSpan.Zero, default);
                 Assert.NotNull(callback);

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.Pods.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.Pods.cs
@@ -30,7 +30,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 Assert.Throws<ArgumentNullException>("pod", () => client.CreatePodHttpClient(null, 80));
                 Assert.Throws<ValidationException>(() => client.CreatePodHttpClient(new V1Pod(), 80));

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.WebDriverSession.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.WebDriverSession.cs
@@ -75,7 +75,7 @@ namespace Kaponata.Kubernetes.Tests
                             });
                     });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var result = await client.CreateWebDriverSessionAsync(session, default).ConfigureAwait(false);
                 Assert.NotNull(result);
@@ -85,7 +85,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.ListWebDriverSessionAsync(string, string, string, string, int?, CancellationToken)"/> returns a typed object
+        /// <see cref="KubernetesClient.ListWebDriverSessionAsync(string, string, string, int?, CancellationToken)"/> returns a typed object
         /// when the operation completes successfully.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -143,9 +143,9 @@ namespace Kaponata.Kubernetes.Tests
                     },
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                var list = await client.ListWebDriverSessionAsync("default").ConfigureAwait(false);
+                var list = await client.ListWebDriverSessionAsync().ConfigureAwait(false);
                 Assert.Collection(
                     list.Items,
                     d => { Assert.Equal("session1", d.Metadata.Name); },
@@ -156,7 +156,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadWebDriverSessionAsync(string, string, CancellationToken)"/> returns a <see cref="WebDriverSession"/>
+        /// <see cref="KubernetesClient.TryReadWebDriverSessionAsync(string, CancellationToken)"/> returns a <see cref="WebDriverSession"/>
         /// object if the requested session exists.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -191,9 +191,9 @@ namespace Kaponata.Kubernetes.Tests
                     },
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                var device = await client.TryReadWebDriverSessionAsync("default", "my-session", default).ConfigureAwait(false);
+                var device = await client.TryReadWebDriverSessionAsync("my-session", default).ConfigureAwait(false);
                 Assert.Equal("my-session", device.Metadata.Name);
             }
 
@@ -229,7 +229,7 @@ namespace Kaponata.Kubernetes.Tests
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WatchWebDriverSessionAsync(
                     session,
@@ -259,13 +259,13 @@ namespace Kaponata.Kubernetes.Tests
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, ItemList<WebDriverSession>>>(), eventHandler, default))
+                .Setup(p => p.WatchNamespacedObjectAsync("default", "fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<WebDriverSession, ItemList<WebDriverSession>>>(), eventHandler, default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Same(tcs.Task, client.WatchWebDriverSessionAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
+                Assert.Same(tcs.Task, client.WatchWebDriverSessionAsync("fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
             }
 
             protocol.Verify();
@@ -326,7 +326,7 @@ namespace Kaponata.Kubernetes.Tests
                         default))
                 .Returns(Task.FromResult(new HttpOperationResponse<object>() { Body = session, Response = new HttpResponseMessage(HttpStatusCode.OK) })).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeleteWebDriverSessionAsync(session, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.cs
@@ -32,9 +32,10 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("protocol", () => new KubernetesClient(null, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesClient(Mock.Of<IKubernetesProtocol>(), null, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesClient(Mock.Of<IKubernetesProtocol>(), NullLogger<KubernetesClient>.Instance, null));
+            Assert.Throws<ArgumentNullException>("protocol", () => new KubernetesClient(null, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("options", () => new KubernetesClient(Mock.Of<IKubernetesProtocol>(), null, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesClient(Mock.Of<IKubernetesProtocol>(), KubernetesOptions.Default, null, NullLoggerFactory.Instance));
+            Assert.Throws<ArgumentNullException>("loggerFactory", () => new KubernetesClient(Mock.Of<IKubernetesProtocol>(), KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, null));
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
+            var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance);
             client.Dispose();
 
             protocol.Verify();
@@ -62,7 +63,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.WaitForPodRunningAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
@@ -80,7 +81,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await client.WaitForPodRunningAsync(
                     new V1Pod()
@@ -108,7 +109,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var ex = await Assert.ThrowsAsync<KubernetesException>(() => client.WaitForPodRunningAsync(
                     new V1Pod()
@@ -166,7 +167,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -217,7 +218,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -271,7 +272,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -337,7 +338,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -387,7 +388,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.WaitForPodRunningAsync(pod, TimeSpan.Zero, default);
                 Assert.NotNull(callback);
@@ -410,7 +411,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.DeletePodAsync(null, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
             }
@@ -457,7 +458,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeletePodAsync(pod, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -513,7 +514,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeletePodAsync(pod, TimeSpan.FromMinutes(1), default);
                 Assert.NotNull(callback);
@@ -569,7 +570,7 @@ namespace Kaponata.Kubernetes.Tests
                     return watchTask.Task;
                 });
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var task = client.DeletePodAsync(pod, TimeSpan.Zero, default);
                 Assert.NotNull(callback);
@@ -592,7 +593,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.CreatePodAsync(null, default)).ConfigureAwait(false);
                 await Assert.ThrowsAsync<ValidationException>(() => client.CreatePodAsync(new V1Pod(), default)).ConfigureAwait(false);
@@ -630,7 +631,7 @@ namespace Kaponata.Kubernetes.Tests
 
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 var ex = await Assert.ThrowsAsync<KubernetesException>(() => client.CreatePodAsync(pod, default)).ConfigureAwait(false);
                 Assert.Equal("pods 'waitforpodrunning-integrationtest-async' already exists", ex.Message);
@@ -671,14 +672,14 @@ namespace Kaponata.Kubernetes.Tests
 
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<HttpOperationException>(() => client.CreatePodAsync(pod, default)).ConfigureAwait(false);
             }
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns the object if the pod exists.
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, CancellationToken)"/> returns the object if the pod exists.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -693,14 +694,14 @@ namespace Kaponata.Kubernetes.Tests
 
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Equal(pod, await client.TryReadPodAsync("default", "my-pod", default).ConfigureAwait(false));
+                Assert.Equal(pod, await client.TryReadPodAsync("my-pod", default).ConfigureAwait(false));
             }
         }
 
         /// <summary>
-        /// <see cref="KubernetesClient.TryReadPodAsync(string, string, CancellationToken)"/> returns <see langword="null"/> if the pod does exist.
+        /// <see cref="KubernetesClient.TryReadPodAsync(string, CancellationToken)"/> returns <see langword="null"/> if the pod does exist.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -713,9 +714,9 @@ namespace Kaponata.Kubernetes.Tests
 
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Null(await client.TryReadPodAsync("default", "my-pod", default).ConfigureAwait(false));
+                Assert.Null(await client.TryReadPodAsync("my-pod", default).ConfigureAwait(false));
             }
         }
 
@@ -729,7 +730,7 @@ namespace Kaponata.Kubernetes.Tests
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ConnectToPodPortAsync(null, 1, default).AsTask()).ConfigureAwait(false);
                 await Assert.ThrowsAsync<ValidationException>(() => client.ConnectToPodPortAsync(new V1Pod { }, 1, default).AsTask()).ConfigureAwait(false);
@@ -767,7 +768,7 @@ namespace Kaponata.Kubernetes.Tests
                 .Verifiable();
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             using (var stream = await client.ConnectToPodPortAsync(pod, 27015, default))
             {
                 var portForwardStream = Assert.IsType<PortForwardStream>(stream);
@@ -788,13 +789,13 @@ namespace Kaponata.Kubernetes.Tests
             var response = new HttpOperationResponse<V1PodList>() { Body = list };
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.ListNamespacedPodWithHttpMessagesAsync("namespace", null, "continue", "fieldSelector", "labelSelector", 1, null, null, null, null, null, null, default))
+                .Setup(p => p.ListNamespacedPodWithHttpMessagesAsync("default", null, "continue", "fieldSelector", "labelSelector", 1, null, null, null, null, null, null, default))
                 .ReturnsAsync(response);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Same(list, await client.ListPodAsync("namespace", "continue", "fieldSelector", "labelSelector", 1, default).ConfigureAwait(false));
+                Assert.Same(list, await client.ListPodAsync("continue", "fieldSelector", "labelSelector", 1, default).ConfigureAwait(false));
             }
 
             protocol.Verify();
@@ -811,13 +812,13 @@ namespace Kaponata.Kubernetes.Tests
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", protocol.Object.ListNamespacedPodWithHttpMessagesAsync, eventHandler, default))
+                .Setup(p => p.WatchNamespacedObjectAsync("default", "fieldSelector", "labelSelector", "resourceVersion", protocol.Object.ListNamespacedPodWithHttpMessagesAsync, eventHandler, default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
-            using (var client = new KubernetesClient(protocol.Object, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
+            using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Same(tcs.Task, client.WatchPodAsync("namespace", "fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
+                Assert.Same(tcs.Task, client.WatchPodAsync("fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
             }
 
             protocol.Verify();

--- a/src/Kaponata.Kubernetes/KubernetesClient.MobileDevice.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.MobileDevice.cs
@@ -36,9 +36,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously list or watch <see cref="MobileDevice"/> objects.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which to list or watch objects.
-        /// </param>
         /// <param name="continue">
         /// The continue option should be set when retrieving more results from the server.
         /// Since this value is server defined, clients may only use the continue value from
@@ -92,7 +89,6 @@ namespace Kaponata.Kubernetes
         /// A <see cref="MobileDeviceList"/> which represents the mobile devices which match the query.
         /// </returns>
         public virtual Task<ItemList<MobileDevice>> ListMobileDeviceAsync(
-            string @namespace,
             string? @continue = null,
             string? fieldSelector = null,
             string? labelSelector = null,
@@ -100,7 +96,6 @@ namespace Kaponata.Kubernetes
             CancellationToken cancellationToken = default)
         {
             return this.mobileDeviceClient.ListAsync(
-                @namespace: @namespace,
                 @continue: @continue,
                 fieldSelector: fieldSelector,
                 labelSelector: labelSelector,
@@ -111,9 +106,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously tries to read a mobile device.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which the mobile device is located.
-        /// </param>
         /// <param name="name">
         /// The name which uniquely identifies the mobile device within the namespace.
         /// </param>
@@ -124,9 +116,9 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested mobile device, or
         /// <see langword="null"/> if the mobile device does not exist.
         /// </returns>
-        public virtual Task<MobileDevice?> TryReadMobileDeviceAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual Task<MobileDevice?> TryReadMobileDeviceAsync(string name, CancellationToken cancellationToken)
         {
-            return this.mobileDeviceClient.TryReadAsync(@namespace, name, cancellationToken);
+            return this.mobileDeviceClient.TryReadAsync(name: name, cancellationToken);
         }
 
         /// <summary>
@@ -178,9 +170,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously watches <see cref="MobileDevice"/> objects.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which to watch for <see cref="MobileDevice"/> objects.
-        /// </param>
         /// <param name="fieldSelector">
         /// A selector to restrict the list of returned objects by their fields. Defaults
         /// to everything.
@@ -209,14 +198,13 @@ namespace Kaponata.Kubernetes
         /// loop errors.
         /// </returns>
         public virtual Task<WatchExitReason> WatchMobileDeviceAsync(
-            string @namespace,
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
             WatchEventDelegate<MobileDevice> eventHandler,
             CancellationToken cancellationToken)
         {
-            return this.mobileDeviceClient.WatchAsync(@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken);
+            return this.mobileDeviceClient.WatchAsync(fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken);
         }
     }
 }

--- a/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -93,9 +93,6 @@ namespace Kaponata.Kubernetes
         /// A <see cref="KindMetadata"/> object which describes the type of object to generate,
         /// such as the API version or plural name.
         /// </param>
-        /// <param name="namespaceParameter">
-        /// The namespace in which to list the objects.
-        /// </param>
         /// <param name="allowWatchBookmarks">
         /// allowWatchBookmarks requests watch events with type "BOOKMARK". Servers that
         /// do not implement bookmarks may ignore this flag and bookmarks are sent at the
@@ -186,7 +183,6 @@ namespace Kaponata.Kubernetes
         /// </returns>
         public async virtual Task<HttpOperationResponse<TList>> ListNamespacedObjectAsync<TObject, TList>(
             KindMetadata kind,
-            string namespaceParameter,
             bool? allowWatchBookmarks = null,
             string? continueParameter = null,
             string? fieldSelector = null,
@@ -208,7 +204,7 @@ namespace Kaponata.Kubernetes
             var operationResponse = await this.RunTaskAsync(this.protocol.ListNamespacedCustomObjectWithHttpMessagesAsync(
                 kind.Group,
                 kind.Version,
-                namespaceParameter,
+                this.options.Value.Namespace,
                 kind.Plural,
                 continueParameter: continueParameter,
                 fieldSelector: fieldSelector,
@@ -255,9 +251,6 @@ namespace Kaponata.Kubernetes
         /// <param name="name">
         /// The name of the object to delete.
         /// </param>
-        /// <param name="namespaceParameter">
-        /// The namespace in which to delete the object.
-        /// </param>
         /// <param name="body">
         /// Specific delete options.
         /// </param>
@@ -296,7 +289,6 @@ namespace Kaponata.Kubernetes
         public async Task<T?> DeleteNamespacedObjectAsync<T>(
             KindMetadata kind,
             string name,
-            string namespaceParameter,
             V1DeleteOptions? body = null,
             string? dryRun = null,
             int? gracePeriodSeconds = null,
@@ -309,7 +301,7 @@ namespace Kaponata.Kubernetes
             using (var operationResponse = await this.protocol.DeleteNamespacedCustomObjectWithHttpMessagesAsync(
                 kind.Group,
                 kind.Version,
-                namespaceParameter,
+                this.options.Value.Namespace,
                 kind.Plural,
                 name,
                 body,
@@ -382,9 +374,6 @@ namespace Kaponata.Kubernetes
         /// <typeparam name="TList">
         /// The type of a list of <typeparamref name="TObject"/> objects.
         /// </typeparam>
-        /// <param name="namespace">
-        /// The namespace in which to watch for <typeparamref name="TObject"/> objects.
-        /// </param>
         /// <param name="fieldSelector">
         /// A selector to restrict the list of returned objects by their fields. Defaults
         /// to everything.
@@ -416,7 +405,6 @@ namespace Kaponata.Kubernetes
         /// loop errors.
         /// </returns>
         public Task<WatchExitReason> WatchNamespacedObjectAsync<TObject, TList>(
-            string @namespace,
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
@@ -427,7 +415,7 @@ namespace Kaponata.Kubernetes
             where TList : IItems<TObject>
         {
             return this.protocol.WatchNamespacedObjectAsync<TObject, TList>(
-                @namespace,
+                this.options.Value.Namespace,
                 fieldSelector,
                 labelSelector,
                 resourceVersion,
@@ -493,9 +481,6 @@ namespace Kaponata.Kubernetes
         /// <param name="metadata">
         /// Metadata which describes the object type.
         /// </param>
-        /// <param name="namespace">
-        /// The namespace of the object to patch.
-        /// </param>
         /// <param name="name">
         /// The name of the object to patch.
         /// </param>
@@ -510,7 +495,6 @@ namespace Kaponata.Kubernetes
         /// </returns>
         public async Task<T> PatchNamespacedObjectStatusAsync<T>(
             KindMetadata metadata,
-            string @namespace,
             string name,
             V1Patch patch,
             CancellationToken cancellationToken)
@@ -519,7 +503,7 @@ namespace Kaponata.Kubernetes
                 patch,
                 metadata.Group,
                 metadata.Version,
-                @namespace,
+                this.options.Value.Namespace,
                 metadata.Plural,
                 name,
                 null,

--- a/src/Kaponata.Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.Pods.cs
@@ -53,9 +53,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously tries to read a pod.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which the pod is located.
-        /// </param>
         /// <param name="name">
         /// The name which uniquely identifies the pod within the namespace.
         /// </param>
@@ -66,18 +63,18 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested pod, or
         /// <see langword="null"/> if the pod does not exist.
         /// </returns>
-        public virtual async Task<V1Pod?> TryReadPodAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual async Task<V1Pod?> TryReadPodAsync(string name, CancellationToken cancellationToken)
         {
-            var list = await this.RunTaskAsync(this.protocol.ListNamespacedPodAsync(@namespace, fieldSelector: $"metadata.name={name}", cancellationToken: cancellationToken)).ConfigureAwait(false);
+            var list = await this.RunTaskAsync(this.protocol.ListNamespacedPodAsync(
+                this.options.Value.Namespace,
+                fieldSelector: $"metadata.name={name}",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
             return list.Items.SingleOrDefault();
         }
 
         /// <summary>
         /// Asynchronously lists <see cref="V1Pod"/> objects.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which to list <see cref="V1Pod"/> objects.
-        /// </param>
         /// <param name="continue">
         /// The continue option should be set when retrieving more results from the server.
         /// Since this value is server defined, clients may only use the continue value from
@@ -130,10 +127,10 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="V1PodList"/> which represents the mobile devices which match the query.
         /// </returns>
-        public async virtual Task<V1PodList> ListPodAsync(string @namespace, string? @continue = null, string? fieldSelector = null, string? labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
+        public async virtual Task<V1PodList> ListPodAsync(string? @continue = null, string? fieldSelector = null, string? labelSelector = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             using (var operationResponse = await this.RunTaskAsync(this.protocol.ListNamespacedPodWithHttpMessagesAsync(
-                namespaceParameter: @namespace,
+                this.options.Value.Namespace,
                 continueParameter: @continue,
                 fieldSelector: fieldSelector,
                 labelSelector: labelSelector,
@@ -179,9 +176,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously watches pods.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which to watch for <see cref="V1Pod"/> objects.
-        /// </param>
         /// <param name="fieldSelector">
         /// A selector to restrict the list of returned objects by their fields. Defaults
         /// to everything.
@@ -210,7 +204,6 @@ namespace Kaponata.Kubernetes
         /// loop errors.
         /// </returns>
         public virtual Task<WatchExitReason> WatchPodAsync(
-            string @namespace,
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
@@ -218,7 +211,7 @@ namespace Kaponata.Kubernetes
             CancellationToken cancellationToken)
         {
             return this.protocol.WatchNamespacedObjectAsync(
-                @namespace,
+                this.options.Value.Namespace,
                 fieldSelector: fieldSelector,
                 labelSelector: labelSelector,
                 resourceVersion: resourceVersion,

--- a/src/Kaponata.Kubernetes/KubernetesClient.WebDriverSession.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.WebDriverSession.cs
@@ -36,9 +36,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously list or watch <see cref="WebDriverSession"/> objects.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which to list or watch objects.
-        /// </param>
         /// <param name="continue">
         /// The continue option should be set when retrieving more results from the server.
         /// Since this value is server defined, clients may only use the continue value from
@@ -92,22 +89,23 @@ namespace Kaponata.Kubernetes
         /// A <see cref="MobileDeviceList"/> which represents the mobile devices which match the query.
         /// </returns>
         public virtual Task<ItemList<WebDriverSession>> ListWebDriverSessionAsync(
-            string @namespace,
             string? @continue = null,
             string? fieldSelector = null,
             string? labelSelector = null,
             int? limit = null,
             CancellationToken cancellationToken = default)
         {
-            return this.webDriverSessionClient.ListAsync(@namespace, @continue, fieldSelector, labelSelector, limit, cancellationToken);
+            return this.webDriverSessionClient.ListAsync(
+                @continue,
+                fieldSelector,
+                labelSelector,
+                limit,
+                cancellationToken);
         }
 
         /// <summary>
         /// Asynchronously tries to read a WebDriver session.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which the WebDriver session is located.
-        /// </param>
         /// <param name="name">
         /// The name which uniquely identifies the WebDriver session within the namespace.
         /// </param>
@@ -118,9 +116,9 @@ namespace Kaponata.Kubernetes
         /// A <see cref="Task"/> which represents the asynchronous operation, and returns the requested WebDriver session, or
         /// <see langword="null"/> if the WebDriver session does not exist.
         /// </returns>
-        public virtual Task<WebDriverSession?> TryReadWebDriverSessionAsync(string @namespace, string name, CancellationToken cancellationToken)
+        public virtual Task<WebDriverSession?> TryReadWebDriverSessionAsync(string name, CancellationToken cancellationToken)
         {
-            return this.webDriverSessionClient.TryReadAsync(@namespace, name, cancellationToken);
+            return this.webDriverSessionClient.TryReadAsync(name: name, cancellationToken);
         }
 
         /// <summary>
@@ -172,9 +170,6 @@ namespace Kaponata.Kubernetes
         /// <summary>
         /// Asynchronously watches <see cref="WebDriverSession"/> objects.
         /// </summary>
-        /// <param name="namespace">
-        /// The namespace in which to watch for <see cref="WebDriverSession"/> objects.
-        /// </param>
         /// <param name="fieldSelector">
         /// A selector to restrict the list of returned objects by their fields. Defaults
         /// to everything.
@@ -203,14 +198,18 @@ namespace Kaponata.Kubernetes
         /// loop errors.
         /// </returns>
         public virtual Task<WatchExitReason> WatchWebDriverSessionAsync(
-            string @namespace,
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
             WatchEventDelegate<WebDriverSession> eventHandler,
             CancellationToken cancellationToken)
         {
-            return this.webDriverSessionClient.WatchAsync(@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken);
+            return this.webDriverSessionClient.WatchAsync(
+                fieldSelector,
+                labelSelector,
+                resourceVersion,
+                eventHandler,
+                cancellationToken);
         }
     }
 }

--- a/src/Kaponata.Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.cs
@@ -8,6 +8,7 @@ using Kaponata.Kubernetes.Models;
 using Kaponata.Kubernetes.Polyfill;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Rest;
 using Microsoft.Rest.Serialization;
 using System;
@@ -32,6 +33,7 @@ namespace Kaponata.Kubernetes
         private readonly ILoggerFactory loggerFactory;
         private readonly NamespacedKubernetesClient<MobileDevice> mobileDeviceClient;
         private readonly NamespacedKubernetesClient<WebDriverSession> webDriverSessionClient;
+        private readonly IOptions<KubernetesOptions> options;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KubernetesClient"/> class.
@@ -39,17 +41,21 @@ namespace Kaponata.Kubernetes
         /// <param name="protocol">
         /// The protocol to use to communicate with the Kubernetes API server.
         /// </param>
+        /// <param name="options">
+        /// General options for the <see cref="KubernetesClient"/>.
+        /// </param>
         /// <param name="logger">
         /// The logger to use when logging.
         /// </param>
         /// <param name="loggerFactory">
         /// The logger factory to use when creating child objects.
         /// </param>
-        public KubernetesClient(IKubernetesProtocol protocol, ILogger<KubernetesClient> logger, ILoggerFactory loggerFactory)
+        public KubernetesClient(IKubernetesProtocol protocol, IOptions<KubernetesOptions> options, ILogger<KubernetesClient> logger, ILoggerFactory loggerFactory)
         {
             this.protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
 
             this.knownTypes.Add(typeof(MobileDevice), MobileDevice.KubeMetadata);
             this.knownTypes.Add(typeof(WebDriverSession), WebDriverSession.KubeMetadata);
@@ -72,6 +78,7 @@ namespace Kaponata.Kubernetes
         {
             this.logger = NullLogger<KubernetesClient>.Instance;
             this.loggerFactory = NullLoggerFactory.Instance;
+            this.options = KubernetesOptions.Default;
         }
 #nullable restore
 
@@ -99,6 +106,11 @@ namespace Kaponata.Kubernetes
             WatchEventDelegate<T> onEvent,
             CancellationToken cancellationToken)
             where T : IKubernetesObject<V1ObjectMeta>;
+
+        /// <summary>
+        /// Gets the <see cref="KubernetesOptions"/> which configure this <see cref="KubernetesClient"/>.
+        /// </summary>
+        public KubernetesOptions Options => this.options.Value;
 
         /// <summary>
         /// Gets a <see cref="NamespacedKubernetesClient{T}"/> which allows you to interact with objects of <typeparamref name="T"/>.

--- a/src/Kaponata.Kubernetes/KubernetesOptions.cs
+++ b/src/Kaponata.Kubernetes/KubernetesOptions.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="KubernetesOptions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft.Extensions.Options;
+
+namespace Kaponata.Kubernetes
+{
+    /// <summary>
+    /// Contains options used by the <see cref="KubernetesClient"/>.
+    /// </summary>
+    public class KubernetesOptions
+    {
+        /// <summary>
+        /// Gets the default options.
+        /// </summary>
+        public static readonly IOptions<KubernetesOptions> Default = new OptionsWrapper<KubernetesOptions>(new KubernetesOptions());
+
+        /// <summary>
+        /// Gets or sets the name of the namespace in which the <see cref="KubernetesClient"/> operates.
+        /// The default value is <c>default</c>.
+        /// </summary>
+        public string Namespace { get; set; } = "default";
+    }
+}

--- a/src/Kaponata.Kubernetes/Polyfill/KubernetesProtocol.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/KubernetesProtocol.cs
@@ -34,6 +34,7 @@ namespace Kaponata.Kubernetes.Polyfill
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
 
+            this.Namespace = "default";
             this.HttpClient = new HttpClient(handler);
         }
 
@@ -54,6 +55,8 @@ namespace Kaponata.Kubernetes.Polyfill
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
+            this.Namespace = config.Namespace ?? "default";
 
             this.FirstMessageHandler = this.HttpClientHandler = CreateRootHandler();
             this.FirstMessageHandler = new CoreApiHandler(new WatchHandler(this.HttpClientHandler));
@@ -91,5 +94,10 @@ namespace Kaponata.Kubernetes.Polyfill
             CreateCredentials(config);
             config.AddCertificates(this.HttpClientHandler);
         }
+
+        /// <summary>
+        /// Gets the name of the namespace in which this client creates objects.
+        /// </summary>
+        public string Namespace { get; }
     }
 }

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -76,7 +76,6 @@ namespace Kaponata.Operator.Tests.Operators
             var podClient = kubernetes.GetClient<V1Pod>();
             var podWatcher =
                 podClient.WatchAsync(
-                    "default",
                     fieldSelector: null,
                     labelSelector: $"{Annotations.ManagedBy}={name}",
                     null,
@@ -101,10 +100,10 @@ namespace Kaponata.Operator.Tests.Operators
 
             // Delete all objects which may have been created by this test.
             await Task.WhenAll(
-                sessionClient.TryDeleteAsync("default", $"{name}-empty", TimeSpan.FromMinutes(1), default),
-                sessionClient.TryDeleteAsync("default", $"{name}-fake", TimeSpan.FromMinutes(1), default),
-                podClient.TryDeleteAsync("default", $"{name}-empty", TimeSpan.FromMinutes(1), default),
-                podClient.TryDeleteAsync("default", $"{name}-fake", TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+                sessionClient.TryDeleteAsync($"{name}-empty", TimeSpan.FromMinutes(1), default),
+                sessionClient.TryDeleteAsync($"{name}-fake", TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync($"{name}-empty", TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync($"{name}-fake", TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
                 kubernetes,

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
@@ -499,7 +499,7 @@ namespace Kaponata.Operator.Tests.Operators
             var kubernetes = new Mock<KubernetesClient>();
             var sessionClient = kubernetes.WithClient<WebDriverSession>();
             sessionClient
-                .Setup(s => s.ListAsync("default", null, null, "parent-label-selector", null, default))
+                .Setup(s => s.ListAsync(null, null, "parent-label-selector", null, default))
                 .ThrowsAsync(new NotSupportedException());
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
@@ -735,12 +735,12 @@ namespace Kaponata.Operator.Tests.Operators
                 };
 
                 sessionClient
-                    .Setup(s => s.TryReadAsync("default", "my-session", "parent-label-selector", It.IsAny<CancellationToken>()))
+                    .Setup(s => s.TryReadAsync("my-session", "parent-label-selector", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(session);
 
                 // Let's assume there's no child for this parent:
                 podClient
-                    .Setup(p => p.TryReadAsync("default", "my-session", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>()))
+                    .Setup(p => p.TryReadAsync("my-session", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>()))
                     .ReturnsAsync((V1Pod)null);
 
                 // And capture the creation of this new child:
@@ -882,8 +882,8 @@ namespace Kaponata.Operator.Tests.Operators
             var webDriverSessionClient = kubernetes.WithClient<WebDriverSession>();
             var podClient = kubernetes.WithClient<V1Pod>();
 
-            webDriverSessionClient.Setup(c => c.TryReadAsync("default", "my-name", "parent-label-selector", It.IsAny<CancellationToken>())).ReturnsAsync((WebDriverSession)null);
-            podClient.Setup(c => c.TryReadAsync("default", "my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>())).ReturnsAsync((V1Pod)null);
+            webDriverSessionClient.Setup(c => c.TryReadAsync("my-name", "parent-label-selector", It.IsAny<CancellationToken>())).ReturnsAsync((WebDriverSession)null);
+            podClient.Setup(c => c.TryReadAsync("my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>())).ReturnsAsync((V1Pod)null);
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
                 kubernetes.Object,
@@ -919,8 +919,8 @@ namespace Kaponata.Operator.Tests.Operators
             var podClient = kubernetes.WithClient<V1Pod>();
 
             var readWebDriverTask = new TaskCompletionSource<WebDriverSession>();
-            webDriverSessionClient.Setup(c => c.TryReadAsync("default", "my-name", "parent-label-selector", It.IsAny<CancellationToken>())).Returns(readWebDriverTask.Task);
-            podClient.Setup(c => c.TryReadAsync("default", "my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>())).ReturnsAsync((V1Pod)null);
+            webDriverSessionClient.Setup(c => c.TryReadAsync("my-name", "parent-label-selector", It.IsAny<CancellationToken>())).Returns(readWebDriverTask.Task);
+            podClient.Setup(c => c.TryReadAsync("my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>())).ReturnsAsync((V1Pod)null);
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
                 kubernetes.Object,
@@ -957,8 +957,8 @@ namespace Kaponata.Operator.Tests.Operators
             var webDriverSessionClient = kubernetes.WithClient<WebDriverSession>();
             var podClient = kubernetes.WithClient<V1Pod>();
 
-            webDriverSessionClient.Setup(c => c.TryReadAsync("default", "my-name", "parent-label-selector", It.IsAny<CancellationToken>())).ReturnsAsync(new WebDriverSession());
-            podClient.Setup(c => c.TryReadAsync("default", "my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>())).ReturnsAsync((V1Pod)null);
+            webDriverSessionClient.Setup(c => c.TryReadAsync("my-name", "parent-label-selector", It.IsAny<CancellationToken>())).ReturnsAsync(new WebDriverSession());
+            podClient.Setup(c => c.TryReadAsync("my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", It.IsAny<CancellationToken>())).ReturnsAsync((V1Pod)null);
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
                 kubernetes.Object,
@@ -993,8 +993,8 @@ namespace Kaponata.Operator.Tests.Operators
             var webDriverSessionClient = kubernetes.WithClient<WebDriverSession>();
             var podClient = kubernetes.WithClient<V1Pod>();
 
-            webDriverSessionClient.Setup(c => c.TryReadAsync("default", "my-name", "parent-label-selector", default)).ThrowsAsync(new InvalidOperationException());
-            podClient.Setup(c => c.TryReadAsync("default", "my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", default)).ThrowsAsync(new InvalidOperationException());
+            webDriverSessionClient.Setup(c => c.TryReadAsync("my-name", "parent-label-selector", default)).ThrowsAsync(new InvalidOperationException());
+            podClient.Setup(c => c.TryReadAsync("my-name", "app.kubernetes.io/managed-by=ChildOperatorTests", default)).ThrowsAsync(new InvalidOperationException());
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
                 kubernetes.Object,

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
@@ -74,13 +74,12 @@ namespace Kaponata.Operator.Tests.Operators
             var ingressClient = kubernetes.GetClient<V1Ingress>();
 
             await Task.WhenAll(
-                sessionClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default),
-                podClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default),
-                serviceClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default),
-                ingressClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+                sessionClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default),
+                serviceClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default),
+                ingressClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
 
             var sessionWatcher = sessionClient.WatchAsync(
-                "default",
                 $"metadata.name={name}",
                 null,
                 null,
@@ -149,7 +148,7 @@ namespace Kaponata.Operator.Tests.Operators
 
             Assert.True(sessionWatcher.IsCompletedSuccessfully, "Failed to properly configure the session within a timeout of 1 minute");
 
-            var session = await sessionClient.TryReadAsync("default", name, default).ConfigureAwait(false);
+            var session = await sessionClient.TryReadAsync(name, default).ConfigureAwait(false);
 
             Assert.NotNull(session.Status.Capabilities);
             Assert.Null(session.Status.Data);
@@ -190,13 +189,12 @@ namespace Kaponata.Operator.Tests.Operators
             var ingressClient = kubernetes.GetClient<V1Ingress>();
 
             await Task.WhenAll(
-                sessionClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default),
-                podClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default),
-                serviceClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default),
-                ingressClient.TryDeleteAsync("default", name, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+                sessionClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default),
+                serviceClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default),
+                ingressClient.TryDeleteAsync(name, TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
 
             var sessionWatcher = sessionClient.WatchAsync(
-                "default",
                 $"metadata.name={name}",
                 null,
                 null,
@@ -267,7 +265,7 @@ namespace Kaponata.Operator.Tests.Operators
 
             Assert.True(sessionWatcher.IsCompletedSuccessfully, "Failed to properly configure the session within a timeout of 1 minute");
 
-            var session = await sessionClient.TryReadAsync("default", name, default).ConfigureAwait(false);
+            var session = await sessionClient.TryReadAsync(name, default).ConfigureAwait(false);
 
             Assert.Null(session.Status.Capabilities);
             Assert.Null(session.Status.Data);

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -80,7 +80,6 @@ namespace Kaponata.Operator.Tests.Operators
                     Assert.Equal("WebDriverSession-IngressOperator", l.Value);
                 });
 
-            Assert.Equal("default", builder.Configuration.Namespace);
             Assert.Equal("WebDriverSession-IngressOperator", builder.Configuration.OperatorName);
             Assert.Null(builder.Configuration.ParentLabelSelector);
 

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
@@ -80,7 +80,6 @@ namespace Kaponata.Operator.Tests.Operators
                     Assert.Equal("WebDriverSession-ServiceOperator", l.Value);
                 });
 
-            Assert.Equal("default", builder.Configuration.Namespace);
             Assert.Equal("WebDriverSession-ServiceOperator", builder.Configuration.OperatorName);
             Assert.Null(builder.Configuration.ParentLabelSelector);
 

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
@@ -225,7 +225,6 @@ namespace Kaponata.Operator.Tests.Operators
                     Assert.Equal("WebDriverSession-FakeDriver-PodOperator", l.Value);
                 });
 
-            Assert.Equal("default", builder.Configuration.Namespace);
             Assert.Equal("WebDriverSession-FakeDriver-PodOperator", builder.Configuration.OperatorName);
             Assert.Equal("kaponata.io/automation-name=fake", builder.Configuration.ParentLabelSelector);
 

--- a/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
+++ b/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
@@ -22,7 +22,7 @@ namespace Kaponata.Operator.Tests.Operators
     internal static class KubernetesClientMockExtensions
     {
         /// <summary>
-        /// Mocks the value of the <see cref="KubernetesClient.ListPodAsync(string, string, string, string, int?, CancellationToken)"/> method.
+        /// Mocks the value of the <see cref="KubernetesClient.ListPodAsync(string, string, string, int?, CancellationToken)"/> method.
         /// </summary>
         /// <param name="client">
         /// The mock to configure.
@@ -41,7 +41,7 @@ namespace Kaponata.Operator.Tests.Operators
             var items = new List<V1Pod>(pods);
 
             client
-                .Setup(k => k.ListPodAsync("default", null, null, labelSelector, null, It.IsAny<CancellationToken>()))
+                .Setup(k => k.ListPodAsync(null, null, labelSelector, null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(
                     new V1PodList()
                     {
@@ -52,7 +52,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// Mocks the value of the <see cref="KubernetesClient.ListMobileDeviceAsync(string, string, string, string, int?, CancellationToken)"/> method.
+        /// Mocks the value of the <see cref="KubernetesClient.ListMobileDeviceAsync(string, string, string, int?, CancellationToken)"/> method.
         /// </summary>
         /// <param name="client">
         /// The mock to configure.
@@ -71,7 +71,7 @@ namespace Kaponata.Operator.Tests.Operators
             var items = new List<MobileDevice>(devices);
 
             client
-                .Setup(k => k.ListMobileDeviceAsync("default", null, null, labelSelector, null, It.IsAny<CancellationToken>()))
+                .Setup(k => k.ListMobileDeviceAsync(null, null, labelSelector, null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<ItemList<MobileDevice>>(
                     new MobileDeviceList()
                     {
@@ -186,7 +186,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// Configures the <see cref="KubernetesClient.WatchPodAsync(string, string, string, string, WatchEventDelegate{V1Pod}, CancellationToken)"/> method
+        /// Configures the <see cref="KubernetesClient.WatchPodAsync(string, string, string, WatchEventDelegate{V1Pod}, CancellationToken)"/> method
         /// on the mock.
         /// </summary>
         /// <param name="client">
@@ -204,14 +204,13 @@ namespace Kaponata.Operator.Tests.Operators
 
             client
                 .Setup(k => k.WatchPodAsync(
-                    "default",
                     null /* fieldSelector */,
                     labelSelector /* labelSelector */,
                     null /* resourceVersion */,
                     It.IsAny<WatchEventDelegate<V1Pod>>(),
                     It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, string, WatchEventDelegate<V1Pod>, CancellationToken>(
-                (@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
+                .Callback<string, string, string, WatchEventDelegate<V1Pod>, CancellationToken>(
+                (fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
                 {
                     cancellationToken.Register(watchClient.TaskCompletionSource.SetCanceled);
                     watchClient.ClientRegistered.SetResult(eventHandler);
@@ -222,7 +221,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// Configures the <see cref="KubernetesClient.WatchMobileDeviceAsync(string, string, string, string, WatchEventDelegate{MobileDevice}, CancellationToken)"/> method
+        /// Configures the <see cref="KubernetesClient.WatchMobileDeviceAsync(string, string, string, WatchEventDelegate{MobileDevice}, CancellationToken)"/> method
         /// on the mock.
         /// </summary>
         /// <param name="client">
@@ -240,14 +239,13 @@ namespace Kaponata.Operator.Tests.Operators
 
             client
                 .Setup(k => k.WatchMobileDeviceAsync(
-                    "default",
                     null /* fieldSelector */,
                     labelSelector, /* labelSelector */
                     null /* resourceVersion */,
                     It.IsAny<WatchEventDelegate<MobileDevice>>(),
                     It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, string, WatchEventDelegate<MobileDevice>, CancellationToken>(
-                (@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
+                .Callback<string, string, string, WatchEventDelegate<MobileDevice>, CancellationToken>(
+                (fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
                 {
                     cancellationToken.Register(watchClient.TaskCompletionSource.SetCanceled);
                     watchClient.ClientRegistered.SetResult(eventHandler);

--- a/src/Kaponata.Operator.Tests/Operators/NamespacedKubernetesClientExtensions.cs
+++ b/src/Kaponata.Operator.Tests/Operators/NamespacedKubernetesClientExtensions.cs
@@ -22,7 +22,7 @@ namespace Kaponata.Operator.Tests.Operators
     public static class NamespacedKubernetesClientExtensions
     {
         /// <summary>
-        /// Mocks the value of the <see cref="NamespacedKubernetesClient{T}.ListAsync(string, string, string, string, int?, CancellationToken)"/> method.
+        /// Mocks the value of the <see cref="NamespacedKubernetesClient{T}.ListAsync(string, string, string, int?, CancellationToken)"/> method.
         /// </summary>
         /// <param name="client">
         /// The mock to configure.
@@ -48,7 +48,7 @@ namespace Kaponata.Operator.Tests.Operators
             var items = new List<T>(values);
 
             client
-                .Setup(k => k.ListAsync("default", null, fieldSelector, labelSelector, null, It.IsAny<CancellationToken>()))
+                .Setup(k => k.ListAsync(null, fieldSelector, labelSelector, null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(
                     new ItemList<T>()
                     {
@@ -121,7 +121,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// Configures the <see cref="NamespacedKubernetesClient{T}.WatchAsync(string, string, string, string, WatchEventDelegate{T}, CancellationToken)"/> method
+        /// Configures the <see cref="NamespacedKubernetesClient{T}.WatchAsync(string, string, string, WatchEventDelegate{T}, CancellationToken)"/> method
         /// on the mock.
         /// </summary>
         /// <param name="client">
@@ -146,14 +146,13 @@ namespace Kaponata.Operator.Tests.Operators
 
             client
                 .Setup(k => k.WatchAsync(
-                    "default",
                     fieldSelector /* fieldSelector */,
                     labelSelector /* labelSelector */,
                     null /* resourceVersion */,
                     It.IsAny<WatchEventDelegate<T>>(),
                     It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, string, WatchEventDelegate<T>, CancellationToken>(
-                (@namespace, fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
+                .Callback<string, string, string, WatchEventDelegate<T>, CancellationToken>(
+                (fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
                 {
                     cancellationToken.Register(watchClient.TaskCompletionSource.SetCanceled);
                     watchClient.ClientRegistered.SetResult(eventHandler);

--- a/src/Kaponata.Operator/Operators/ChildOperator.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperator.cs
@@ -161,14 +161,12 @@ namespace Kaponata.Operator.Operators
 
                 // List all parent and child objects
                 var parents = await this.parentClient.ListAsync(
-                    this.configuration.Namespace,
                     fieldSelector: null,
                     labelSelector: this.configuration.ParentLabelSelector,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
                 this.logger.LogInformation("Found {count} parents for the {operator} operator.", parents.Items.Count, this.configuration.OperatorName);
 
                 var children = await this.childClient.ListAsync(
-                    this.configuration.Namespace,
                     labelSelector: Selector.Create(this.configuration.ChildLabels)).ConfigureAwait(false);
                 this.logger.LogInformation("Found {count} children for the {operator} operator.", children.Items.Count, this.configuration.OperatorName);
 
@@ -272,13 +270,11 @@ namespace Kaponata.Operator.Operators
 
                     // Start reading parent and child in parallel
                     var readParentTask = this.parentClient.TryReadAsync(
-                        this.configuration.Namespace,
                         name,
                         this.configuration.ParentLabelSelector,
                         operationCts.Token);
 
                     var readChildTask = this.childClient.TryReadAsync(
-                        this.configuration.Namespace,
                         name,
                         Selector.Create(this.configuration.ChildLabels),
                         operationCts.Token);
@@ -417,7 +413,6 @@ namespace Kaponata.Operator.Operators
         {
             // Watch child objects
             var sourceWatch = this.parentClient.WatchAsync(
-                this.configuration.Namespace,
                 fieldSelector: null,
                 this.configuration.ParentLabelSelector,
                 null,
@@ -430,7 +425,6 @@ namespace Kaponata.Operator.Operators
                 stoppingToken);
 
             var targetWatch = this.childClient.WatchAsync(
-                this.configuration.Namespace,
                 fieldSelector: null,
                 Selector.Create(this.configuration.ChildLabels),
                 null,

--- a/src/Kaponata.Operator/Operators/ChildOperatorConfiguration.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorConfiguration.cs
@@ -26,11 +26,6 @@ namespace Kaponata.Operator.Operators
         }
 
         /// <summary>
-        /// Gets or sets the name of the namespace in which the operator observes object.
-        /// </summary>
-        public string Namespace { get; set; } = "default";
-
-        /// <summary>
         /// Gets the name of the operator.
         /// </summary>
         public string OperatorName { get; }

--- a/src/Kaponata.Operator/Operators/RedroidOperator.cs
+++ b/src/Kaponata.Operator/Operators/RedroidOperator.cs
@@ -24,7 +24,6 @@ namespace Kaponata.Operator.Operators
     {
         private readonly ILogger<RedroidOperator> logger;
         private readonly KubernetesClient kubernetes;
-        private readonly string @namespace = "default";
 
         /// <summary>
         /// A semaphore which prevents multiple iterations of the <see cref="ReconcileAsync(CancellationToken)"/>
@@ -113,12 +112,12 @@ namespace Kaponata.Operator.Operators
             {
                 // Enumerate all Android emulator pods
                 this.logger.LogInformation("Listing all emulator pods");
-                var pods = await this.kubernetes.ListPodAsync(this.@namespace, labelSelector: this.PodLabelSelector, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var pods = await this.kubernetes.ListPodAsync(labelSelector: this.PodLabelSelector, cancellationToken: cancellationToken).ConfigureAwait(false);
                 this.logger.LogInformation("Found {count} emulator pods", pods.Items.Count);
 
                 // Enumerate all Android emulator devices
                 this.logger.LogInformation("Listing all emulator devices");
-                var devices = await this.kubernetes.ListMobileDeviceAsync(this.@namespace, labelSelector: this.DeviceLabelSelector, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var devices = await this.kubernetes.ListMobileDeviceAsync(labelSelector: this.DeviceLabelSelector, cancellationToken: cancellationToken).ConfigureAwait(false);
                 this.logger.LogInformation("Found {count} emulator devices", devices.Items.Count);
 
                 // Loop over all Android emulator pods. Process them one by one; remove the equivalent device from the device list
@@ -206,7 +205,6 @@ namespace Kaponata.Operator.Operators
                 var watchTasks = new Task<WatchExitReason>[]
                 {
                     this.kubernetes.WatchMobileDeviceAsync(
-                        @namespace: this.@namespace,
                         fieldSelector: null,
                         labelSelector: this.DeviceLabelSelector,
                         resourceVersion: null,
@@ -217,7 +215,6 @@ namespace Kaponata.Operator.Operators
                         },
                         cancellationToken),
                     this.kubernetes.WatchPodAsync(
-                        @namespace: this.@namespace,
                         fieldSelector: null,
                         labelSelector: this.PodLabelSelector,
                         resourceVersion: null,


### PR DESCRIPTION
Make the Kubernetes namespace in which to operate an option of the `KubernetesClient`, instead of an argument to all methods.

Kaponata will always operate in a well-defined namespace, so make this a one-off configuration option.

Plus, unit tests in #114 are failing because they are interfering with the operation which is deployed via the Helm chart. Making this an option will help us isolate the unit tests in a dedicated namespace.