### PR TITLE
Add the kaponata/appium-android image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -10,6 +10,7 @@ on:
     - src/adb/**
     - src/fake-driver/**
     - src/appium/**
+    - src/appium-android/**
 
 jobs:
   build:
@@ -22,6 +23,7 @@ jobs:
         - adb
         - fake-driver
         - appium
+        - appium-android
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -43,6 +43,14 @@ jobs:
           gomplate --version
 
       - name: Build Docker image
-        run: |
-          make
+        run: make
+        working-directory: src/${{ matrix.image }}
+
+      - name: Login to quay.io
+        if: github.ref == 'refs/heads/main'
+        run: docker login -u="${{ secrets.QUAY_ACCOUNT_NAME }}" -p="${{ secrets.QUAY_ACCOUNT_TOKEN }}" quay.io
+
+      - name: Publish Operator container image
+        if: github.ref == 'refs/heads/main'
+        run: make push
         working-directory: src/${{ matrix.image }}

--- a/src/adb/Dockerfile
+++ b/src/adb/Dockerfile
@@ -33,4 +33,4 @@ LABEL org.opencontainers.image.ref.name=$GIT_REF
 
 COPY --from=build /build/adb /usr/bin/
 
-CMD [ "/usr/bin/adb",  "-a", "-P", "5037", "server", "nodaemon" ]
+CMD [ "/usr/bin/adb", "-a", "-P", "5037", "server", "nodaemon" ]

--- a/src/appium-android/Dockerfile
+++ b/src/appium-android/Dockerfile
@@ -1,0 +1,70 @@
+FROM ubuntu:focal AS build
+
+RUN apt-get update \
+&& apt-get install -y curl unzip zlib1g \
+&& rm -rf /var/lib/apt/lists/*
+
+ARG JDK_VERSION=15.0.2
+ARG JDK_SLUG=0d1cfde4252546c6931946de8db48ee2
+ENV JAVA_HOME=/java
+
+WORKDIR $JAVA_HOME
+ENV PATH=$PATH:$JAVA_HOME
+
+RUN curl -o java.tar.gz https://download.java.net/java/GA/jdk${JDK_VERSION}/${JDK_SLUG}/7/GPL/openjdk-${JDK_VERSION}_linux-x64_bin.tar.gz \
+&& tar xvzf java.tar.gz --strip-components=1 \
+&& rm java.tar.gz
+
+# The latest build tools and platform tools version number can
+# be found in https://dl.google.com/android/repository/repository2-1.xml
+ARG BUILD_TOOLS_VERSION="30.0.3"
+ARG PLATFORM_TOOLS_VERSION="30.0.5"
+
+ENV ANDROID_HOME=/android
+
+WORKDIR $ANDROID_HOME/build-tools
+
+RUN curl -o build-tools_r${BUILD_TOOLS_VERSION}-linux.zip https://dl.google.com/android/repository/build-tools_r${BUILD_TOOLS_VERSION}-linux.zip \
+&& unzip build-tools_r${BUILD_TOOLS_VERSION}-linux.zip \
+&& rm build-tools_r${BUILD_TOOLS_VERSION}-linux.zip
+
+WORKDIR $ANDROID_HOME
+
+RUN curl -o platform-tools_r${PLATFORM_TOOLS_VERSION}-linux.zip https://dl.google.com/android/repository/platform-tools_r${PLATFORM_TOOLS_VERSION}-linux.zip \
+&& unzip platform-tools_r${PLATFORM_TOOLS_VERSION}-linux.zip \
+&& rm platform-tools_r${PLATFORM_TOOLS_VERSION}-linux.zip
+
+FROM quay.io/kaponata/appium:1.20.2
+
+ARG GIT_COMMIT_DATE
+ARG GIT_COMMIT_ID
+ARG GIT_REF
+ARG GIT_REMOTE
+ARG VERSION
+
+LABEL org.opencontainers.image.title="appium-android"
+LABEL org.opencontainers.image.description="Appium is an open source test automation framework for use with native, hybrid and mobile web apps. It drives iOS, Android, and Windows apps using the WebDriver protocol. This image contains the tools required to run tests on Android devices."
+
+LABEL org.opencontainers.image.created=$GIT_COMMIT_DATE
+LABEL org.opencontainers.image.authors="Frederik Carlier <frederik.carlier@quamotion.mobi>"
+LABEL org.opencontainers.image.vendor="Quamotion bv <info@quamotion.mobi>"
+LABEL org.opencontainers.image.url="https://www.kaponata.io/"
+LABEL org.opencontainers.image.source=$GIT_REMOTE
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$GIT_COMMIT_ID
+LABEL org.opencontainers.image.ref.name=$GIT_REF
+
+COPY --from=build /lib/x86_64-linux-gnu/libz.so* /lib/x86_64-linux-gnu/
+COPY --from=build /java /java
+
+# We can significantly reduce the size of the resulting container by only copying
+# the Android tools which are actually used by Appium:
+COPY --from=build --chmod=a+x /android/platform-tools/adb /android/platform-tools/
+COPY --from=build /android/build-tools/android-11/lib/apksigner.jar /android/build-tools/android-11/lib/
+
+# Alternatively, to just copy the entire Android SDK:
+# COPY --from=build /android /android
+
+ENV JAVA_HOME=/java
+ENV ANDROID_HOME=/android
+ENV PATH=$PATH:$JAVA_HOME:$ANDROID_HOME/platform-tools

--- a/src/appium-android/Makefile
+++ b/src/appium-android/Makefile
@@ -1,0 +1,33 @@
+registry=quay.io/kaponata
+image=appium-android
+
+all: .amd64.docker-id .version
+
+push: all
+	docker push $(registry)/$(image):latest-amd64
+	docker manifest rm $(registry)/$(image):$(shell cat .version) || echo "Manifest does not exist"
+	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64
+	docker manifest push $(registry)/$(image):$(shell cat .version)
+
+deploy: all
+	k3d image import $(registry)/$(image):latest-amd64
+	docker image ls $(registry)/$(image):latest-amd64
+	docker exec -it k3d-k3s-default-server-0 crictl images | grep $(registry)/$(image)
+
+.version: .amd64.docker-id
+	docker run --rm -it $(shell cat .amd64.docker-id) /app/appium/build/lib/main.js --version | tee .version
+
+.amd64.docker-id: Dockerfile
+	docker buildx build \
+		--progress plain \
+		--platform linux/amd64 \
+		--build-arg host= \
+		--build-arg arch= \
+		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
+		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
+		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
+		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
+		--build-arg VERSION="$(shell nbgv get-version -v SemVer2)" \
+		. \
+		-t $(registry)/$(image):latest-amd64
+	docker images --no-trunc --quiet $(registry)/$(image):latest-amd64 > .amd64.docker-id

--- a/src/appium/Dockerfile
+++ b/src/appium/Dockerfile
@@ -44,4 +44,4 @@ COPY --from=build /src/node_modules/ /app/
 COPY --from=build /bin/tini /bin/
 
 ENTRYPOINT [ "/bin/tini", "--", "/nodejs/bin/node" ]
-CMD [ "/app/appium/build/lib/main.js", "--host", "0.0.0.0" ]
+CMD [ "/app/appium/build/lib/main.js" ]


### PR DESCRIPTION
This PR adds the kaponata/appium-android image, which builds on the kaponata/appium image, and adds the ADK-specific tools required by the appium-android-uiautomator2 image.

Specifically, this adds:
- adb
- apksigner.jar

The apksigner.jar is a Java application, so this adds a dependency on a Java runtime, too. In the current iteration, this uses OpenJDK.

Installing the ADK is always a bit of an adventure. Installing the utilities via the cmdline-tool package would pull in all sorts of dependencies (including the emulator), so the strategy for now is to download the individual zip files and extract them.
To reduce the size of the final container, only tools which are required (as opposed to all those available in the ADK) are copied to the container.

This PR also:
- Fixes the kaponata/appium image by removing the unsupported `--host` argument
- Fixes a whitespace issue in the kaponata/adb image
- Updates the CI pipeline to publish the various Docker images (adb, usbmuxd,...) from main whenever they have changed