### PR TITLE
Don't attach an terminal when none may be available

### DIFF
--- a/src/adb/Makefile
+++ b/src/adb/Makefile
@@ -10,7 +10,7 @@ push: all
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/adb --version | head -n 1 | awk '{ print $$5 }' | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /usr/bin/adb --version | head -n 1 | awk '{ print $$5 }' | tee .version
 
 .amd64.docker-id: Dockerfile
 	docker buildx build \

--- a/src/appium-android/Makefile
+++ b/src/appium-android/Makefile
@@ -15,7 +15,7 @@ deploy: all
 	docker exec -it k3d-k3s-default-server-0 crictl images | grep $(registry)/$(image)
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /app/appium/build/lib/main.js --version | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /app/appium/build/lib/main.js --version | tee .version
 
 .amd64.docker-id: Dockerfile
 	docker buildx build \

--- a/src/appium/Makefile
+++ b/src/appium/Makefile
@@ -11,7 +11,7 @@ push: all
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /app/appium/build/lib/main.js --version | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /app/appium/build/lib/main.js --version | tee .version
 
 .amd64.docker-id: Dockerfile
 	docker buildx build \

--- a/src/fake-driver/Makefile
+++ b/src/fake-driver/Makefile
@@ -11,7 +11,7 @@ push: all
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /app/appium-fake-driver/build/index.js --version | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /app/appium-fake-driver/build/index.js --version | tee .version
 
 .amd64.docker-id: Dockerfile
 	docker buildx build \

--- a/src/iproxy/Makefile
+++ b/src/iproxy/Makefile
@@ -11,7 +11,7 @@ push: all
 	docker manifest push $(registry)/$(image):$(shell cat .version)
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/iproxy --version | awk '{ print $$2 }' | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /usr/bin/iproxy --version | awk '{ print $$2 }' | tee .version
 
 .amd64.docker-id: Dockerfile
 	docker buildx build \

--- a/src/usbmuxd/Makefile
+++ b/src/usbmuxd/Makefile
@@ -13,7 +13,7 @@ push: all
 	docker push $(registry)/$(image):latest-udev-amd64
 
 .version: .amd64.docker-id
-	docker run --rm -it $(shell cat .amd64.docker-id) /usr/bin/usbmuxd --version | awk '{ print $$2 }' | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /usr/bin/usbmuxd --version | awk '{ print $$2 }' | tee .version
 
 Dockerfile.default: Dockerfile.template default.yaml
 	gomplate -d config=./default.yaml -f Dockerfile.template -o Dockerfile.default


### PR DESCRIPTION
For example, no terminal is available when building the Docker images in GitHub pipelines.