### PR TITLE
WebDriverSession: Add deviceHost, sessionPort fields

### DIFF
--- a/src/Kaponata.Kubernetes/Models/WebDriverSession.yaml
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSession.yaml
@@ -9,7 +9,7 @@ metadata:
     # operator to determine whether the CRD should be reinstalled or not.
     # Use the following command to determine that version:
     # nbgv get-version $(git rev-list -1 HEAD) -v NuGetPackageVersion
-    app.kubernetes.io/version: "0.2.46"
+    app.kubernetes.io/version: "0.3.25"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kaponata.io
@@ -33,7 +33,13 @@ spec:
               type: object
               properties:
                 capabilities:
-                  description: The capabilities requested by the client.
+                  description: |
+                    The capabilities requested by the client. This is the value of the "capabilities"
+                    element in the new session request, serialized as a string. This object should
+                    at least include an "alwaysMatch" property.
+                  type: string
+                deviceHost:
+                  description: The name or IP address at which the device can be reached.
                   type: string
             status:
               type: object
@@ -77,6 +83,10 @@ spec:
                 sessionReady:
                   description: A value indicating whether the session is ready on the back-end pod.
                   type: boolean
+                sessionPort:
+                  description: The TCP port number at which the Appium server is listening.
+                  type: integer
+
                 ingressReady:
                   description: A value indicating whether the ingress rules are ready.
                   type: boolean

--- a/src/Kaponata.Kubernetes/Models/WebDriverSessionSpec.cs
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSessionSpec.cs
@@ -18,5 +18,11 @@ namespace Kaponata.Kubernetes.Models
         /// </summary>
         [JsonProperty(PropertyName = "capabilities")]
         public string Capabilities { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name or IP address at which the device can be reached.
+        /// </summary>
+        [JsonProperty(PropertyName = "deviceHost")]
+        public string DeviceHost { get; set; }
     }
 }

--- a/src/Kaponata.Kubernetes/Models/WebDriverSessionStatus.cs
+++ b/src/Kaponata.Kubernetes/Models/WebDriverSessionStatus.cs
@@ -32,6 +32,12 @@ namespace Kaponata.Kubernetes.Models
         public bool SessionReady { get; set; }
 
         /// <summary>
+        /// Gets or sets the TCP port number at which the Appium server is listening.
+        /// </summary>
+        [JsonProperty("sessionPort")]
+        public int SessionPort { get; set; }
+
+        /// <summary>
         /// Gets or sets a string indicating the error code. The session failed to start if this
         /// value is set.
         /// </summary>

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -185,8 +185,13 @@ namespace Kaponata.Operator.Tests.Operators
         /// <summary>
         /// <see cref="FakeOperators.BuildIngressOperator(IServiceProvider)"/> correctly configures the child pod.
         /// </summary>
-        [Fact]
-        public void BuildIngressOperator_ConfiguresIngress_Test()
+        /// <param name="sessionPort">
+        /// The port at which the Appium server is listening.
+        /// </param>
+        [Theory]
+        [InlineData(4774)]
+        [InlineData(4723)]
+        public void BuildIngressOperator_ConfiguresIngress_Test(int sessionPort)
         {
             var builder = FakeOperators.BuildIngressOperator(this.host.Services);
 
@@ -199,6 +204,7 @@ namespace Kaponata.Operator.Tests.Operators
                 Status = new WebDriverSessionStatus()
                 {
                     SessionId = "1234",
+                    SessionPort = sessionPort,
                 },
             };
 
@@ -211,7 +217,7 @@ namespace Kaponata.Operator.Tests.Operators
             Assert.Equal("/wd/hub/session/my-session/", path.Path);
             Assert.Equal("Prefix", path.PathType);
             Assert.Equal("my-session", path.Backend.Service.Name);
-            Assert.Equal(4774, path.Backend.Service.Port.Number);
+            Assert.Equal(sessionPort, path.Backend.Service.Port.Number);
 
             Assert.NotNull(ingress.Metadata?.Annotations);
             Assert.Collection(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
@@ -98,8 +98,13 @@ namespace Kaponata.Operator.Tests.Operators
         /// <summary>
         /// <see cref="FakeOperators.BuildServiceOperator(IServiceProvider)"/> correctly configures the child pod.
         /// </summary>
-        [Fact]
-        public void BuildServiceOperator_ConfiguresService_Test()
+        /// <param name="sessionPort">
+        /// The port at which the Appium server is listening.
+        /// </param>
+        [Theory]
+        [InlineData(4774)]
+        [InlineData(4723)]
+        public void BuildServiceOperator_ConfiguresService_Test(int sessionPort)
         {
             var builder = FakeOperators.BuildServiceOperator(this.host.Services);
 
@@ -108,6 +113,10 @@ namespace Kaponata.Operator.Tests.Operators
                 Metadata = new V1ObjectMeta()
                 {
                     Name = "my-session",
+                },
+                Status = new WebDriverSessionStatus()
+                {
+                    SessionPort = sessionPort,
                 },
             };
 
@@ -124,6 +133,8 @@ namespace Kaponata.Operator.Tests.Operators
                 });
 
             var port = Assert.Single(service.Spec.Ports);
+            Assert.Equal(sessionPort, port.TargetPort);
+            Assert.Equal(sessionPort, port.Port);
         }
 
         /// <summary>

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
@@ -366,6 +366,12 @@ namespace Kaponata.Operator.Tests.Operators
                 o =>
                 {
                     Assert.Equal(OperationType.Add, o.OperationType);
+                    Assert.Equal("/status/sessionPort", o.path);
+                    Assert.Equal(4774, o.value);
+                },
+                o =>
+                {
+                    Assert.Equal(OperationType.Add, o.OperationType);
                     Assert.Equal("/status/capabilities", o.path);
                     Assert.Equal("{}", o.value);
                 });


### PR DESCRIPTION
This PR updates the WebDriverSession objects:

- Adds a `spec.deviceHost` field, which should store the IP address at which the muxer/daemon for the device can be reached (think adbd, adb or usbmuxd)
- Adds a `status.sessionPort` field, which contains the TCP port at which the Appium server is running. Not all servers use the same port (think fake-driver vs Appium), so make it configurable

It also updates the ingress and service operators to repsect the `sessionPort` value.