### PR TITLE
RedroidOperator: Rewrite as an a ChildOperator

### DIFF
--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
@@ -393,7 +393,7 @@ namespace Kaponata.Kubernetes
                     this.logger.LogInformation("The server disconnected while watching objects of type {kind}. Currently at resourceVersion {resourceVersion}, reconnecting.", this.metadata.Plural, currentResourceVersion);
                 }
 
-                this.logger.LogInformation("The client disconnected while watching objects of type {kind}. Currently at resourceVersion {resourceVersion}, reconnecting.", this.metadata.Plural, currentResourceVersion);
+                this.logger.LogInformation("The client disconnected while watching objects of type {kind}.", this.metadata.Plural, currentResourceVersion);
                 return WatchExitReason.ClientDisconnected;
             }
             catch (Exception ex)

--- a/src/Kaponata.Operator.Tests/LogConfig.cs
+++ b/src/Kaponata.Operator.Tests/LogConfig.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="LogConfig.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+
+namespace Kaponata.Operator.Tests
+{
+    /// <summary>
+    /// A <see cref="LoggingConfig"/> whih uses the <see cref="LogFormatter"/>.
+    /// </summary>
+    public class LogConfig : LoggingConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogConfig"/> class.
+        /// </summary>
+        public LogConfig()
+        {
+            this.Formatter = new LogFormatter();
+        }
+
+        /// <summary>
+        /// Gets the default logging configuration.
+        /// </summary>
+        public static LoggingConfig Default { get; } = new LogConfig();
+    }
+}

