### PR TITLE
NamespacedKubernetesClient.TryReadAsync: Always populate the ApiGroup, Kind properties

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/KindMetadataTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/KindMetadataTests.cs
@@ -18,9 +18,10 @@ namespace Kaponata.Kubernetes.Tests
         /// </summary>
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("group", () => new KindMetadata("group", "version", "plural"));
-            Assert.Throws<ArgumentNullException>("version", () => new KindMetadata("group", null, "plural"));
-            Assert.Throws<ArgumentNullException>("plural", () => new KindMetadata("group", "version", null));
+            Assert.Throws<ArgumentNullException>("group", () => new KindMetadata("group", "version", "kind", "plural"));
+            Assert.Throws<ArgumentNullException>("version", () => new KindMetadata("group", null, "kind", "plural"));
+            Assert.Throws<ArgumentNullException>("kind", () => new KindMetadata("group", "version", null, "plural"));
+            Assert.Throws<ArgumentNullException>("plural", () => new KindMetadata("group", "version", "kind", null));
         }
 
         /// <summary>
@@ -28,10 +29,13 @@ namespace Kaponata.Kubernetes.Tests
         /// </summary>
         public void Constructor_SetsProperties()
         {
-            var meta = new KindMetadata("group", "version", "plural");
+            var meta = new KindMetadata("group", "version", "kind", "plural");
             Assert.Equal("group", meta.Group);
             Assert.Equal("version", meta.Version);
+            Assert.Equal("kind", meta.Kind);
             Assert.Equal("plural", meta.Plural);
+
+            Assert.Equal("group/version", meta.ApiVersion);
         }
     }
 }

--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.NamespacedObject.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.NamespacedObject.cs
@@ -32,7 +32,7 @@ namespace Kaponata.Kubernetes.Tests
 
             using (var client = mock.Object)
             {
-                var kind = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+                var kind = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
                 await Assert.ThrowsAsync<ArgumentNullException>("kind", () => client.CreateNamespacedValueAsync(null, new V1Pod(), default)).ConfigureAwait(false);
                 await Assert.ThrowsAsync<ArgumentNullException>("value", () => client.CreateNamespacedValueAsync(kind, (V1Pod)null, default)).ConfigureAwait(false);

--- a/src/Kaponata.Kubernetes.Tests/NamespacedKubernetesClientTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/NamespacedKubernetesClientTests.cs
@@ -921,7 +921,7 @@ namespace Kaponata.Kubernetes.Tests
         public async Task TryReadAsync_ItemExists_Works_Async()
         {
             var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
+            var metadata = new KindMetadata("core", V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             V1Pod pod = new V1Pod();
             var pods = new ItemList<V1Pod>()
@@ -944,6 +944,12 @@ namespace Kaponata.Kubernetes.Tests
             var value = await client.TryReadAsync("name", null, default).ConfigureAwait(false);
 
             Assert.Same(pod, value);
+
+            // Additionally, calling TryReadAsync also populates the "ApiGroup" and "Kind" properties on the
+            // individual items. This acts as a workaround for https://github.com/kubernetes/kubernetes/issues/80609
+            // https://github.com/kubernetes/kubernetes/issues/3030 and https://github.com/kubernetes/kubernetes/pull/80618
+            Assert.Equal("core/v1", value.ApiVersion);
+            Assert.Equal(V1Pod.KubeKind, value.Kind);
         }
 
         /// <summary>

--- a/src/Kaponata.Kubernetes.Tests/NamespacedKubernetesClientTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/NamespacedKubernetesClientTests.cs
@@ -34,9 +34,9 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("parent", () => new NamespacedKubernetesClient<V1Pod>(null, new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "core"), NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance));
+            Assert.Throws<ArgumentNullException>("parent", () => new NamespacedKubernetesClient<V1Pod>(null, new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "core"), NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance));
             Assert.Throws<ArgumentNullException>("metadata", () => new NamespacedKubernetesClient<V1Pod>(Mock.Of<KubernetesClient>(), null, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance));
-            Assert.Throws<ArgumentNullException>("logger", () => new NamespacedKubernetesClient<V1Pod>(Mock.Of<KubernetesClient>(), new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "core"), null));
+            Assert.Throws<ArgumentNullException>("logger", () => new NamespacedKubernetesClient<V1Pod>(Mock.Of<KubernetesClient>(), new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "core"), null));
         }
 
         /// <summary>
