### PR TITLE
ChildOperator: Expose the current service provider as part of the operator context.

### DIFF
--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -72,6 +73,7 @@ namespace Kaponata.Operator.Tests.Operators
             };
 
             var podCreated = new TaskCompletionSource<V1Pod>();
+            var podRunning = new TaskCompletionSource<V1Pod>();
             var podDeleted = new TaskCompletionSource<V1Pod>();
 
             var kubernetes = this.host.Services.GetRequiredService<KubernetesClient>();
@@ -99,6 +101,10 @@ namespace Kaponata.Operator.Tests.Operators
                         {
                             case k8s.WatchEventType.Added:
                                 podCreated.TrySetResult(pod);
+                                break;
+
+                            case k8s.WatchEventType.Modified when pod.Status.Phase == "Running" && pod.Status.ContainerStatuses.All(c => c.Ready):
+                                podRunning.TrySetResult(pod);
                                 break;
 
                             case k8s.WatchEventType.Deleted:
@@ -174,6 +180,11 @@ namespace Kaponata.Operator.Tests.Operators
                 logger.LogInformation($"Created pod: {JsonConvert.SerializeObject(createdPod)}");
                 logger.LogInformation($"Owner reference: {JsonConvert.SerializeObject(ownerReference)}");
                 Assert.Equal($"{name}-fake", createdPod.Metadata.Name);
+
+                await Task.WhenAny(podRunning.Task, Task.Delay(TimeSpan.FromMinutes(2))).ConfigureAwait(false);
+                Assert.True(podRunning.Task.IsCompleted, "Failed to create start the pod within a timespan of 2 minutes");
+                var runningPod = await podCreated.Task.ConfigureAwait(false);
+                logger.LogInformation($"Pod is running: {JsonConvert.SerializeObject(runningPod)}");
 
                 // Deleting the sessions should result in the associated pod being deleted, too.
                 await sessionClient.DeleteAsync(emptySession, new V1DeleteOptions(propagationPolicy: "Foreground"), TimeSpan.FromMinutes(1), default).ConfigureAwait(false);

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -129,7 +129,8 @@ namespace Kaponata.Operator.Tests.Operators
                     };
                 },
                 new Collection<FeedbackLoop<WebDriverSession, V1Pod>>(),
-                this.host.Services.GetRequiredService<ILogger<ChildOperator<WebDriverSession, V1Pod>>>()))
+                this.host.Services.GetRequiredService<ILogger<ChildOperator<WebDriverSession, V1Pod>>>(),
+                this.host.Services))
             {
                 // Start the operator
                 await @operator.StartAsync(default).ConfigureAwait(false);

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -7,7 +7,6 @@ using Kaponata.Kubernetes;
 using Kaponata.Kubernetes.Models;
 using Kaponata.Operator.Operators;
 using Microsoft.AspNetCore.JsonPatch.Operations;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -38,8 +37,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    null,
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             // The ingress is not ready
@@ -51,8 +49,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    new V1Ingress(),
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             yield return new object[]
@@ -66,8 +63,7 @@ namespace Kaponata.Operator.Tests.Operators
                    {
                        Status = new V1IngressStatus(),
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             yield return new object[]
@@ -84,8 +80,7 @@ namespace Kaponata.Operator.Tests.Operators
                             LoadBalancer = new V1LoadBalancerStatus(),
                        },
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             yield return new object[]
@@ -105,8 +100,7 @@ namespace Kaponata.Operator.Tests.Operators
                             },
                        },
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             yield return new object[]
@@ -126,8 +120,7 @@ namespace Kaponata.Operator.Tests.Operators
                             },
                        },
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             // The session has an associated Ingress but the IngressReady flag is already set.
@@ -151,8 +144,7 @@ namespace Kaponata.Operator.Tests.Operators
                             },
                        },
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
         }
 
@@ -290,8 +282,7 @@ namespace Kaponata.Operator.Tests.Operators
                         },
                     },
                 },
