### PR TITLE
Add Guacamole Docker image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -11,6 +11,7 @@ on:
     - src/fake-driver/**
     - src/appium/**
     - src/appium-android/**
+    - src/guacamole/**
 
 jobs:
   build:
@@ -24,6 +25,7 @@ jobs:
         - fake-driver
         - appium
         - appium-android
+        - guacamole
 
     steps:
       - uses: actions/checkout@v2

--- a/src/guacamole/Dockerfile
+++ b/src/guacamole/Dockerfile
@@ -1,0 +1,22 @@
+# Guacamole is built using maven:3-jdk-8, so let's use the same JDK version for building
+# the guacamole-auth-rest module, too:
+# https://github.com/apache/guacamole-client/blob/master/Dockerfile#L31
+FROM maven:3.6.3-jdk-8 AS build
+
+ENV GUACAMOLE_AUTH_REST_VERSION=896baa1038ffaa745a19a24f8759e449a471f8ad
+
+# Clone the guacamole-auth-rest module, and checkout out a specific commit.
+RUN git clone https://github.com/soulwing/guacamole-auth-rest \
+&& cd guacamole-auth-rest \
+&& git checkout ${GUACAMOLE_AUTH_REST_VERSION}
+
+WORKDIR /guacamole-auth-rest
+RUN mvn package
+
+FROM guacamole/guacamole:1.3.0
+
+ENV GUACAMOLE_HOME /quamotion/.guacamole
+
+COPY guacamole.properties $GUACAMOLE_HOME/
+COPY --from=build /guacamole-auth-rest/target/dependency/*.jar $GUACAMOLE_HOME/lib/
+COPY --from=build /guacamole-auth-rest/target/guacamole-auth-rest-1.0.0-SNAPSHOT.jar $GUACAMOLE_HOME/extensions/

--- a/src/guacamole/Makefile
+++ b/src/guacamole/Makefile
@@ -1,0 +1,33 @@
+registry=quay.io/kaponata
+image=guacamole
+
+all: .amd64.docker-id .version
+
+push: all
+	docker push $(registry)/$(image):latest-amd64
+	docker manifest rm $(registry)/$(image):$(shell cat .version) || echo "Manifest does not exist"
+	docker manifest create --amend $(registry)/$(image):$(shell cat .version) $(registry)/$(image):latest-amd64
+	docker manifest push $(registry)/$(image):$(shell cat .version)
+
+deploy: all
+	k3d image import $(registry)/$(image):latest-amd64
+	docker image ls $(registry)/$(image):latest-amd64
+	docker exec -it k3d-k3s-default-server-0 crictl images | grep $(registry)/$(image)
+
+.version: .amd64.docker-id
+	docker run --rm -i $(shell cat .amd64.docker-id) unzip -c /opt/guacamole/guacamole.war META-INF/maven/org.apache.guacamole/guacamole/pom.properties | grep version | awk -F= '{ print $$2 }' | tee .version
+
+.amd64.docker-id: Dockerfile
+	docker buildx build \
+		--progress plain \
+		--platform linux/amd64 \
+		--build-arg host= \
+		--build-arg arch= \
+		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
+		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
+		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
+		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
+		--build-arg VERSION="$(shell nbgv get-version -v SemVer2)" \
+		. \
+		-t $(registry)/$(image):latest-amd64
+	docker images --no-trunc --quiet $(registry)/$(image):latest-amd64 > .amd64.docker-id

--- a/src/guacamole/guacamole.properties
+++ b/src/guacamole/guacamole.properties
@@ -1,0 +1,1 @@
+enable-environment-properties: true


### PR DESCRIPTION
This image contains the guacamole-auth-rest extension.
This enables configuring Guacamole using a REST API.