### PR TITLE
 Add the KubernetesWebDriver class

### DIFF
--- a/src/Kaponata.Api.Tests/Kaponata.Api.Tests.csproj
+++ b/src/Kaponata.Api.Tests/Kaponata.Api.Tests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
+
+    <Compile Include="$(MSbuildThisFileDirectory)\..\Kaponata.Tests.Shared\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Api.Tests/KubernetesWebDriverTests.cs
+++ b/src/Kaponata.Api.Tests/KubernetesWebDriverTests.cs
@@ -1,0 +1,448 @@
+﻿// <copyright file="KubernetesWebDriverTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Api.WebDriver;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Models;
+using Kaponata.Kubernetes.Polyfill;
+using Kaponata.Tests.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Api.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesWebDriver"/> class.
+    /// </summary>
+    public class KubernetesWebDriverTests
+    {
+        /// <summary>
+        /// The data for the <see cref="CreateSessionAsync_InvalidCapabilities_Async(NewSessionRequest, string)"/> test.
+        /// </summary>
+        /// <returns>
+        /// Test data.
+        /// </returns>
+        public static IEnumerable<object[]> CreateSessionAsync_InvalidCapabilities_Data()
+        {
+            yield return new object[]
+            {
+                (NewSessionRequest)null,
+                "Required capabilities are missing",
+            };
+
+            yield return new object[]
+            {
+                new NewSessionRequest(),
+                "Required capabilities are missing",
+            };
+
+            yield return new object[]
+            {
+                new NewSessionRequest() { Capabilities = new CapabilitiesRequest() },
+                "Required capabilities are missing",
+            };
+
+            yield return new object[]
+            {
+                new NewSessionRequest()
+                {
+                    Capabilities = new CapabilitiesRequest()
+                    {
+                        AlwaysMatch = new Dictionary<string, object>(),
+                    },
+                },
+                "The platformName capability is required and must be a string.",
+            };
+
+            yield return new object[]
+            {
+                new NewSessionRequest()
+                {
+                    Capabilities = new CapabilitiesRequest()
+                    {
+                        AlwaysMatch = new Dictionary<string, object>()
+                        {
+                            { "platformName", true },
+                        },
+                    },
+                },
+                "The platformName capability is required and must be a string.",
+            };
+
+            yield return new object[]
+            {
+                new NewSessionRequest()
+                {
+                    Capabilities = new CapabilitiesRequest()
+                    {
+                        AlwaysMatch = new Dictionary<string, object>()
+                        {
+                            { "platformName", null },
+                        },
+                    },
+                },
+                "The platformName capability is required and must be a string.",
+            };
+
+            yield return new object[]
+            {
+                new NewSessionRequest()
+                {
+                    Capabilities = new CapabilitiesRequest()
+                    {
+                        AlwaysMatch = new Dictionary<string, object>()
+                        {
+                            { "platformName", "test" },
+                        },
+                    },
+                },
+                "The platform 'test' is not supported",
+            };
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.KubernetesWebDriver(KubernetesClient, ILogger{KubernetesWebDriver})"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("kubernetes", () => new KubernetesWebDriver(null, NullLogger<KubernetesWebDriver>.Instance));
+            Assert.Throws<ArgumentNullException>("logger", () => new KubernetesWebDriver(Mock.Of<KubernetesClient>(), null));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.CreateSessionAsync(NewSessionRequest, CancellationToken)"/> returns an error if the capabilities
+        /// are missing or invalid.
+        /// </summary>
+        /// <param name="request">
+        /// The session request.
+        /// </param>
+        /// <param name="expectedMessage">
+        /// The expected error message.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(CreateSessionAsync_InvalidCapabilities_Data))]
+        public async Task CreateSessionAsync_InvalidCapabilities_Async(NewSessionRequest request, string expectedMessage)
+        {
+            var kubernetes = new Mock<KubernetesClient>();
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+
+            var result = await webDriver.CreateSessionAsync(request, default).ConfigureAwait(false);
+            var error = Assert.IsType<WebDriverError>(result.Value);
+
+            Assert.Equal(WebDriverErrorCode.SessionNotCreated, error.ErrorCode);
+            Assert.Equal(expectedMessage, error.Message);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.CreateSessionAsync(NewSessionRequest, CancellationToken)"/> can create a new session.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateSession_CreatesSession_Async()
+        {
+            var sessionClient = new Mock<NamespacedKubernetesClient<WebDriverSession>>(MockBehavior.Strict);
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(c => c.GetClient<WebDriverSession>()).Returns(sessionClient.Object);
+
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+
+            var request = new NewSessionRequest()
+            {
+                Capabilities = new CapabilitiesRequest()
+                {
+                    AlwaysMatch = new Dictionary<string, object>()
+                     {
+                         { "platformName", "fake" },
+                     },
+                },
+            };
+
+            var session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "fake-abcd",
+                },
+            };
+
+            sessionClient
+                .Setup(s => s.CreateAsync(It.IsAny<WebDriverSession>(), default))
+                .Returns<WebDriverSession, CancellationToken>((request, ct) =>
+                {
+                    Assert.Equal("fake-", request.Metadata.GenerateName);
+                    Assert.Collection(
+                        request.Metadata.Labels,
+                        l =>
+                        {
+                            Assert.Equal(Annotations.AutomationName, l.Key);
+                            Assert.Equal("fake", l.Value);
+                        });
+
+                    Assert.Equal("{\"alwaysMatch\":{\"platformName\":\"fake\"}}", request.Spec.Capabilities);
+
+                    return Task.FromResult(session);
+                });
+
+            var watchHook = sessionClient.WithWatcher(session);
+
+            var task = webDriver.CreateSessionAsync(request, default);
+            var watchClient = await watchHook.ClientRegistered.Task.ConfigureAwait(false);
+
+            // Simulate the session going through the various stages of setup
+            Assert.Equal(WatchResult.Continue, await watchClient(k8s.WatchEventType.Added, session).ConfigureAwait(false));
+            Assert.Equal(WatchResult.Continue, await watchClient(k8s.WatchEventType.Modified, session).ConfigureAwait(false));
+            Assert.Equal(WatchResult.Continue, await watchClient(k8s.WatchEventType.Bookmark, session).ConfigureAwait(false));
+
+            session.Status = new WebDriverSessionStatus()
+            {
+                IngressReady = false,
+                ServiceReady = false,
+                SessionReady = false,
+            };
+
+            Assert.Equal(WatchResult.Continue, await watchClient(k8s.WatchEventType.Modified, session).ConfigureAwait(false));
+
+            session.Status.IngressReady = true;
+            Assert.Equal(WatchResult.Continue, await watchClient(k8s.WatchEventType.Modified, session).ConfigureAwait(false));
+
+            session.Status.SessionReady = true;
+            session.Status.Capabilities = "{}";
+            Assert.Equal(WatchResult.Continue, await watchClient(k8s.WatchEventType.Modified, session).ConfigureAwait(false));
+
+            session.Status.ServiceReady = true;
+            Assert.Equal(WatchResult.Stop, await watchClient(k8s.WatchEventType.Modified, session).ConfigureAwait(false));
+
+            sessionClient.Setup(s => s.TryReadAsync(session.Metadata.Name, default)).ReturnsAsync(session);
+            watchHook.TaskCompletionSource.SetResult(WatchExitReason.ClientDisconnected);
+
+            var result = await task.ConfigureAwait(false);
+            var response = Assert.IsType<NewSessionResponse>(result.Value);
+
+            Assert.Equal("fake-abcd", response.SessionId);
+            Assert.Empty(response.Capabilities);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.CreateSessionAsync(NewSessionRequest, CancellationToken)"/> returns an error
+        /// when the session creation fails.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateSession_HandlesError_Async()
+        {
+            var sessionClient = new Mock<NamespacedKubernetesClient<WebDriverSession>>(MockBehavior.Strict);
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(c => c.GetClient<WebDriverSession>()).Returns(sessionClient.Object);
+
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+
+            var request = new NewSessionRequest()
+            {
+                Capabilities = new CapabilitiesRequest()
+                {
+                    AlwaysMatch = new Dictionary<string, object>()
+                     {
+                         { "platformName", "fake" },
+                     },
+                },
+            };
+
+            var session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "fake-abcd",
+                },
+            };
+
+            sessionClient
+                .Setup(s => s.CreateAsync(It.IsAny<WebDriverSession>(), default))
+                .ReturnsAsync(session);
+
+            var watchHook = sessionClient.WithWatcher(session);
+
+            var task = webDriver.CreateSessionAsync(request, default);
+            var watchClient = await watchHook.ClientRegistered.Task.ConfigureAwait(false);
+
+            // Simulate the session going through the various stages of setup
+            session.Status = new WebDriverSessionStatus()
+            {
+                Error = "error",
+                Data = "data",
+                Message = "message",
+                StackTrace = "stacktrace",
+            };
+            Assert.Equal(WatchResult.Stop, await watchClient(k8s.WatchEventType.Modified, session).ConfigureAwait(false));
+
+            sessionClient.Setup(s => s.TryReadAsync(session.Metadata.Name, default)).ReturnsAsync(session);
+            sessionClient.Setup(s => s.DeleteAsync(session, It.IsAny<TimeSpan>(), default)).Returns(Task.CompletedTask);
+            watchHook.TaskCompletionSource.SetResult(WatchExitReason.ClientDisconnected);
+
+            var result = await task.ConfigureAwait(false);
+            var response = Assert.IsType<WebDriverError>(result.Value);
+
+            Assert.Equal(WebDriverErrorCode.SessionNotCreated, response.ErrorCode);
+            Assert.Equal("data", response.Data);
+            Assert.Equal("message", response.Message);
+            Assert.Equal("stacktrace", response.StackTrace);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.CreateSessionAsync(NewSessionRequest, CancellationToken)"/> returns an error
+        /// when the session creation times out.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateSession_TimesOut_Async()
+        {
+            var sessionClient = new Mock<NamespacedKubernetesClient<WebDriverSession>>(MockBehavior.Strict);
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(c => c.GetClient<WebDriverSession>()).Returns(sessionClient.Object);
+
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+            webDriver.CreationTimeout = TimeSpan.FromMilliseconds(10);
+
+            var request = new NewSessionRequest()
+            {
+                Capabilities = new CapabilitiesRequest()
+                {
+                    AlwaysMatch = new Dictionary<string, object>()
+                     {
+                         { "platformName", "fake" },
+                     },
+                },
+            };
+
+            var session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "fake-abcd",
+                },
+            };
+
+            sessionClient
+                .Setup(s => s.CreateAsync(It.IsAny<WebDriverSession>(), default))
+                .ReturnsAsync(session);
+
+            var watchHook = sessionClient.WithWatcher(session);
+
+            var task = webDriver.CreateSessionAsync(request, default);
+            var watchClient = await watchHook.ClientRegistered.Task.ConfigureAwait(false);
+
+            var result = await task.ConfigureAwait(false);
+            var response = Assert.IsType<WebDriverError>(result.Value);
+
+            Assert.Equal(WebDriverErrorCode.SessionNotCreated, response.ErrorCode);
+            Assert.Equal("The session creation timed out.", response.Message);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.CreateSessionAsync(NewSessionRequest, CancellationToken)"/> returns an error
+        /// when the session is deleted while creation is still in progress.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateSession_HandlesDeletion_Async()
+        {
+            var sessionClient = new Mock<NamespacedKubernetesClient<WebDriverSession>>(MockBehavior.Strict);
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(c => c.GetClient<WebDriverSession>()).Returns(sessionClient.Object);
+
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+
+            var request = new NewSessionRequest()
+            {
+                Capabilities = new CapabilitiesRequest()
+                {
+                    AlwaysMatch = new Dictionary<string, object>()
+                     {
+                         { "platformName", "fake" },
+                     },
+                },
+            };
+
+            var session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "fake-abcd",
+                },
+            };
+
+            sessionClient
+                .Setup(s => s.CreateAsync(It.IsAny<WebDriverSession>(), default))
+                .ReturnsAsync(session);
+
+            var watchHook = sessionClient.WithWatcher(session);
+
+            var task = webDriver.CreateSessionAsync(request, default);
+            var watchClient = await watchHook.ClientRegistered.Task.ConfigureAwait(false);
+
+            // Simulate the session going through the various stages of setup
+            Assert.Equal(WatchResult.Stop, await watchClient(k8s.WatchEventType.Deleted, session).ConfigureAwait(false));
+
+            sessionClient.Setup(s => s.TryReadAsync(session.Metadata.Name, default)).ReturnsAsync((WebDriverSession)null);
+            watchHook.TaskCompletionSource.SetResult(WatchExitReason.ClientDisconnected);
+
+            var result = await task.ConfigureAwait(false);
+            var response = Assert.IsType<WebDriverError>(result.Value);
+
+            Assert.Equal(WebDriverErrorCode.SessionNotCreated, response.ErrorCode);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.DeleteSessionAsync(string, CancellationToken)"/> returns an error when an attempt
+        /// is made to delete a session which does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteSessionAsync_NoSession_ReturnsError_Async()
+        {
+            var sessionClient = new Mock<NamespacedKubernetesClient<WebDriverSession>>(MockBehavior.Strict);
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(c => c.GetClient<WebDriverSession>()).Returns(sessionClient.Object);
+
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+
+            sessionClient.Setup(s => s.TryReadAsync("abc", default)).ReturnsAsync((WebDriverSession)null);
+            var result = await webDriver.DeleteSessionAsync("abc", default).ConfigureAwait(false);
+
+            var error = Assert.IsType<WebDriverError>(result.Value);
+            Assert.Equal(WebDriverErrorCode.InvalidSessionId, error.ErrorCode);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesWebDriver.DeleteSessionAsync(string, CancellationToken)"/> deletes the session.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteSessionAsync_DeletesSession_Async()
+        {
+            var sessionClient = new Mock<NamespacedKubernetesClient<WebDriverSession>>(MockBehavior.Strict);
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(c => c.GetClient<WebDriverSession>()).Returns(sessionClient.Object);
+
+            var webDriver = new KubernetesWebDriver(kubernetes.Object, NullLogger<KubernetesWebDriver>.Instance);
+
+            var session = new WebDriverSession();
+            sessionClient.Setup(s => s.TryReadAsync("abc", default)).ReturnsAsync(session);
+            sessionClient.Setup(s => s.DeleteAsync(session, It.IsAny<V1DeleteOptions>(), It.IsAny<TimeSpan>(), default)).Returns(Task.CompletedTask).Verifiable();
+            var result = await webDriver.DeleteSessionAsync("abc", default).ConfigureAwait(false);
+
+            Assert.Null(result.Value);
+
+            sessionClient.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Api/Kaponata.Api.csproj
+++ b/src/Kaponata.Api/Kaponata.Api.csproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="4.0.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kaponata.Kubernetes\Kaponata.Kubernetes.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Kaponata.Api/KubernetesWebDriver.cs
+++ b/src/Kaponata.Api/KubernetesWebDriver.cs
@@ -1,0 +1,258 @@
+﻿// <copyright file="KubernetesWebDriver.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Kaponata.Api.WebDriver;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Models;
+using Kaponata.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Api
+{
+    /// <summary>
+    /// Implements the WebDriver API, using a Kubernetes cluster as a back-end.
+    /// </summary>
+    public class KubernetesWebDriver
+    {
+        private readonly KubernetesClient kubernetes;
+        private readonly NamespacedKubernetesClient<WebDriverSession> sessionClient;
+        private readonly ILogger<KubernetesWebDriver> logger;
+
+        private readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings()
+        {
+            Formatting = Formatting.None,
+            ContractResolver = new DefaultContractResolver()
+            {
+                NamingStrategy = new CamelCaseNamingStrategy(),
+            },
+            NullValueHandling = NullValueHandling.Ignore,
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesWebDriver"/> class.
+        /// </summary>
+        /// <param name="kubernetes">
+        /// A <see cref="KubernetesClient"/> which can be used to connect to Kubernetes.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which can be used when logging.
+        /// </param>
+        public KubernetesWebDriver(KubernetesClient kubernetes, ILogger<KubernetesWebDriver> logger)
+        {
+            this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            this.sessionClient = this.kubernetes.GetClient<WebDriverSession>();
+        }
+
+        /// <summary>
+        /// Gets or sets the amount of time to wait for a session to be fully provisioned,
+        /// before the operation times out.
+        /// </summary>
+        public TimeSpan CreationTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Asynchronously creates a new session.
+        /// </summary>
+        /// <param name="request">
+        /// The capabilities requested by the client.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a <see cref="WebDriverResponse"/>
+        /// which represents the result of the operation.
+        /// </returns>
+        public async Task<WebDriverResponse> CreateSessionAsync(NewSessionRequest request, CancellationToken cancellationToken)
+        {
+            if (request?.Capabilities?.AlwaysMatch == null)
+            {
+                return new WebDriverResponse(
+                    new WebDriverError(
+                        WebDriverErrorCode.SessionNotCreated,
+                        "Required capabilities are missing"));
+            }
+
+            if (!request.Capabilities.AlwaysMatch.TryGetValue("platformName", out object? platformName)
+                || !(platformName is string))
+            {
+                return new WebDriverResponse(
+                    new WebDriverError(
+                        WebDriverErrorCode.SessionNotCreated,
+                        "The platformName capability is required and must be a string."));
+            }
+
+            if (!string.Equals((string)platformName, "fake", StringComparison.OrdinalIgnoreCase))
+            {
+                return new WebDriverResponse(
+                    new WebDriverError(
+                        WebDriverErrorCode.SessionNotCreated,
+                        $"The platform '{platformName}' is not supported"));
+            }
+
+            var session = await this.sessionClient.CreateAsync(
+                new WebDriverSession()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        NamespaceProperty = "default",
+                        GenerateName = "fake-",
+                        Labels = new Dictionary<string, string>()
+                        {
+                            { Annotations.AutomationName, Annotations.AutomationNames.Fake },
+                        },
+                    },
+                    Spec = new WebDriverSessionSpec()
+                    {
+                        Capabilities = JsonConvert.SerializeObject(request.Capabilities, this.serializerSettings),
+                    },
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            // Wait for the session to:
+            // - have a valid session ID (session creation was successful)
+            // - has an error (session creation failed)
+            // - has been deleted (somebody interfered)
+            // - time out
+            var watcher = this.sessionClient.WatchAsync(
+                session,
+                (eventType, updatedSession) =>
+                {
+                    switch (eventType)
+                    {
+                        case WatchEventType.Deleted:
+                            return Task.FromResult(WatchResult.Stop);
+
+                        case WatchEventType.Modified when SessionIsReadyOrHasFailed(updatedSession):
+                            return Task.FromResult(WatchResult.Stop);
+
+                        default:
+                            return Task.FromResult(WatchResult.Continue);
+                    }
+                },
+                cancellationToken);
+
+            // Give the session one minute to be properly initialized.
+            if (await Task.WhenAny(watcher, Task.Delay(this.CreationTimeout)) == watcher)
+            {
+                session = await this.sessionClient.TryReadAsync(session.Metadata.Name, cancellationToken).ConfigureAwait(false);
+
+                if (SessionIsReady(session))
+                {
+                    return new WebDriverResponse(
+                        new NewSessionResponse
+                        {
+                            SessionId = session.Metadata.Name,
+                            Capabilities = JsonConvert.DeserializeObject<Dictionary<string, object>>(session.Status.Capabilities),
+                        });
+                }
+                else if (session != null)
+                {
+                    await this.sessionClient.DeleteAsync(session, TimeSpan.FromMinutes(1), cancellationToken).ConfigureAwait(false);
+
+                    return new WebDriverResponse(
+                        new WebDriverError(WebDriverErrorCode.SessionNotCreated)
+                        {
+                            Data = session.Status.Data,
+                            Message = session.Status.Message,
+                            StackTrace = session.Status.StackTrace,
+                        });
+                }
+                else
+                {
+                    return new WebDriverResponse(
+                        new WebDriverError(WebDriverErrorCode.SessionNotCreated));
+                }
+            }
+            else
+            {
+                return new WebDriverResponse(
+                    new WebDriverError(WebDriverErrorCode.SessionNotCreated)
+                    {
+                        Message = "The session creation timed out.",
+                    });
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a session.
+        /// </summary>
+        /// <param name="sessionId">
+        /// The ID of the session to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task<WebDriverResponse> DeleteSessionAsync(string sessionId, CancellationToken cancellationToken)
+        {
+            // Find session by label
+            var session = await this.sessionClient.TryReadAsync(
+                sessionId,
+                cancellationToken).ConfigureAwait(false);
+
+            if (session == null)
+            {
+                return new WebDriverResponse(
+                    new WebDriverError(WebDriverErrorCode.InvalidSessionId));
+            }
+            else
+            {
+                await this.sessionClient.DeleteAsync(
+                    session,
+                    new V1DeleteOptions() { PropagationPolicy = "Foreground" },
+                    TimeSpan.FromMinutes(1),
+                    cancellationToken).ConfigureAwait(false);
+
+                return new WebDriverResponse();
+            }
+        }
+
+        private static bool SessionIsReady([NotNullWhen(true)] WebDriverSession? session)
+        {
+            if (session?.Status == null)
+            {
+                return false;
+            }
+
+            var status = session.Status;
+
+            return status.SessionReady && status.IngressReady && status.ServiceReady;
+        }
+
+        private static bool SessionIsReadyOrHasFailed(WebDriverSession session)
+        {
+            if (session?.Status == null)
+            {
+                return false;
+            }
+
+            var status = session.Status;
+
+            if (status.Error != null)
+            {
+                return true;
+            }
+
+            if (status.SessionReady && status.IngressReady && status.ServiceReady)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
@@ -291,7 +291,7 @@ namespace Kaponata.Kubernetes
         /// return value describes why the watcher stopped. The task errors if the watch
         /// loop errors.
         /// </returns>
-        public Task<WatchExitReason> WatchAsync(
+        public virtual Task<WatchExitReason> WatchAsync(
             T value,
             WatchEventDelegate<T> eventHandler,
             CancellationToken cancellationToken)

--- a/src/Kaponata.Operator.Tests/Kaponata.Operator.Tests.csproj
+++ b/src/Kaponata.Operator.Tests/Kaponata.Operator.Tests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
+
+    <Compile Include="$(MSbuildThisFileDirectory)\..\Kaponata.Tests.Shared\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
@@ -7,6 +7,7 @@ using Kaponata.Kubernetes;
 using Kaponata.Kubernetes.Models;
 using Kaponata.Kubernetes.Polyfill;
 using Kaponata.Operator.Operators;
+using Kaponata.Tests.Shared;
 using MELT;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
The `KubernetesWebDriver` class is responsible for creating WebDriver sessions by creating a `WebDriverSession` object in the Kubernetes cluster, and report back whether the session has been provisioned successfully.

Once this PR is merged, the `WebDriverController` can be updated to invoke the `KubernetesWebDriver` class, rather than just returning error codes.