### PR TITLE
Add IKubernetesObject.AsOwnerReference extension method

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/KubernetesObjectExtensionsTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesObjectExtensionsTests.cs
@@ -1,0 +1,84 @@
+﻿// <copyright file="KubernetesObjectExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Microsoft.Rest;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesObjectExtensions" /> class.
+    /// </summary>
+    public class KubernetesObjectExtensionsTests
+    {
+        /// <summary>
+        /// The owner reference used by <see cref="KubernetesObjectExtensions.AsOwnerReference(IKubernetesObject{V1ObjectMeta}, bool?, bool?)"/>
+        /// returns a reference which matches <see cref="ModelExtensions.IsOwnedBy(IMetadata{V1ObjectMeta}, IKubernetesObject{V1ObjectMeta})"/>.
+        /// </summary>
+        [Fact]
+        public void AsOwner_MatchesOwnedBy()
+        {
+            var parent = new V1Pod()
+            {
+                ApiVersion = V1Pod.KubeApiVersion,
+                Kind = V1Pod.KubeKind,
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            var child = new V1Pod();
+            child.AddOwnerReference(parent.AsOwnerReference());
+
+            Assert.True(child.IsOwnedBy(parent));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesObjectExtensions.AsOwnerReference(IKubernetesObject{V1ObjectMeta}, bool?, bool?)"/>
+        /// validates its arguments.
+        /// </summary>
+        [Fact]
+        public void AsOwner_ValidatesArguments()
+        {
+            Assert.Throws<ValidationException>(() => new V1Pod().AsOwnerReference());
+            Assert.Throws<ValidationException>(() => new V1Pod() { Kind = V1Pod.KubeKind }.AsOwnerReference());
+            Assert.Throws<ValidationException>(() => new V1Pod() { ApiVersion = V1Pod.KubeApiVersion }.AsOwnerReference());
+        }
+
+        /// <summary>
+        /// The owner reference used by <see cref="KubernetesObjectExtensions.AsOwnerReference(IKubernetesObject{V1ObjectMeta}, bool?, bool?)"/>
+        /// is configured correctly.
+        /// </summary>
+        [Fact]
+        public void AsOwner_ReturnsValidReference()
+        {
+            var parent = new V1Pod()
+            {
+                ApiVersion = V1Pod.KubeApiVersion,
+                Kind = V1Pod.KubeKind,
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test",
+                    NamespaceProperty = "default",
+                    Uid = "my-uid",
+                },
+            };
+
+            var reference = parent.AsOwnerReference();
+            reference.Validate();
+
+            Assert.Equal(V1Pod.KubeApiVersion, reference.ApiVersion);
+            Assert.Null(reference.BlockOwnerDeletion);
+            Assert.Null(reference.Controller);
+            Assert.Equal(V1Pod.KubeKind, reference.Kind);
+            Assert.Equal("test", reference.Name);
+            Assert.Equal("my-uid", reference.Uid);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/KubernetesObjectExtensions.cs
+++ b/src/Kaponata.Kubernetes/KubernetesObjectExtensions.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="KubernetesObjectExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Microsoft.Rest;
+
+namespace Kaponata.Kubernetes
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="IKubernetesObject{TMetadata}"/> interface.
+    /// </summary>
+    public static class KubernetesObjectExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="V1OwnerReference"/> which references this <see cref="IKubernetesObject{TMetadata}"/>.
+        /// </summary>
+        /// <param name="value">
+        /// The object for which to create an owner reference.
+        /// </param>
+        /// <param name="blockOwnerDeletion">
+        /// Gets get or sets a value indicating whether the owner cannot be deleted from the
+        /// clsuter until reference is removed.
+        /// </param>
+        /// <param name="controller">
+        /// Gets or sets a value indicating whether this reference points to the managing controller.
+        /// </param>
+        /// <returns>
+        /// The owner reference for the object.
+        /// </returns>
+        public static V1OwnerReference AsOwnerReference(
+            this IKubernetesObject<V1ObjectMeta> value,
+            bool? blockOwnerDeletion = null,
+            bool? controller = null)
+        {
+            if (value.ApiVersion == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "value.ApiVersion");
+            }
+
+            if (value.Kind == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "value.Kind");
+            }
+
+            // To be kept in sync with https://github.com/kubernetes-client/csharp/blob/5be3cff425b91b1d16dd0361bf7756a0cb779d8d/src/KubernetesClient/ModelExtensions.cs#L610
+            return new V1OwnerReference()
+            {
+                ApiVersion = value.ApiVersion,
+                Kind = value.Kind,
+                Name = value.Name(),
+                Uid = value.Uid(),
+                BlockOwnerDeletion = blockOwnerDeletion,
+                Controller = controller,
+            };
+        }
+    }
+}

--- a/src/Kaponata.Operator/Operators/ChildOperator.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperator.cs
@@ -353,15 +353,7 @@ namespace Kaponata.Operator.Operators
                             NamespaceProperty = context.Parent.Metadata.NamespaceProperty,
                             OwnerReferences = new V1OwnerReference[]
                             {
-                                new V1OwnerReference()
-                                {
-                                    Kind = context.Parent.Kind,
-                                    ApiVersion = context.Parent.ApiVersion,
-                                    BlockOwnerDeletion = false,
-                                    Controller = false,
-                                    Name = context.Parent.Metadata.Name,
-                                    Uid = context.Parent.Metadata.Uid,
-                                },
+                                context.Parent.AsOwnerReference(blockOwnerDeletion: false, controller: false),
                             },
                         },
                     };


### PR DESCRIPTION
Instead of manually creating the `V1OwnerReference` object over and over again, add an extension method for this.