### PR TITLE
adb: use tini, bump to 31.0.0

### DIFF
--- a/src/adb/Dockerfile
+++ b/src/adb/Dockerfile
@@ -1,6 +1,8 @@
 FROM --platform=$BUILDPLATFORM ubuntu:focal AS build
 
-ARG platform_tools_version=30.0.4
+# The latest platform tools version number can
+# be found at https://dl.google.com/android/repository/repository2-1.xml
+ARG platform_tools_version=31.0.0
 ARG tini_version=0.19.0
 
 RUN apt-get update \

--- a/src/adb/Dockerfile
+++ b/src/adb/Dockerfile
@@ -1,9 +1,13 @@
 FROM --platform=$BUILDPLATFORM ubuntu:focal AS build
 
 ARG platform_tools_version=30.0.4
+ARG tini_version=0.19.0
 
 RUN apt-get update \
 && apt-get install -y curl unzip
+
+RUN curl -L -X GET https://github.com/krallin/tini/releases/download/v${tini_version}/tini-amd64 --output /bin/tini \
+&& chmod +x /bin/tini
 
 RUN mkdir -p /build \
 && curl -X GET https://dl.google.com/android/repository/platform-tools_r${platform_tools_version}-linux.zip --output /build/platform-tools_r${platform_tools_version}-linux.zip \
@@ -31,6 +35,9 @@ LABEL org.opencontainers.image.version=$VERSION
 LABEL org.opencontainers.image.revision=$GIT_COMMIT_ID
 LABEL org.opencontainers.image.ref.name=$GIT_REF
 
+COPY --from=build /bin/tini /bin/
 COPY --from=build /build/adb /usr/bin/
+
+ENTRYPOINT [ "/bin/tini", "--" ]
 
 CMD [ "/usr/bin/adb", "-a", "-P", "5037", "server", "nodaemon" ]

--- a/src/appium-android/Dockerfile
+++ b/src/appium-android/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -o java.tar.gz https://download.java.net/java/GA/jdk${JDK_VERSION}/${JD
 # The latest build tools and platform tools version number can
 # be found in https://dl.google.com/android/repository/repository2-1.xml
 ARG BUILD_TOOLS_VERSION="30.0.3"
-ARG PLATFORM_TOOLS_VERSION="30.0.5"
+ARG PLATFORM_TOOLS_VERSION="31.0.0"
 
 ENV ANDROID_HOME=/android
 
@@ -60,7 +60,9 @@ COPY --from=build /java /java
 # We can significantly reduce the size of the resulting container by only copying
 # the Android tools which are actually used by Appium:
 COPY --from=build --chmod=a+x /android/platform-tools/adb /android/platform-tools/
+COPY --from=build --chmod=a+x /android/platform-tools/NOTICE.txt /android/platform-tools/
 COPY --from=build /android/build-tools/android-11/lib/apksigner.jar /android/build-tools/android-11/lib/
+COPY --from=build /android/build-tools/android-11/NOTICE.txt /android/build-tools/android-11/
 
 # Alternatively, to just copy the entire Android SDK:
 # COPY --from=build /android /android


### PR DESCRIPTION
- Terminating a container where adb is running as the top-level process does not work correctly; use tini for signal handling
- Use platform-tools 31.0.0 in the adb and appium-android containers
- Add missing NOTICE files