### PR TITLE
Sample YAML files for starting Appium on Redroid

### DIFF
--- a/ci/appium.yaml
+++ b/ci/appium.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redroid-appium
+spec:
+  containers:
+    - name: appium
+      image: quay.io/kaponata/appium-android:latest-amd64
+      resources:
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+      args: [ "/app/appium/build/lib/main.js" ]
+    - name: adb
+      image: quay.io/kaponata/appium-android:latest-amd64
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+      command: [ "/bin/tini", "--", "/android/platform-tools/adb" ]
+      args: [ "-a", "-P", "5037", "server", "nodaemon" ]
+  nodeSelector:
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux

--- a/ci/capabilities.json
+++ b/ci/capabilities.json
@@ -1,0 +1,10 @@
+{
+    "capabilities":
+    {
+        "alwaysMatch":
+        {
+            "platformName": "android",
+            "appium:automationName": "uiautomator2"
+        }
+    }
+}

--- a/ci/redroid.sh
+++ b/ci/redroid.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Start the Redroid and Appium containers
+kubectl create -f redroid.yaml
+kubectl create -f appium.yaml
+
+# Wait for the pods to be ready
+kubectl wait --for=condition=ready pod redroid
+kubectl wait --for=condition=ready pod redroid-appium
+
+# Run 'adb connect' in the Appium pod
+kubectl exec -it redroid-appium -c appium -- /android/platform-tools/adb connect $(kubectl get pods redroid -o=jsonpath='{.status.podIP}')
+kubectl exec -it redroid-appium -c appium -- /android/platform-tools/adb devices
+
+# Start port forwarding
+kubectl port-forward redroid-appium 4723
+
+# Start the session (port-forward will block, so you'll need a separate terminal for this)
+curl -X POST -H "Content-Type: application/json" http://localhost:4723/wd/hub/session --data "@capabilities.json"
+
+# Troubleshooting tips
+kubectl exec -it redroid-appium /android/platform-tools/adb shell

--- a/ci/redroid.yaml
+++ b/ci/redroid.yaml
@@ -23,7 +23,7 @@ spec:
     command: [ 'sh', '-c', 'if [ $(cat /proc/filesystems | grep binder | wc -l) -ne 1 ]; then echo "binder is not configured correctly." >&2 && exit 1; fi']
   containers:
     - name: android
-      image: redroid/redroid:11.0.0-latest
+      image: redroid/redroid:10.0.0-latest
       securityContext:
         privileged: true
       env:


### PR DESCRIPTION
This PR:

- Updates the Redroid YAML file to use Redroid 10.0, as we've seen some issues with Redroid 11 (to be confirmed)
- Adds a YAML file for hosting an Appium pod which can run tests on Android devices. It hosts both the Appium server and an instance of the adb server.