--- a/src/Kaponata.Operator.Tests/LogFormatter.cs
+++ b/src/Kaponata.Operator.Tests/LogFormatter.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="LogFormatter.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Kaponata.Operator.Tests
+{
+    /// <summary>
+    /// Formats log messages.
+    /// </summary>
+    public class LogFormatter : ILogFormatter
+    {
+        /// <inheritdoc/>
+        public string Format(
+            int scopeLevel,
+            string name,
+            LogLevel logLevel,
+            EventId eventId,
+            string message,
+            Exception exception)
+        {
+            const int ScopePaddingSpaces = 4;
+            const string Format = "{0:O} {1}{2} [{3}]: {4}";
+            var padding = new string(' ', scopeLevel * ScopePaddingSpaces);
+
+            StringBuilder builder = new StringBuilder();
+
+            if (string.IsNullOrWhiteSpace(message) == false)
+            {
+                builder.AppendFormat(CultureInfo.InvariantCulture, Format, DateTime.Now, padding, logLevel, eventId.Id, message);
+            }
+
+            if (exception != null)
+            {
+                builder.AppendFormat(
+                    CultureInfo.InvariantCulture,
+                    Format,
+                    DateTime.Now,
+                    padding,
+                    logLevel,
+                    eventId.Id,
+                    exception);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -44,7 +44,7 @@ namespace Kaponata.Operator.Tests.Operators
                     services.AddLogging(
                         (loggingBuilder) =>
                         {
-                            loggingBuilder.AddXunit(output);
+                            loggingBuilder.AddXunit(output, LogConfig.Default);
                         });
                 });
 

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -75,6 +75,17 @@ namespace Kaponata.Operator.Tests.Operators
 
             var kubernetes = this.host.Services.GetRequiredService<KubernetesClient>();
             var podClient = kubernetes.GetClient<V1Pod>();
+
+            var sessionClient = kubernetes.GetClient<WebDriverSession>();
+            var logger = this.host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(name);
+
+            // Delete all objects which may have been previously created by this test.
+            await Task.WhenAll(
+                sessionClient.TryDeleteAsync($"{name}-empty", TimeSpan.FromMinutes(1), default),
+                sessionClient.TryDeleteAsync($"{name}-fake", TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync($"{name}-empty", TimeSpan.FromMinutes(1), default),
+                podClient.TryDeleteAsync($"{name}-fake", TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
+
             var podWatcher =
                 podClient.WatchAsync(
                     fieldSelector: null,
@@ -82,6 +93,7 @@ namespace Kaponata.Operator.Tests.Operators
                     null,
                     (eventType, pod) =>
                     {
+                        logger.LogInformation($"Got an added {eventType}  event for pod {pod}", eventType, pod.Metadata.Name);
                         switch (eventType)
                         {
                             case k8s.WatchEventType.Added:
@@ -96,15 +108,6 @@ namespace Kaponata.Operator.Tests.Operators
                         return Task.FromResult(WatchResult.Continue);
                     },
                     default);
-
-            var sessionClient = kubernetes.GetClient<WebDriverSession>();
-
-            // Delete all objects which may have been created by this test.
-            await Task.WhenAll(
-                sessionClient.TryDeleteAsync($"{name}-empty", TimeSpan.FromMinutes(1), default),
-                sessionClient.TryDeleteAsync($"{name}-fake", TimeSpan.FromMinutes(1), default),
-                podClient.TryDeleteAsync($"{name}-empty", TimeSpan.FromMinutes(1), default),
-                podClient.TryDeleteAsync($"{name}-fake", TimeSpan.FromMinutes(1), default)).ConfigureAwait(false);
 
             using (var @operator = new ChildOperator<WebDriverSession, V1Pod>(
                 kubernetes,
@@ -170,7 +173,7 @@ namespace Kaponata.Operator.Tests.Operators
                 // Deleting the sessions should result in the associated pod being deleted, too.
                 await sessionClient.DeleteAsync(emptySession, new V1DeleteOptions(propagationPolicy: "Foreground"), TimeSpan.FromMinutes(1), default).ConfigureAwait(false);
                 await sessionClient.DeleteAsync(fakeSession, new V1DeleteOptions(propagationPolicy: "Foreground"), TimeSpan.FromMinutes(1), default).ConfigureAwait(false);
-                await Task.WhenAny(podDeleted.Task, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
+                await Task.WhenAny(podWatcher, podDeleted.Task, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
                 Assert.True(podDeleted.Task.IsCompleted, "Failed to delete the pod within a timespan of 1 minute");
                 var deletedPod = await podDeleted.Task.ConfigureAwait(false);
                 Assert.Equal($"{name}-fake", deletedPod.Metadata.Name);

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorTests.cs
@@ -511,7 +511,7 @@ namespace Kaponata.Operator.Tests.Operators
                 this.feedbackLoops,
                 this.logger))
             {
-                await @operator.InitializeAsync(default).ConfigureAwait(false);
+                await Assert.ThrowsAsync<NotSupportedException>(() => @operator.InitializeAsync(default)).ConfigureAwait(false);
 
                 await Assert.ThrowsAsync<NotSupportedException>(() => @operator.InitializationCompleted).ConfigureAwait(false);
             }

--- a/src/Kaponata.Operator/Operators/RedroidOperator.cs
+++ b/src/Kaponata.Operator/Operators/RedroidOperator.cs
@@ -5,14 +5,10 @@
 using k8s.Models;
 using Kaponata.Kubernetes;
 using Kaponata.Kubernetes.Models;
-using Kaponata.Kubernetes.Polyfill;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Kaponata.Operator.Operators
 {
@@ -20,228 +16,44 @@ namespace Kaponata.Operator.Operators
     /// The <see cref="RedroidOperator"/> detects Android running in Docker containers and creates <see cref="MobileDevice"/>
     /// objects.
     /// </summary>
-    public class RedroidOperator : BackgroundService
+    public class RedroidOperator
     {
-        private readonly ILogger<RedroidOperator> logger;
-        private readonly KubernetesClient kubernetes;
-        private readonly NamespacedKubernetesClient<MobileDevice> mobileDeviceClient;
-
         /// <summary>
-        /// A semaphore which prevents multiple iterations of the <see cref="ReconcileAsync(CancellationToken)"/>
-        /// task running in parallel.
+        /// Creates a builder which can build the redroid operator.
         /// </summary>
-        private readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
-
-        private TaskCompletionSource waitForCompletionTcs;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RedroidOperator"/> class.
-        /// </summary>
-        /// <param name="kubernetes">
-        /// A <see cref="KubernetesClient"/> object which provides access to the Kubernetes API server.
-        /// </param>
-        /// <param name="logger">
-        /// The logger to use when logging.
-        /// </param>
-        public RedroidOperator(KubernetesClient kubernetes, ILogger<RedroidOperator> logger)
-        {
-            this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
-            this.mobileDeviceClient = kubernetes.GetClient<MobileDevice>();
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the operator is currently running.
-        /// </summary>
-        public bool IsRunning { get; private set; }
-
-        /// <summary>
-        /// Gets a <see cref="Task"/> which will finish when the <see cref="RedroidOperator"/> stops executing.
-        /// </summary>
-        public Task WaitForCompletion => this.waitForCompletionTcs.Task;
-
-        /// <summary>
-        /// Gets the labels attached to devices managed by the <see cref="RedroidOperator"/> class.
-        /// </summary>
-        private Dictionary<string, string> DeviceLabels
-            => new ()
-            {
-                // kubernetes.io/os=android
-                { Annotations.Os, Annotations.OperatingSystem.Android },
-
-                // app.kubernetes.io/managedBy=RedroidOperator
-                { Annotations.ManagedBy, nameof(RedroidOperator) },
-            };
-
-        /// <summary>
-        /// Gets a selector which can be used to list devices managed by the <see cref="RedroidOperator"/> class.
-        /// </summary>
-        private string DeviceLabelSelector
-            => Selector.Create(this.DeviceLabels);
-
-        /// <summary>
-        /// Gets a selector which can be used to list Redroid pods.
-        /// </summary>
-        private string PodLabelSelector
-            => Selector.Create(
-                new ()
-                {
-                    // Assume that all pods running the Android operation system are emulators
-                    // kubernetes.io/os=android
-                    { Annotations.Os, Annotations.OperatingSystem.Android },
-                });
-
-        /// <summary>
-        /// The main reconciliation loop for the <see cref="RedroidOperator"/>. Lists all Redroid pods and Redroid mobile device objects
-        /// (by using selector labels). For each Redroid pod, the creates a mobile device object if needed. Finally, the loop
-        /// removes all mobile device objects which refer to Redroid pods which no longer exist.
-        /// </summary>
-        /// <param name="cancellationToken">
-        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// <param name="services">
+        /// The service provider from which to source the required services.
         /// </param>
         /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// A builder which can build the redroid operator.
         /// </returns>
-        public virtual async Task<bool> ReconcileAsync(CancellationToken cancellationToken)
+        public static ChildOperatorBuilder<V1Pod, MobileDevice> BuildRedroidOperator(IServiceProvider services)
         {
-            this.logger.LogInformation("Starting the reconciliation loop");
-
-            this.logger.LogInformation("Acquiring the sempahore.");
-            await this.semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            this.logger.LogInformation("Acquired the semaphore.");
-
-            try
+            if (services == null)
             {
-                // Enumerate all Android emulator pods
-                this.logger.LogInformation("Listing all emulator pods");
-                var pods = await this.kubernetes.ListPodAsync(labelSelector: this.PodLabelSelector, cancellationToken: cancellationToken).ConfigureAwait(false);
-                this.logger.LogInformation("Found {count} emulator pods", pods.Items.Count);
-
-                // Enumerate all Android emulator devices
-                this.logger.LogInformation("Listing all emulator devices");
-                var devices = await this.mobileDeviceClient.ListAsync(labelSelector: this.DeviceLabelSelector, cancellationToken: cancellationToken).ConfigureAwait(false);
-                this.logger.LogInformation("Found {count} emulator devices", devices.Items.Count);
-
-                // Loop over all Android emulator pods. Process them one by one; remove the equivalent device from the device list
-                // when processing is done. Any device which persists is an obsolete device.
-                foreach (var pod in pods.Items)
-                {
-                    if (pod.Status.Phase != "Running")
-                    {
-                        this.logger.LogInformation("The pod '{pod}' is in phase '{phase}'. Skipping", pod.Metadata.Name, pod.Status.Phase);
-                        continue;
-                    }
-
-                    if (!pod.Status.ContainerStatuses.All(c => c.Ready))
-                    {
-                        this.logger.LogInformation("The pod '{pod}' is not ready. Skipping", pod.Metadata.Name);
-                        continue;
-                    }
-
-                    var device = devices.Items.SingleOrDefault(d => d.Metadata.Name == pod.Metadata.Name);
-
-                    if (device == null)
-                    {
-                        device =
-                            await this.mobileDeviceClient.CreateAsync(
-                                new MobileDevice()
-                                {
-                                    Metadata = new V1ObjectMeta()
-                                    {
-                                        Name = pod.Metadata.Name,
-                                        NamespaceProperty = pod.Metadata.NamespaceProperty,
-                                        Labels = this.DeviceLabels,
-                                    },
-                                    Spec = new MobileDeviceSpec()
-                                    {
-                                        Owner = pod.Metadata.Name,
-                                    },
-                                },
-                                cancellationToken).ConfigureAwait(false);
-
-                        this.logger.LogInformation("Created device '{device}' for emulator pod '{pod}'", device.Metadata.Name, pod.Metadata.Name);
-                    }
-                    else
-                    {
-                        devices.Items.Remove(device);
-                        this.logger.LogInformation("Device '{device}' exists for emulator pod '{pod}'", device.Metadata.Name, pod.Metadata.Name);
-                    }
-                }
-
-                // Remove all obsolete devices.
-                foreach (var device in devices.Items)
-                {
-                    this.logger.LogInformation("Deleting obsolete device {device}", device.Metadata.Name);
-                    await this.mobileDeviceClient.DeleteAsync(device, TimeSpan.FromMinutes(1), cancellationToken: cancellationToken).ConfigureAwait(false);
-                    this.logger.LogInformation("Deleted obsolete device {device}", device.Metadata.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogError(ex, "An error occurred while executing the {operatorName} reconciliation loop: {message}", this.GetType().Name, ex.Message);
-                return false;
-            }
-            finally
-            {
-                this.logger.LogInformation("Releasing the semaphore");
-                this.semaphore.Release();
-                this.logger.LogInformation("Released the semaphore");
+                throw new ArgumentNullException(nameof(services));
             }
 
-            return true;
-        }
+            var kubernetes = services.GetRequiredService<KubernetesClient>();
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("RedroidOperator");
 
-        /// <inheritdoc/>
-        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
-        {
-            this.waitForCompletionTcs = new TaskCompletionSource();
-            this.IsRunning = true;
+            return new ChildOperatorBuilder(services)
+                .CreateOperator("RedroidOperator")
+                .Watches<V1Pod>()
+                .WithLabels(s => s.Metadata.Labels[Annotations.Os] == Annotations.OperatingSystem.Android)
+                .Where(pod => pod.Status?.ContainerStatuses != null && pod.Status.ContainerStatuses.All(c => c.Ready))
+                .Creates<MobileDevice>(
+                    (pod, device) =>
+                    {
+                        device.EnsureMetadata().EnsureLabels();
+                        device.Metadata.Labels.Add(Annotations.Os, Annotations.OperatingSystem.Android);
 
-            this.logger.LogInformation("Starting the {operatorName} operator", this.GetType().Name);
-
-            try
-            {
-                // Start a first reconciliation loop.
-                await this.ReconcileAsync(cancellationToken).ConfigureAwait(false);
-
-                var watchTasks = new Task<WatchExitReason>[]
-                {
-                    this.mobileDeviceClient.WatchAsync(
-                        fieldSelector: null,
-                        labelSelector: this.DeviceLabelSelector,
-                        resourceVersion: null,
-                        async (eventType, device) =>
+                        device.Spec = new MobileDeviceSpec()
                         {
-                            await this.ReconcileAsync(cancellationToken);
-                            return WatchResult.Continue;
-                        },
-                        cancellationToken),
-                    this.kubernetes.WatchPodAsync(
-                        fieldSelector: null,
-                        labelSelector: this.PodLabelSelector,
-                        resourceVersion: null,
-                        async (eventType, pod) =>
-                        {
-                            await this.ReconcileAsync(cancellationToken);
-                            return WatchResult.Continue;
-                        },
-                        cancellationToken),
-                };
-
-                var exitTask = await Task.WhenAny(watchTasks);
-                var exitReason = await exitTask.ConfigureAwait(false);
-
-                this.logger.LogInformation("Exiting operator {operatorName} because a watch task exited with reason {exitReason}", this.GetType().Name, exitReason);
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogError(ex, "An unexpected exception occurred when running the {operatorName} operator: {message}.", this.GetType().Name, ex.Message);
-            }
-            finally
-            {
-                this.waitForCompletionTcs.SetResult();
-                this.IsRunning = false;
-            }
+                            Owner = pod.Metadata.Name,
+                        };
+                    });
         }
     }
 }

--- a/src/Kaponata.Operator/Startup.cs
+++ b/src/Kaponata.Operator/Startup.cs
@@ -29,7 +29,7 @@ namespace Kaponata.Operator
             services.AddHealthChecks();
 
             services.AddKubernetes();
-            services.AddHostedService<RedroidOperator>();
+            services.AddHostedService(serviceProvider => RedroidOperator.BuildRedroidOperator(serviceProvider).Build());
             services.AddFakeOperators();
         }
 

--- a/src/Kaponata.Tests.Shared/NamespacedKubernetesClientExtensions.cs
+++ b/src/Kaponata.Tests.Shared/NamespacedKubernetesClientExtensions.cs
@@ -55,6 +55,18 @@ namespace Kaponata.Tests.Shared
                         Items = items,
                     }));
 
+            foreach (var value in values)
+            {
+                if (value?.Metadata == null)
+                {
+                    continue;
+                }
+
+                client
+                    .Setup(k => k.TryReadAsync(value.Metadata.Name, labelSelector, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(value);
+            }
+
             return items;
         }
 


### PR DESCRIPTION
This PR rewrites the `RedroidOperator` as a `ChildOperator`, and manages to remove a bunch of code in the process.

It also updates the `ci/redroid.yaml` file to include some init containers, which prevent the Redroid container from booting if the required modules (`ashmem_linux` and `binder_linux`) are not configured properly.