### PR TITLE
Add UIAutomatorOperator

### DIFF
--- a/src/Kaponata.Kubernetes/Annotations.cs
+++ b/src/Kaponata.Kubernetes/Annotations.cs
@@ -95,6 +95,11 @@ namespace Kaponata.Kubernetes
             /// The fake automation provider, implemented by the appium-fake-driver driver.
             /// </summary>
             public const string Fake = "fake";
+
+            /// <summary>
+            /// The UI Automator 2 provider enables test automation of Android devices.
+            /// </summary>
+            public const string UIAutomator2 = "uiautomator2";
         }
 
         /// <summary>

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesAdbContextTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesAdbContextTests.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="KubernetesAdbContextTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Android.Adb;
+using Kaponata.Kubernetes;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Operator.Tests.Kubernetes
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesAdbContext"/> class.
+    /// </summary>
+    public class KubernetesAdbContextTests
+    {
+        /// <summary>
+        /// A <see cref="AdbClient"/> object can be sourced from a dependency injection container, and uses a <see cref="KubernetesAdbSocketLocator"/>
+        /// configured in that DI container if one is available.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task KubernetesAdbSocketLocator_WorksWithDependencyInjection_Async()
+        {
+            var pod = new V1Pod();
+
+            var kubernetes = new Mock<KubernetesClient>();
+            var context = new KubernetesAdbContext() { Pod = pod };
+            var stream = Mock.Of<Stream>();
+
+            kubernetes
+                .Setup(p => p.ConnectToPodPortAsync(pod, 5037, default))
+                .ReturnsAsync(stream);
+
+            var services =
+                new ServiceCollection()
+                .AddScoped<AdbClient>()
+                .AddScoped<AdbSocketLocator, KubernetesAdbSocketLocator>()
+                .AddScoped((p) => context)
+                .AddSingleton(kubernetes.Object)
+                .AddLogging()
+                .BuildServiceProvider();
+
+            var client = services.GetRequiredService<AdbClient>();
+            await using (var protocol = await client.TryConnectToAdbAsync(default))
+            {
+                Assert.Same(stream, protocol.Stream);
+            }
+        }
+    }
+}

--- a/src/Kaponata.Operator.Tests/Kubernetes/KubernetesAdbSocketLocatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Kubernetes/KubernetesAdbSocketLocatorTests.cs
@@ -24,8 +24,8 @@ namespace Kaponata.Operator.Tests.Kubernetes
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("kubernetes", () => new KubernetesAdbSocketLocator(null, new V1Pod()));
-            Assert.Throws<ArgumentNullException>("pod", () => new KubernetesAdbSocketLocator(Mock.Of<KubernetesClient>(), null));
+            Assert.Throws<ArgumentNullException>("kubernetes", () => new KubernetesAdbSocketLocator(null, new KubernetesAdbContext()));
+            Assert.Throws<ArgumentNullException>("context", () => new KubernetesAdbSocketLocator(Mock.Of<KubernetesClient>(), null));
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
                 .Setup(k => k.ConnectToPodPortAsync(pod, 5037, default))
                 .ReturnsAsync(stream.Object);
 
-            var locator = new KubernetesAdbSocketLocator(kubernetes.Object, pod);
+            var locator = new KubernetesAdbSocketLocator(kubernetes.Object, new KubernetesAdbContext() { Pod = pod });
             using (var value = await locator.ConnectToAdbAsync(default))
             {
                 Assert.Same(stream.Object, value);
@@ -67,7 +67,7 @@ namespace Kaponata.Operator.Tests.Kubernetes
         [Fact]
         public void GetAdbSocket_Throws()
         {
-            var locator = new KubernetesAdbSocketLocator(Mock.Of<KubernetesClient>(), new V1Pod());
+            var locator = new KubernetesAdbSocketLocator(Mock.Of<KubernetesClient>(), new KubernetesAdbContext() { Pod = new V1Pod() });
             Assert.Throws<NotSupportedException>(() => locator.GetAdbSocket());
         }
     }

