### PR TITLE
AdbClient: Better support for mocking, DI

### DIFF
--- a/src/Kaponata.Android/Adb/AdbClient.Services.cs
+++ b/src/Kaponata.Android/Adb/AdbClient.Services.cs
@@ -2,14 +2,12 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,7 +52,7 @@ namespace Kaponata.Android.Adb
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// </returns>
-        public async Task ConnectDeviceAsync(DnsEndPoint endpoint, CancellationToken cancellationToken)
+        public virtual async Task ConnectDeviceAsync(DnsEndPoint endpoint, CancellationToken cancellationToken)
         {
             if (endpoint == null)
             {
@@ -81,7 +79,7 @@ namespace Kaponata.Android.Adb
         /// <returns>
         /// The list of connected devices.
         /// </returns>
-        public async Task<IList<DeviceData>> GetDevicesAsync(CancellationToken cancellationToken)
+        public virtual async Task<IList<DeviceData>> GetDevicesAsync(CancellationToken cancellationToken)
         {
             await using var protocol = await this.TryConnectToAdbAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Kaponata.Android/Adb/AdbClient.cs
+++ b/src/Kaponata.Android/Adb/AdbClient.cs
@@ -3,9 +3,8 @@
 // </copyright>
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
-using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -52,6 +51,17 @@ namespace Kaponata.Android.Adb
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.socketLocator = socketLocator ?? throw new ArgumentNullException(nameof(socketLocator));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdbClient"/> class.
+        /// </summary>
+        /// <remarks>
+        /// Intended for unit testing purposes only.
+        /// </remarks>
+        protected AdbClient()
+            : this(NullLogger<AdbClient>.Instance, NullLoggerFactory.Instance)
+        {
         }
 
         /// <summary>

--- a/src/Kaponata.Android/Adb/AdbProtocol.cs
+++ b/src/Kaponata.Android/Adb/AdbProtocol.cs
@@ -8,7 +8,6 @@ using Nerdbank.Streams;
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -65,6 +64,11 @@ namespace Kaponata.Android.Adb
         /// Gets the encoding used when communicating with adb.
         /// </summary>
         public static Encoding AdbEncoding { get; } = Encoding.GetEncoding(DefaultEncoding);
+
+        /// <summary>
+        /// Gets the underling <see cref="Stream"/> used by this <see cref="AdbProtocol"/>.
+        /// </summary>
+        public Stream Stream => this.stream;
 
         /// <summary>
         /// Gets a shell output stream.


### PR DESCRIPTION
- `AdbClient`: add a protected parameterless constructor which can be used for mocking purposes
- Add a unit test which makes sure that an `AdbClient` can be configured in DI, and that it uses a `AdbSocketLocator` 
- `AdbClient`: mark some methods as `virtual` so they can be mocked
- `AdbClientProtocol`: Expose the underlying stream as property, so we can check it's operating on the correct base stream.