### PR TITLE
Fake operator: Set ingress to true only if a load balancer has been assigned.

### DIFF
--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -39,6 +39,84 @@ namespace Kaponata.Operator.Tests.Operators
                    null),
             };
 
+            // The ingress is not ready
+            yield return new object[]
+            {
+               new ChildOperatorContext<WebDriverSession, V1Ingress>(
+                   new WebDriverSession()
+                   {
+                       Status = new WebDriverSessionStatus(),
+                   },
+                   new V1Ingress()),
+            };
+
+            yield return new object[]
+            {
+               new ChildOperatorContext<WebDriverSession, V1Ingress>(
+                   new WebDriverSession()
+                   {
+                       Status = new WebDriverSessionStatus(),
+                   },
+                   new V1Ingress()
+                   {
+                       Status = new V1IngressStatus(),
+                   }),
+            };
+
+            yield return new object[]
+            {
+               new ChildOperatorContext<WebDriverSession, V1Ingress>(
+                   new WebDriverSession()
+                   {
+                       Status = new WebDriverSessionStatus(),
+                   },
+                   new V1Ingress()
+                   {
+                       Status = new V1IngressStatus()
+                       {
+                            LoadBalancer = new V1LoadBalancerStatus(),
+                       },
+                   }),
+            };
+
+            yield return new object[]
+            {
+               new ChildOperatorContext<WebDriverSession, V1Ingress>(
+                   new WebDriverSession()
+                   {
+                       Status = new WebDriverSessionStatus(),
+                   },
+                   new V1Ingress()
+                   {
+                       Status = new V1IngressStatus()
+                       {
+                            LoadBalancer = new V1LoadBalancerStatus()
+                            {
+                                 Ingress = null,
+                            },
+                       },
+                   }),
+            };
+
+            yield return new object[]
+            {
+               new ChildOperatorContext<WebDriverSession, V1Ingress>(
+                   new WebDriverSession()
+                   {
+                       Status = new WebDriverSessionStatus(),
+                   },
+                   new V1Ingress()
+                   {
+                       Status = new V1IngressStatus()
+                       {
+                            LoadBalancer = new V1LoadBalancerStatus()
+                            {
+                                 Ingress = new V1LoadBalancerIngress[] { },
+                            },
+                       },
+                   }),
+            };
+
             // The session has an associated Ingress but the IngressReady flag is already set.
             yield return new object[]
             {
@@ -50,7 +128,16 @@ namespace Kaponata.Operator.Tests.Operators
                            IngressReady = true,
                        },
                    },
-                   new V1Ingress()),
+                   new V1Ingress()
+                   {
+                       Status = new V1IngressStatus()
+                       {
+                            LoadBalancer = new V1LoadBalancerStatus()
+                            {
+                                 Ingress = new V1LoadBalancerIngress[] { new V1LoadBalancerIngress() },
+                            },
+                       },
+                   }),
             };
         }
 
@@ -174,6 +261,13 @@ namespace Kaponata.Operator.Tests.Operators
                 },
                 new V1Ingress()
                 {
+                    Status = new V1IngressStatus()
+                    {
+                        LoadBalancer = new V1LoadBalancerStatus()
+                        {
+                            Ingress = new V1LoadBalancerIngress[] { new V1LoadBalancerIngress() },
+                        },
+                    },
                 });
 
             var result = await feedback(context, default).ConfigureAwait(false);

--- a/src/Kaponata.Operator/Operators/FakeOperators.cs
+++ b/src/Kaponata.Operator/Operators/FakeOperators.cs
@@ -261,7 +261,12 @@ namespace Kaponata.Operator.Operators
                     var session = context.Parent;
                     var ingress = context.Child;
 
-                    if (ingress != null && !session.Status.IngressReady)
+                    if (ingress?.Status?.LoadBalancer?.Ingress == null
+                        || ingress.Status.LoadBalancer.Ingress.Count == 0)
+                    {
+                        logger.LogInformation("Not setting the ingress status to ready for session {session} because the ingress does not have any load balancer endpoints.", context.Parent?.Metadata?.Name);
+                    }
+                    else if (!session.Status.IngressReady)
                     {
                         patch = new JsonPatchDocument<WebDriverSession>();
                         patch.Add(s => s.Status.IngressReady, true);


### PR DESCRIPTION
`CreateFakeSession_IntegrationTest_Async` seems to be particularly flakey because the session is considered to be "ready" even though the reverse proxy rules have not yet been deployed.