--- a/src/Kaponata.Operator.Tests/Operators/UIAutomatorOperatorsTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/UIAutomatorOperatorsTests.cs
@@ -1,0 +1,277 @@
+﻿// <copyright file="UIAutomatorOperatorsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Android.Adb;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Models;
+using Kaponata.Operator.Kubernetes;
+using Kaponata.Operator.Operators;
+using Microsoft.AspNetCore.JsonPatch.Operations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Operator.Tests.Operators
+{
+    /// <summary>
+    /// Tests the <see cref="UIAutomatorOperators"/> class.
+    /// </summary>
+    public class UIAutomatorOperatorsTests
+    {
+        private readonly Mock<KubernetesClient> kubernetes;
+        private readonly Mock<NamespacedKubernetesClient<V1Pod>> podClient;
+        private readonly Mock<NamespacedKubernetesClient<MobileDevice>> deviceClient;
+        private readonly IHost host;
+        private readonly Mock<AdbClient> adbClient = new Mock<AdbClient>(MockBehavior.Strict);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UIAutomatorOperatorsTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// An output helper to use when logging.
+        /// </param>
+        public UIAutomatorOperatorsTests(ITestOutputHelper output)
+        {
+            this.kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            this.podClient = this.kubernetes.WithClient<V1Pod>();
+            this.deviceClient = this.kubernetes.WithClient<MobileDevice>();
+
+            var builder = new HostBuilder();
+            builder.ConfigureServices(
+                (services) =>
+                {
+                    services.AddSingleton(this.kubernetes.Object);
+                    services.AddLogging(
+                        (loggingBuilder) =>
+                        {
+                            loggingBuilder.AddXunit(output);
+                        });
+
+                    services.AddScoped((p) => this.adbClient.Object);
+                    services.AddScoped<KubernetesAdbContext>();
+                });
+
+            this.host = builder.Build();
+        }
+
+        /// <summary>
+        /// <see cref="UIAutomatorOperators.BuildPodOperator(IServiceProvider)"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void BuildPodOperator_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>("services", () => UIAutomatorOperators.BuildPodOperator(null));
+        }
+
+        /// <summary>
+        /// The parent label selector and the child labels are configured correctly.
+        /// </summary>
+        [Fact]
+        public void Operator_HasCorrectLabels()
+        {
+            var builder = UIAutomatorOperators.BuildPodOperator(this.host.Services);
+
+            Assert.Equal("kaponata.io/automation-name=uiautomator2", builder.Configuration.ParentLabelSelector);
+            Assert.Collection(
+                builder.Configuration.ChildLabels,
+                c =>
+                {
+                    Assert.Equal("app.kubernetes.io/managed-by", c.Key);
+                    Assert.Equal("WebDriverSession-UIAutomator2Driver-PodOperator", c.Value);
+                });
+        }
+
+        /// <summary>
+        /// The session pod is configured correctly.
+        /// </summary>
+        [Fact]
+        public void Operator_ConfiguresPod()
+        {
+            var builder = UIAutomatorOperators.BuildPodOperator(this.host.Services);
+
+            var session = new WebDriverSession()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "my-session",
+                },
+            };
+
+            var child = new V1Pod();
+
+            builder.ChildFactory(session, child);
+
+            Assert.Collection(
+                child.Metadata.Labels,
+                a =>
+                {
+                    Assert.Equal("kaponata.io/session-name", a.Key);
+                    Assert.Equal("my-session", a.Value);
+                });
+
+            Assert.Collection(
+                child.Spec.Containers,
+                c =>
+                {
+                    Assert.Equal("quay.io/kaponata/appium-android:1.20.2", c.Image);
+                    Assert.Equal("appium", c.Name);
+                    Assert.Collection(
+                        c.Args,
+                        a => Assert.Equal("/app/appium/build/lib/main.js", a));
+
+                    var port = Assert.Single(c.Ports);
+                    Assert.Equal(4723, port.ContainerPort);
+                    Assert.Equal("http", port.Name);
+
+                    Assert.Equal("/wd/hub/status", c.ReadinessProbe.HttpGet.Path);
+                    Assert.Equal("4723", c.ReadinessProbe.HttpGet.Port);
+                },
+                c =>
+                {
+                    Assert.Equal("quay.io/kaponata/appium-android:1.20.2", c.Image);
+                    Assert.Equal("adb", c.Name);
+                    Assert.Collection(
+                        c.Command,
+                        a => Assert.Equal("/bin/tini", a),
+                        a => Assert.Equal("--", a),
+                        a => Assert.Equal("/android/platform-tools/adb", a));
+                    Assert.Collection(
+                        c.Args,
+                        a => Assert.Equal("-a", a),
+                        a => Assert.Equal("-P", a),
+                        a => Assert.Equal("5037", a),
+                        a => Assert.Equal("server", a),
+                        a => Assert.Equal("nodaemon", a));
+
+                    var port = Assert.Single(c.Ports);
+                    Assert.Equal(5037, port.ContainerPort);
+                    Assert.Equal("adb", port.Name);
+
+                    Assert.Equal("5037", c.ReadinessProbe.TcpSocket.Port);
+                });
+        }
+
+        /// <summary>
+        /// <see cref="UIAutomatorOperators"/> connects the adb instance in the pod running Appium to the emulator
+        /// on which the test is being executed.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ConnectsDevice_Async()
+        {
+            var builder = UIAutomatorOperators.BuildPodOperator(this.host.Services);
+            var feedbackLoop = Assert.Single(builder.FeedbackLoops);
+
+            var session = new WebDriverSession()
+            {
+                Spec = new WebDriverSessionSpec()
+                {
+                    Capabilities = "{}",
+                    DeviceHost = "1.2.3.4",
+                },
+            };
+
+            var pod = new V1Pod()
+            {
+                Status = new V1PodStatus()
+                {
+                    Phase = "Running",
+                    ContainerStatuses = new V1ContainerStatus[] { },
+                },
+            };
+
+            var adbStream = new Mock<Stream>();
+            this.kubernetes
+                .Setup(c => c.ConnectToPodPortAsync(pod, 5037, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adbStream.Object);
+
+            var context = new ChildOperatorContext<WebDriverSession, V1Pod>(
+                parent: session,
+                child: pod,
+                this.host.Services);
+
+            this.adbClient
+                .Setup(c => c.ConnectDeviceAsync(new DnsEndPoint("1.2.3.4", 5555), default))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            this.adbClient
+                .Setup(c => c.GetDevicesAsync(default))
+                .Returns(Task.FromResult<IList<DeviceData>>(new List<DeviceData>()))
+                .Verifiable();
+
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"{value:{'sessionId':'1','capabilities':{}}}"),
+            };
+
+            var handler = new Mock<HttpClientHandler>();
+            handler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response)
+               .Verifiable();
+
+            var client = new HttpClient(handler.Object);
+            client.BaseAddress = new Uri("http://webdriver/");
+
+            this.kubernetes.Setup(
+                k => k.CreatePodHttpClient(context.Child, 4723))
+                .Returns(client);
+
+            var patch = await feedbackLoop(context, default).ConfigureAwait(false);
+            Assert.NotNull(patch);
+
+            this.adbClient.Verify();
+
+            Assert.Collection(
+                patch.Operations,
+                o =>
+                {
+                    Assert.Equal(OperationType.Add, o.OperationType);
+                    Assert.Equal("/status", o.path);
+                },
+                o =>
+                {
+                    Assert.Equal(OperationType.Add, o.OperationType);
+                    Assert.Equal("/status/sessionId", o.path);
+                    Assert.Equal("1", o.value);
+                },
+                o =>
+                {
+                    Assert.Equal(OperationType.Add, o.OperationType);
+                    Assert.Equal("/status/sessionReady", o.path);
+                    Assert.Equal(true, o.value);
+                },
+                o =>
+                {
+                    Assert.Equal(OperationType.Add, o.OperationType);
+                    Assert.Equal("/status/sessionPort", o.path);
+                    Assert.Equal(4723, o.value);
+                },
+                o =>
+                {
+                    Assert.Equal(OperationType.Add, o.OperationType);
+                    Assert.Equal("/status/capabilities", o.path);
+                    Assert.Equal("{}", o.value);
+                });
+        }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesAdbContext.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesAdbContext.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="KubernetesAdbContext.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+
+namespace Kaponata.Operator.Kubernetes
+{
+    /// <summary>
+    /// The <see cref="KubernetesAdbContext"/> configures the <see cref="KubernetesAdbSocketLocator"/>.
+    /// </summary>
+    public class KubernetesAdbContext
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="V1Pod"/> on which the adb instance is running.
+        /// </summary>
+        public V1Pod Pod { get; set; }
+    }
+}