@@ -657,7 +657,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task TryDeleteAsync_ValidatesArguments_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
 
             var client = new NamespacedKubernetesClient<V1Pod>(parent.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
@@ -672,7 +672,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task TryDeleteAsync_DoesNotExist_DoesNothing_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
 
             // Return an empty list when searching for the requested pod.
@@ -699,7 +699,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task TryDeleteAsync_DoesExist_DoesDelete_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
 
             // Return the requested pod when searching for the requested pod.
@@ -750,7 +750,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task PatchAsync_ValidatesParameters_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
             var client = new NamespacedKubernetesClient<V1Pod>(parent.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
 
@@ -770,7 +770,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task PatchAsync_Works_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.DeserializationSettings).Returns(new JsonSerializerSettings());
             protocol.Setup(p => p.Dispose());
@@ -827,7 +827,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task PatchStatusAsync_ValidatesParameters_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var parent = new Mock<KubernetesClient>(MockBehavior.Strict);
             var client = new NamespacedKubernetesClient<V1Pod>(parent.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
 
@@ -847,7 +847,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task PatchStatusAsync_Works_Async()
         {
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol.Setup(p => p.DeserializationSettings).Returns(new JsonSerializerSettings());
             protocol.Setup(p => p.Dispose());
@@ -907,7 +907,7 @@ namespace Kaponata.Kubernetes.Tests
         [Fact]
         public async Task TryReadAsync_ValidatesArguments_Async()
         {
-            var client = new NamespacedKubernetesClient<V1Pod>(Mock.Of<KubernetesClient>(), new KindMetadata(string.Empty, string.Empty, string.Empty), NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
+            var client = new NamespacedKubernetesClient<V1Pod>(Mock.Of<KubernetesClient>(), new KindMetadata(string.Empty, string.Empty, string.Empty, string.Empty), NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
 
             await Assert.ThrowsAsync<ArgumentNullException>("name", () => client.TryReadAsync(null, "selector", default)).ConfigureAwait(false);
         }
@@ -921,7 +921,7 @@ namespace Kaponata.Kubernetes.Tests
         public async Task TryReadAsync_ItemExists_Works_Async()
         {
             var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             V1Pod pod = new V1Pod();
             var pods = new ItemList<V1Pod>()
@@ -955,7 +955,7 @@ namespace Kaponata.Kubernetes.Tests
         public async Task TryReadAsync_ItemDoesNotExist_Works_Async()
         {
             var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             var pods = new ItemList<V1Pod>()
             {
@@ -990,7 +990,7 @@ namespace Kaponata.Kubernetes.Tests
                 .Setup(w => w.WatchNamespacedObjectAsync<V1Pod, ItemList<V1Pod>>("fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<V1Pod, ItemList<V1Pod>>>(), It.IsAny<WatchEventDelegate<V1Pod>>(), default))
                 .ReturnsAsync(WatchExitReason.ClientDisconnected)
                 .Verifiable();
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             var client = new NamespacedKubernetesClient<V1Pod>(kubernetes.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
             WatchEventDelegate<V1Pod> eventHandler = (eventType, value) => { return Task.FromResult(WatchResult.Stop); };
@@ -1015,7 +1015,7 @@ namespace Kaponata.Kubernetes.Tests
                 .Setup(w => w.WatchNamespacedObjectAsync<V1Pod, ItemList<V1Pod>>("fieldSelector", "labelSelector", "resourceVersion", It.IsAny<ListNamespacedObjectWithHttpMessagesAsync<V1Pod, ItemList<V1Pod>>>(), It.IsAny<WatchEventDelegate<V1Pod>>(), default))
                 .ThrowsAsync(new HttpOperationException())
                 .Verifiable();
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             var client = new NamespacedKubernetesClient<V1Pod>(kubernetes.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
             WatchEventDelegate<V1Pod> eventHandler = (eventType, value) => { return Task.FromResult(WatchResult.Stop); };
@@ -1052,7 +1052,7 @@ namespace Kaponata.Kubernetes.Tests
                 .ReturnsAsync(WatchExitReason.ClientDisconnected)
                 .Verifiable();
 
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             var client = new NamespacedKubernetesClient<V1Pod>(kubernetes.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
             WatchEventDelegate<V1Pod> eventHandler = (eventType, value) => { throw new NotImplementedException(); };
@@ -1084,7 +1084,7 @@ namespace Kaponata.Kubernetes.Tests
                 .ReturnsAsync(WatchExitReason.ClientDisconnected)
                 .Verifiable();
 
-            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, "pods");
+            var metadata = new KindMetadata(V1Pod.KubeGroup, V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods");
 
             var client = new NamespacedKubernetesClient<V1Pod>(kubernetes.Object, metadata, NullLogger<NamespacedKubernetesClient<V1Pod>>.Instance);
             WatchEventDelegate<V1Pod> eventHandler = (eventType, value) => { return Task.FromResult(WatchResult.Stop); };

--- a/src/Kaponata.Kubernetes/KindMetadata.cs
+++ b/src/Kaponata.Kubernetes/KindMetadata.cs
@@ -21,14 +21,18 @@ namespace Kaponata.Kubernetes
         /// <param name="version">
         /// The Version used by Kubernetes to identify the object.
         /// </param>
+        /// <param name="kind">
+        /// The Kind used by Kubernetes to identify the object.
+        /// </param>
         /// <param name="plural">
         /// The plural name of the object type, used by Kubernetes to identify the object.
         /// </param>
-        public KindMetadata(string group, string version, string plural)
+        public KindMetadata(string group, string version, string kind, string plural)
         {
             this.Group = group ?? throw new ArgumentNullException(nameof(group));
             this.Version = version ?? throw new ArgumentNullException(nameof(version));
             this.Plural = plural ?? throw new ArgumentNullException(nameof(plural));
+            this.Kind = kind ?? throw new ArgumentNullException(nameof(kind));
         }
 
         /// <summary>
@@ -42,8 +46,19 @@ namespace Kaponata.Kubernetes
         public string Version { get; }
 
         /// <summary>
+        /// Gets the Kind used by Kubernetes to identify the object.
+        /// </summary>
+        public string Kind { get; }
+
+        /// <summary>
         /// Gets the plural name of the object type, used by Kubernetes to identify the object.
         /// </summary>
         public string Plural { get; }
+
+        /// <summary>
+        /// Gets the API Version used by Kubernetes to identify the object. Consists of the
+        /// <see cref="Group"/> and <see cref="Version"/> information.
+        /// </summary>
+        public string ApiVersion => $"{this.Group}/{this.Version}";
     }
 }

--- a/src/Kaponata.Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.cs
@@ -57,9 +57,9 @@ namespace Kaponata.Kubernetes
 
             this.knownTypes.Add(typeof(MobileDevice), MobileDevice.KubeMetadata);
             this.knownTypes.Add(typeof(WebDriverSession), WebDriverSession.KubeMetadata);
-            this.knownTypes.Add(typeof(V1Pod), new KindMetadata("core", V1Pod.KubeApiVersion, "pods"));
-            this.knownTypes.Add(typeof(V1Service), new KindMetadata("core", V1Service.KubeApiVersion, "services"));
-            this.knownTypes.Add(typeof(V1Ingress), new KindMetadata(V1Ingress.KubeGroup, V1Ingress.KubeApiVersion, "ingresses"));
+            this.knownTypes.Add(typeof(V1Pod), new KindMetadata("core", V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods"));
+            this.knownTypes.Add(typeof(V1Service), new KindMetadata("core", V1Service.KubeApiVersion, V1Service.KubeKind, "services"));
+            this.knownTypes.Add(typeof(V1Ingress), new KindMetadata(V1Ingress.KubeGroup, V1Ingress.KubeApiVersion, V1Ingress.KubeKind, "ingresses"));
         }
 
 #nullable disable

--- a/src/Kaponata.Kubernetes/Models/MobileDevice.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDevice.cs
@@ -50,7 +50,7 @@ namespace Kaponata.Kubernetes.Models
         /// <summary>
         /// Gets <see cref="KindMetadata"/> which describes the <see cref="MobileDevice"/> object type.
         /// </summary>
-        public static KindMetadata KubeMetadata { get; } = new KindMetadata(KubeGroup, KubeVersion, KubePlural);
+        public static KindMetadata KubeMetadata { get; } = new KindMetadata(KubeGroup, KubeVersion, KubeKind, KubePlural);
 
         /// <summary>
         /// Gets or sets the API version, which defines the versioned schema of this representation of

--- a/src/Kaponata.Kubernetes/Models/WebDriverSession.cs
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSession.cs
@@ -46,7 +46,7 @@ namespace Kaponata.Kubernetes.Models
         /// <summary>
         /// Gets <see cref="KindMetadata"/> which describes the <see cref="WebDriverSession"/> object type.
         /// </summary>
-        public static KindMetadata KubeMetadata { get; } = new KindMetadata(KubeGroup, KubeVersion, KubePlural);
+        public static KindMetadata KubeMetadata { get; } = new KindMetadata(KubeGroup, KubeVersion, KubeKind, KubePlural);
 
         /// <summary>
         /// Gets or sets the API version, which defines the versioned schema of this representation of

--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
@@ -193,7 +193,24 @@ namespace Kaponata.Kubernetes
             }
 
             var list = await this.parent.RunTaskAsync(this.ListAsync(fieldSelector: $"metadata.name={name}", labelSelector: labelSelector, cancellationToken: cancellationToken)).ConfigureAwait(false);
-            return list.Items?.SingleOrDefault();
+            var value = list.Items?.SingleOrDefault();
+
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value.Kind == null)
+            {
+                value.Kind = this.metadata.Kind;
+            }
+
+            if (value.ApiVersion == null)
+            {
+                value.ApiVersion = this.metadata.ApiVersion;
+            }
+
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
Have `TryReadAsync` also populates the `ApiGroup` and `Kind` properties on the individual items. This acts as a workaround for https://github.com/kubernetes/kubernetes/issues/80609, https://github.com/kubernetes/kubernetes/issues/3030 and https://github.com/kubernetes/kubernetes/pull/80618