-                Mock.Of<KubernetesClient>(),
-                NullLogger.Instance);
+                Mock.Of<IServiceProvider>());
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -7,6 +7,7 @@ using Kaponata.Kubernetes;
 using Kaponata.Kubernetes.Models;
 using Kaponata.Operator.Operators;
 using Microsoft.AspNetCore.JsonPatch.Operations;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -28,6 +29,11 @@ namespace Kaponata.Operator.Tests.Operators
         /// </returns>
         public static IEnumerable<object[]> BuildIngressOperator_NoFeedback_Data()
         {
+            var services = new ServiceCollection()
+                .AddLogging()
+                .AddSingleton(Mock.Of<KubernetesClient>())
+                .BuildServiceProvider();
+
             // The session has no associated Ingress.
             yield return new object[]
             {
@@ -37,7 +43,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    null,
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             // The ingress is not ready
@@ -49,7 +55,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    new V1Ingress(),
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             yield return new object[]
@@ -63,7 +69,7 @@ namespace Kaponata.Operator.Tests.Operators
                    {
                        Status = new V1IngressStatus(),
                    },
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             yield return new object[]
@@ -80,7 +86,7 @@ namespace Kaponata.Operator.Tests.Operators
                             LoadBalancer = new V1LoadBalancerStatus(),
                        },
                    },
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             yield return new object[]
@@ -100,7 +106,7 @@ namespace Kaponata.Operator.Tests.Operators
                             },
                        },
                    },
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             yield return new object[]
@@ -120,7 +126,7 @@ namespace Kaponata.Operator.Tests.Operators
                             },
                        },
                    },
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             // The session has an associated Ingress but the IngressReady flag is already set.
@@ -144,7 +150,7 @@ namespace Kaponata.Operator.Tests.Operators
                             },
                        },
                    },
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
         }
 
@@ -282,7 +288,7 @@ namespace Kaponata.Operator.Tests.Operators
                         },
                     },
                 },
-                Mock.Of<IServiceProvider>());
+                this.host.Services);
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
@@ -7,7 +7,6 @@ using Kaponata.Kubernetes;
 using Kaponata.Kubernetes.Models;
 using Kaponata.Operator.Operators;
 using Microsoft.AspNetCore.JsonPatch.Operations;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -38,8 +37,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    null,
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
 
             // The session has an associated service but the serviceReady flag is already set.
@@ -54,8 +52,7 @@ namespace Kaponata.Operator.Tests.Operators
                        },
                    },
                    new V1Service(),
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   Mock.Of<IServiceProvider>()),
             };
         }
 
@@ -176,8 +173,7 @@ namespace Kaponata.Operator.Tests.Operators
                 new V1Service()
                 {
                 },
-                Mock.Of<KubernetesClient>(),
-                NullLogger.Instance);
+                Mock.Of<IServiceProvider>());
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
@@ -7,6 +7,7 @@ using Kaponata.Kubernetes;
 using Kaponata.Kubernetes.Models;
 using Kaponata.Operator.Operators;
 using Microsoft.AspNetCore.JsonPatch.Operations;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -28,6 +29,11 @@ namespace Kaponata.Operator.Tests.Operators
         /// </returns>
         public static IEnumerable<object[]> BuildServiceOperator_NoFeedback_Data()
         {
+            var services = new ServiceCollection()
+                .AddLogging()
+                .AddSingleton(Mock.Of<KubernetesClient>())
+                .BuildServiceProvider();
+
             // The session has no associated service.
             yield return new object[]
             {
@@ -37,7 +43,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    null,
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
 
             // The session has an associated service but the serviceReady flag is already set.
@@ -52,7 +58,7 @@ namespace Kaponata.Operator.Tests.Operators
                        },
                    },
                    new V1Service(),
-                   Mock.Of<IServiceProvider>()),
+                   services),
             };
         }
 
@@ -173,7 +179,7 @@ namespace Kaponata.Operator.Tests.Operators
                 new V1Service()
                 {
                 },