--- a/src/Kaponata.Operator/Kubernetes/KubernetesAdbSocketLocator.cs
+++ b/src/Kaponata.Operator/Kubernetes/KubernetesAdbSocketLocator.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using k8s.Models;
 using Kaponata.Android.Adb;
 using Kaponata.Kubernetes;
 using System;
@@ -21,7 +20,7 @@ namespace Kaponata.Operator.Kubernetes
     public class KubernetesAdbSocketLocator : AdbSocketLocator
     {
         private readonly KubernetesClient kubernetes;
-        private readonly V1Pod pod;
+        private readonly KubernetesAdbContext context;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KubernetesAdbSocketLocator"/> class.
@@ -29,21 +28,21 @@ namespace Kaponata.Operator.Kubernetes
         /// <param name="kubernetes">
         /// A connection to the Kubernetes cluster.
         /// </param>
-        /// <param name="pod">
+        /// <param name="context">
         /// The pod in which adb is running.
         /// </param>
         public KubernetesAdbSocketLocator(
             KubernetesClient kubernetes,
-            V1Pod pod)
+            KubernetesAdbContext context)
         {
             this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
-            this.pod = pod ?? throw new ArgumentNullException(nameof(pod));
+            this.context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         /// <inheritdoc/>
         public override Task<Stream> ConnectToAdbAsync(CancellationToken cancellationToken)
         {
-            return this.kubernetes.ConnectToPodPortAsync(this.pod, DefaultAdbPort, cancellationToken).AsTask();
+            return this.kubernetes.ConnectToPodPortAsync(this.context.Pod, DefaultAdbPort, cancellationToken).AsTask();
         }
 
         /// <inheritdoc/>

--- a/src/Kaponata.Operator/Operators/ChildOperatorBuilderExtensions.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperatorBuilderExtensions.cs
@@ -29,12 +29,17 @@ namespace Kaponata.Operator.Operators
         /// <param name="appiumPort">
         /// The port at which the Appium server is listening.
         /// </param>
+        /// <param name="initializer">
+        /// Optionally, a delegate which can be used to initialize the pod before the session
+        /// is created.
+        /// </param>
         /// <returns>
         /// An operator builder which can be used to further configure the operator.
         /// </returns>
         public static ChildOperatorBuilder<WebDriverSession, V1Pod> CreatesSession(
             this ChildOperatorBuilder<WebDriverSession, V1Pod> builder,
-            int appiumPort)
+            int appiumPort,
+            SessionPodInitializer initializer = null)
         {
             return builder.PostsFeedback(
                 async (context, cancellationToken) =>
@@ -66,6 +71,11 @@ namespace Kaponata.Operator.Operators
                     }
                     else
                     {
+                        if (initializer != null)
+                        {
+                            await initializer(context, cancellationToken).ConfigureAwait(false);
+                        }
+
                         var requestedCapabilities = JsonConvert.DeserializeObject(context.Parent.Spec.Capabilities);
                         var request = JsonConvert.SerializeObject(
                             new

--- a/src/Kaponata.Operator/Operators/SessionPodInitializer.cs
+++ b/src/Kaponata.Operator/Operators/SessionPodInitializer.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="SessionPodInitializer.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Kubernetes.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// A common delegate for any action which configures a pod related to a WebDriver session.
+    /// </summary>
+    /// <param name="context">
+    /// A <see cref="ChildOperatorContext{TParent, TChild}"/> object which represents the parent and child objects being
+    /// evaluated.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task"/> which represents the asynchronous operation.
+    /// </returns>
+    public delegate Task SessionPodInitializer(
+        ChildOperatorContext<WebDriverSession, V1Pod> context,
+        CancellationToken cancellationToken);
+}

--- a/src/Kaponata.Operator/Operators/UIAutomatorOperators.cs
+++ b/src/Kaponata.Operator/Operators/UIAutomatorOperators.cs
@@ -1,0 +1,126 @@
+﻿// <copyright file="UIAutomatorOperators.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Android.Adb;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Models;
+using Kaponata.Operator.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Contains the operators for creating UIAutomator2-based sessions.
+    /// </summary>
+    public class UIAutomatorOperators
+    {
+        private const string ImageName = "quay.io/kaponata/appium-android:1.20.2";
+        private const int AppiumPort = 4723;
+        private const int AdbPort = 5037;
+
+        /// <summary>
+        /// Builds an operator which provides a UIAutomator2 driver pod for each <see cref="WebDriverSession"/> which uses
+        /// the UIAutomator2 driver.
+        /// </summary>
+        /// <param name="services">
+        /// A service collection from which to host services.
+        /// </param>
+        /// <returns>
+        /// A configured operator.
+        /// </returns>
+        public static ChildOperatorBuilder<WebDriverSession, V1Pod> BuildPodOperator(IServiceProvider services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            var kubernetes = services.GetRequiredService<KubernetesClient>();
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("UIAutomator2Operator");
+
+            return new ChildOperatorBuilder(services)
+                .CreateOperator("WebDriverSession-UIAutomator2Driver-PodOperator")
+                .Watches<WebDriverSession>()
+                .WithLabels(s => s.Metadata.Labels[Annotations.AutomationName] == Annotations.AutomationNames.UIAutomator2)
+                .Creates<V1Pod>(
+                    (session, pod) =>
+                    {
+                        pod.EnsureMetadata().EnsureLabels();
+                        pod.Metadata.Labels.Add(Annotations.SessionName, session.Metadata.Name);
+
+                        pod.Spec = new V1PodSpec()
+                        {
+                            Containers = new V1Container[]
+                            {
+                                new V1Container()
+                                {
+                                    Image = ImageName,
+                                    Name = "appium",
+                                    Args = new string[] { "/app/appium/build/lib/main.js" },
+                                    Ports = new V1ContainerPort[]
+                                    {
+                                        new V1ContainerPort()
+                                        {
+                                             ContainerPort = AppiumPort,
+                                             Name = "http",
+                                        },
+                                    },
+                                    ReadinessProbe = new V1Probe()
+                                    {
+                                        HttpGet = new V1HTTPGetAction()
+                                        {
+                                            Path = "/wd/hub/status",
+                                            Port = $"{AppiumPort}",
+                                        },
+                                    },
+                                },
+                                new V1Container()
+                                {
+                                    Image = ImageName,
+                                    Name = "adb",
+                                    Command = new string[] { "/bin/tini", "--", "/android/platform-tools/adb" },
+                                    Args = new string[] { "-a", "-P", $"{AdbPort}", "server", "nodaemon" },
+                                    Ports = new V1ContainerPort[]
+                                    {
+                                        new V1ContainerPort()
+                                        {
+                                             ContainerPort = AdbPort,
+                                             Name = "adb",
+                                        },
+                                    },
+                                    ReadinessProbe = new V1Probe()
+                                    {
+                                        TcpSocket = new V1TCPSocketAction()
+                                        {
+                                             Port = $"{AdbPort}",
+                                        },
+                                    },
+                                },
+                            },
+                        };
+                    })
+                .CreatesSession(
+                    AppiumPort,
+                    async (context, cancellationToken) =>
+                    {
+                        var session = context.Parent;
+                        var pod = context.Child;
+
+                        var adbContext = context.Services.GetRequiredService<KubernetesAdbContext>();
+                        adbContext.Pod = pod;
+
+                        // First, connect the instance of adb running on the Appium pod to the Android device
+                        var adbClient = context.Services.GetRequiredService<AdbClient>();
+
+                        await adbClient.ConnectDeviceAsync(new DnsEndPoint(session.Spec.DeviceHost, 5555), cancellationToken).ConfigureAwait(false);
+                        var devices = await adbClient.GetDevicesAsync(cancellationToken).ConfigureAwait(false);
+                    });
+        }
+    }
+}


### PR DESCRIPTION
This operator supports creating Appium sessions which run Appium on Android devices using the UIAutomator2 provider.

The operator:
- Creates an Appium pod which runs Appium in a container and adb in another
- Has a feedback loop which calls `adb.Connect("...")` to connect that adb instance to the device