-                Mock.Of<IServiceProvider>());
+                this.host.Services);
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
@@ -65,14 +65,19 @@ namespace Kaponata.Operator.Tests.Operators
         /// </returns>
         public static IEnumerable<object[]> BuildPodOperator_NoFeedback_Data()
         {
+            var services =
+                new ServiceCollection()
+                    .AddSingleton(Mock.Of<KubernetesClient>())
+                    .AddLogging()
+                    .BuildServiceProvider();
+
             // The session has no requested capabilities.
             yield return new object[]
             {
                new ChildOperatorContext<WebDriverSession, V1Pod>(
                    new WebDriverSession(),
                    null,
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The session has no requested capabilities.
@@ -84,8 +89,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Spec = new WebDriverSessionSpec(),
                    },
                    null,
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The session already has a session id
@@ -104,8 +108,7 @@ namespace Kaponata.Operator.Tests.Operators
                        },
                    },
                    null,
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The pod does not exist.
@@ -121,8 +124,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    null,
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The pod is not ready.
@@ -138,8 +140,7 @@ namespace Kaponata.Operator.Tests.Operators
                        Status = new WebDriverSessionStatus(),
                    },
                    new V1Pod(),
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The pod is not ready.
@@ -158,8 +159,7 @@ namespace Kaponata.Operator.Tests.Operators
                    {
                        Status = new V1PodStatus(),
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The pod is not ready.
@@ -181,8 +181,7 @@ namespace Kaponata.Operator.Tests.Operators
                            Phase = "Pending",
                        },
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
 
             // The pod is not ready.
@@ -211,8 +210,7 @@ namespace Kaponata.Operator.Tests.Operators
                            },
                        },
                    },
-                   Mock.Of<KubernetesClient>(),
-                   NullLogger.Instance),
+                   services),
             };
         }
 
@@ -336,8 +334,7 @@ namespace Kaponata.Operator.Tests.Operators
                         ContainerStatuses = new V1ContainerStatus[] { },
                     },
                 },
-                this.kubernetes.Object,
-                NullLogger.Instance);
+                this.host.Services);
 
             var response = new HttpResponseMessage
             {
@@ -425,8 +422,7 @@ namespace Kaponata.Operator.Tests.Operators
                         ContainerStatuses = new V1ContainerStatus[] { },
                     },
                 },
-                this.kubernetes.Object,
-                NullLogger.Instance);
+                this.host.Services);
 
             var response = new HttpResponseMessage
             {

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent,TChild}.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilder{TParent,TChild}.cs
@@ -115,7 +115,8 @@ namespace Kaponata.Operator.Operators
                 this.parentFilter,
                 this.childFactory,
                 this.feedbackLoops,
-                loggerFactory.CreateLogger<ChildOperator<TParent, TChild>>());
+                loggerFactory.CreateLogger<ChildOperator<TParent, TChild>>(),
+                this.services);
         }
     }
 }

--- a/src/Kaponata.Operator/Operators/ChildOperatorContext.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorContext.cs
@@ -5,6 +5,7 @@
 using k8s;
 using k8s.Models;
 using Kaponata.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -33,16 +34,14 @@ namespace Kaponata.Operator.Operators
         /// <param name="child">
         /// The child object being reconciled.
         /// </param>
-        /// <param name="kubernetes">
-        /// A <see cref="KubernetesClient"/> which provides access to the Kubernetes API.
+        /// <param name="services">
+        /// A service provider from which required services can be sourced.
         /// </param>
-        /// <param name="logger">
-        /// A <see cref="ILogger"/> which can be used when logging diagnostic messages.
-        /// </param>
-        public ChildOperatorContext(TParent parent, TChild child, KubernetesClient kubernetes, ILogger logger)
+        public ChildOperatorContext(TParent parent, TChild child, IServiceProvider services)
         {
-            this.Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            this.Kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
+            this.Services = services ?? throw new ArgumentNullException(nameof(services));
+            this.Logger = services.GetRequiredService<ILogger<ChildOperatorContext<TParent, TChild>>>();
+            this.Kubernetes = services.GetRequiredService<KubernetesClient>();
             this.Parent = parent ?? throw new ArgumentNullException(nameof(parent));
             this.Child = child;
         }
@@ -67,5 +66,10 @@ namespace Kaponata.Operator.Operators
         /// if no child exists.
         /// </summary>
         public TChild Child { get; }
+
+        /// <summary>
+        /// Gets a service context from which additional services may be sourced.
+        /// </summary>
+        public IServiceProvider Services { get; }
     }
 }


### PR DESCRIPTION
An operator may want to access various services in its reconciliation loop.

For example, when working with Android devices, the feedback loop may want to create an `AdbClient` instance so that it can connect to the Android device and configure the device.

This PR:
- Extends the `ChildOperatorContext<TParent, TChild>` class so that it has a `Services` property, which exposes the ServiceProvider.
- Updates the `ChildOperator<TParent, TChild>` class to pass a new service scope to the operator context