### PR TITLE
Add Guacamole to the Kaponata chart

### DIFF
--- a/src/Kaponata.Api.Tests/GuacamoleControllerTests.cs
+++ b/src/Kaponata.Api.Tests/GuacamoleControllerTests.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="GuacamoleControllerTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.Guacamole;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Kaponata.Api.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="GuacamoleController"/> class.
+    /// </summary>
+    public class GuacamoleControllerTests
+    {
+        /// <summary>
+        /// <see cref="GuacamoleController.Authorize(AuthorizationRequest)"/> always returns an empty list.
+        /// </summary>
+        [Fact]
+        public void Authorize_ReturnsEmptyList()
+        {
+            var controller = new GuacamoleController(NullLogger<GuacamoleController>.Instance);
+            var result = controller.Authorize(new AuthorizationRequest());
+            var objectResult = Assert.IsType<OkObjectResult>(result);
+
+            var authorizationResult = Assert.IsType<AuthorizationResult>(objectResult.Value);
+            Assert.True(authorizationResult.Authorized);
+            Assert.Empty(authorizationResult.Configurations);
+        }
+    }
+}

--- a/src/Kaponata.Api/Guacamole/AuthorizationRequest.cs
+++ b/src/Kaponata.Api/Guacamole/AuthorizationRequest.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="AuthorizationRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+
+namespace Kaponata.Api.Guacamole
+{
+    /// <summary>
+    /// Represents a request to authorize a subject.
+    /// </summary>
+    public class AuthorizationRequest
+    {
+        /// <summary>
+        /// Gets or sets the user name of the subject.
+        /// </summary>
+        [JsonPropertyName("username")]
+        public string? UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for the user, if any.
+        /// </summary>
+        [JsonPropertyName("password")]
+        public string? Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the network address at which the subject is located, if available.
+        /// </summary>
+        [JsonPropertyName("remoteAddress")]
+        public string? RemoteAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the network host at which the subject is located, if available.
+        /// </summary>
+        [JsonPropertyName("remoteHostname")]
+        public string? RemoteHostName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of HTTP headers associated with the request, and their values.
+        /// </summary>
+        /// <remarks>
+        /// Because a given HTTP header may have multiple values, the object associated with a header name is an array
+        /// of strings, even if there is just one value for a given header name.
+        /// </remarks>
+        [JsonPropertyName("headers")]
+        public Dictionary<string, Collection<string>>? Headers { get; set; }
+    }
+}

--- a/src/Kaponata.Api/Guacamole/AuthorizationResult.cs
+++ b/src/Kaponata.Api/Guacamole/AuthorizationResult.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="AuthorizationResult.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Kaponata.Api.Guacamole
+{
+    /// <summary>
+    /// Represents the result of an authorization request.
+    /// </summary>
+    public class AuthorizationResult
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the authorization request was successful.
+        /// </summary>
+        [JsonPropertyName("authorized")]
+        public bool Authorized { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of authorized connection resources for the authorized user.
+        /// </summary>
+        /// <remarks>
+        /// This value is included only for an authorized subject.
+        /// </remarks>
+        [JsonPropertyName("configurations")]
+        public Dictionary<string, Configuration>? Configurations { get; set; }
+    }
+}

--- a/src/Kaponata.Api/Guacamole/Configuration.cs
+++ b/src/Kaponata.Api/Guacamole/Configuration.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="Configuration.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Kaponata.Api.Guacamole
+{
+    /// <summary>
+    /// Represents an authorized connection resource.
+    /// </summary>
+    public class Configuration
+    {
+        /// <summary>
+        /// Gets or sets the Guacamole protocol name; e.g. RDP, VNC or SSH.
+        /// </summary>
+        [JsonPropertyName("protocol")]
+        public string? Protocol { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary which contains parameter names and corresponding value types for this configuration.
+        /// </summary>
+        /// <remarks>
+        /// These values are protocol-specific, and are typically defined and described in the Guacamole documentation for a supported protocol.
+        /// The value data types may be either strings, numbers, or booleans. This structure corresponds to the <c>GuacamoleConfiguration</c>
+        /// defined in guacamole-common.
+        /// </remarks>
+        [JsonPropertyName("parameters")]
+        public Dictionary<string, object>? Parameters { get; set; }
+    }
+}

--- a/src/Kaponata.Api/GuacamoleController.cs
+++ b/src/Kaponata.Api/GuacamoleController.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="GuacamoleController.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Api.Guacamole;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Api
+{
+    /// <summary>
+    /// Implements an REST API which allows Guacamole to authenticate users using the guacamole-auth-rest extension.
+    /// </summary>
+    [ApiController]
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None)]
+    public class GuacamoleController
+    {
+        private readonly ILogger<GuacamoleController> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuacamoleController"/> class.
+        /// </summary>
+        /// <param name="logger">
+        /// A logger which is used when logging.
+        /// </param>
+        public GuacamoleController(ILogger<GuacamoleController> logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Processes an authorization request.
+        /// </summary>
+        /// <param name="body">
+        /// The authorization request.
+        /// </param>
+        /// <returns>
+        /// A <see cref="AuthorizationResult"/> which contains the result of the authentication operation.
+        /// </returns>
+        [HttpPost("/api/guacamole/authorization")]
+        public ActionResult Authorize([FromBody] AuthorizationRequest body)
+        {
+            var result = new AuthorizationResult
+            {
+                Authorized = true,
+                Configurations = new Dictionary<string, Configuration>(),
+            };
+
+            return new OkObjectResult(result);
+        }
+    }
+}

--- a/src/Kaponata.Chart.Tests/GuacamoleClient.cs
+++ b/src/Kaponata.Chart.Tests/GuacamoleClient.cs
@@ -1,0 +1,73 @@
+﻿// <copyright file="GuacamoleClient.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// A client for the Guacamole client REST API.
+    /// </summary>
+    public class GuacamoleClient
+    {
+        private readonly HttpClient client;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuacamoleClient"/> class.
+        /// </summary>
+        /// <param name="client">
+        /// A <see cref="HttpClient"/> which can be used to send requests to the remote server.
+        /// </param>
+        public GuacamoleClient(HttpClient client)
+        {
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        /// <summary>
+        /// Asynchronously generates a Guacamole token.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation, and returns a <see cref="GuacamoleToken"/>.</returns>
+        /// <seealso href="https://github.com/ridvanaltun/guacamole-rest-api-documentation/blob/master/docs/AUTHENTICATION.md#post-apitokens"/>
+        public async Task<GuacamoleToken> GenerateTokenAsync(CancellationToken cancellationToken)
+        {
+            var response = await this.client.PostAsync("api/tokens", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<GuacamoleToken>(json);
+        }
+
+        /// <summary>
+        /// Gets the connection tree for a data source.
+        /// </summary>
+        /// <param name="dataSource">
+        /// The name of the data source for which to get the connection tree.
+        /// </param>
+        /// <param name="token">
+        /// The token to use to authenticate to the remote service.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which rerpesents the asynchronous operation, and returns a <see cref="GuacamoleTree"/>.
+        /// </returns>
+        /// <seealso href="https://github.com/ridvanaltun/guacamole-rest-api-documentation/blob/32f8d34af8ee0996a08ed11fa4543d579135671c/docs/CONNECTION-GROUPS.md#headers-1"/>
+        public async Task<GuacamoleTree> GetTreeAsync(string dataSource, string token, CancellationToken cancellationToken)
+        {
+            var response = await this.client.GetAsync($"api/session/data/{dataSource}/connectionGroups/ROOT/tree?token={token}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<GuacamoleTree>(json);
+        }
+    }
+}

--- a/src/Kaponata.Chart.Tests/GuacamoleTests.cs
+++ b/src/Kaponata.Chart.Tests/GuacamoleTests.cs
@@ -1,0 +1,161 @@
+﻿// <copyright file="GuacamoleTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+using k8s;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// Integration tests for the Guacamole chart.
+    /// </summary>
+    public class GuacamoleTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuacamoleTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// The test output helper which will be used to log to xunit.
+        /// </param>
+        public GuacamoleTests(ITestOutputHelper output)
+        {
+            this.loggerFactory = LogFactory.Create(output);
+            this.output = output;
+        }
+
+        /// <summary>
+        /// At least one guacd pod is up and running, and can successfully perform a handshake.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task Guacd_PerformsHandshake_Async()
+        {
+            var config = KubernetesClientConfiguration.BuildDefaultConfig();
+            if (config.Namespace == null)
+            {
+                config.Namespace = "default";
+            }
+
+            using (var kubernetes = new KubernetesProtocol(
+                config,
+                this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                this.loggerFactory))
+            using (var client = new KubernetesClient(
+                kubernetes,
+                KubernetesOptions.Default,
+                this.output.BuildLoggerFor<KubernetesClient>(),
+                this.loggerFactory))
+            {
+                // There's at least one guacd pod
+                var pods = await kubernetes.ListNamespacedPodAsync(config.Namespace, labelSelector: "app.kubernetes.io/name=guacamole,app.kubernetes.io/component=guacd");
+                Assert.NotEmpty(pods.Items);
+                var pod = pods.Items[0];
+
+                // The pod is in the running state
+                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+                Assert.Equal("Running", pod.Status.Phase);
+
+                // Try to perform a handshake
+                using (var connection = await client.ConnectToPodPortAsync(pod, 4822, default).ConfigureAwait(false))
+                {
+                    GuacdProtocol protocol = new GuacdProtocol(connection);
+
+                    // Handshake phase
+                    await protocol.SendInstructionAsync("select", new string[] { "vnc" }, default).ConfigureAwait(false);
+                    var response = await protocol.ReadInstructionAsync(default);
+
+                    Assert.Equal("args", response[0]);
+                    Assert.Equal("VERSION_1_3_0", response[1]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// At least one Guacamole pod is up and running, and the user can request a token.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task Guacamole_CanAuthenticate_OnPod_Async()
+        {
+            var config = KubernetesClientConfiguration.BuildDefaultConfig();
+            if (config.Namespace == null)
+            {
+                config.Namespace = "default";
+            }
+
+            using (var kubernetes = new KubernetesProtocol(
+                config,
+                this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                this.loggerFactory))
+            using (var client = new KubernetesClient(
+                kubernetes,
+                KubernetesOptions.Default,
+                this.output.BuildLoggerFor<KubernetesClient>(),
+                this.loggerFactory))
+            {
+                // There's at least one guacd pod
+                var pods = await kubernetes.ListNamespacedPodAsync(config.Namespace, labelSelector: "app.kubernetes.io/name=guacamole,app.kubernetes.io/component=guacamole");
+                Assert.NotEmpty(pods.Items);
+                var pod = pods.Items[0];
+
+                // The pod is in the running state
+                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+                Assert.Equal("Running", pod.Status.Phase);
+
+                // Try to perform a handshake
+                var httpClient = client.CreatePodHttpClient(pod, 8080);
+                httpClient.BaseAddress = new Uri($"http://{pod.Metadata.Name}:8080/guacamole/");
+                var guacamoleClient = new GuacamoleClient(httpClient);
+
+                var token = await guacamoleClient.GenerateTokenAsync(default).ConfigureAwait(false);
+
+                Assert.NotNull(token.AuthToken);
+                Assert.Equal("RestAuthProvider", token.DataSource);
+                Assert.Single(token.AvailableDataSources, "RestAuthProvider");
+                Assert.NotNull(token.UserName);
+            }
+        }
+
+        /// <summary>
+        /// The Guacamole service is exposed over the default ingress, the user can successfully authenticate, and fetch an (empty)
+        /// connection tree.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task Guacamole_CanAuthenticate_OverIngress_Async()
+        {
+            // Try to perform a handshake
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri($"http://localhost:80/guacamole/");
+            var guacamoleClient = new GuacamoleClient(httpClient);
+
+            var token = await guacamoleClient.GenerateTokenAsync(default).ConfigureAwait(false);
+
+            Assert.NotNull(token.AuthToken);
+            Assert.Equal("RestAuthProvider", token.DataSource);
+            Assert.Single(token.AvailableDataSources, "RestAuthProvider");
+            Assert.NotNull(token.UserName);
+
+            var tree = await guacamoleClient.GetTreeAsync("RestAuthProvider", token.AuthToken, default).ConfigureAwait(false);
+            Assert.Equal(0, tree.ActiveConnections);
+            Assert.Equal("ROOT", tree.Identifier);
+            Assert.Equal("ROOT", tree.Name);
+            Assert.Equal("ORGANIZATIONAL", tree.Type);
+        }
+    }
+}

--- a/src/Kaponata.Chart.Tests/GuacamoleToken.cs
+++ b/src/Kaponata.Chart.Tests/GuacamoleToken.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="GuacamoleToken.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// A token which can be used to authenticate with the Guacamole client.
+    /// </summary>
+    public class GuacamoleToken
+    {
+        /// <summary>
+        /// Gets or sets the raw token.
+        /// </summary>
+        [JsonProperty("authToken")]
+        public string AuthToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the user to which the token belongs.
+        /// </summary>
+        [JsonProperty("username")]
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the data source which was used to generate the token.
+        /// </summary>
+        [JsonProperty("dataSource")]
+        public string DataSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of all available data sources.
+        /// </summary>
+        [JsonProperty("availableDataSources")]
+        public List<string> AvailableDataSources { get; set; }
+    }
+}

--- a/src/Kaponata.Chart.Tests/GuacamoleTree.cs
+++ b/src/Kaponata.Chart.Tests/GuacamoleTree.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="GuacamoleTree.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// A Guacamole connection tree.
+    /// </summary>
+    public class GuacamoleTree
+    {
+        /// <summary>
+        /// Gets or sets the user-friendly name of the connection tree.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the connection tree.
+        /// </summary>
+        [JsonProperty("identifier")]
+        public string Identifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the connection tree.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of active connections.
+        /// </summary>
+        [JsonProperty("activeConnections")]
+        public int ActiveConnections { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional attributes.
+        /// </summary>
+        [JsonProperty("attributes")]
+        public object Attributes { get; set; }
+    }
+}

--- a/src/Kaponata.Chart.Tests/GuacdProtocol.cs
+++ b/src/Kaponata.Chart.Tests/GuacdProtocol.cs
@@ -1,0 +1,103 @@
+﻿// <copyright file="GuacdProtocol.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// A very basic client which speaks the guacamole daemon protocol. Used by the guacd integration tests,
+    /// to ensure the service is up and running.
+    /// </summary>
+    /// <seealso href="https://guacamole.apache.org/doc/gug/guacamole-protocol.html"/>
+    public class GuacdProtocol
+    {
+        private readonly Stream stream;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuacdProtocol"/> class.
+        /// </summary>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> which represents a connection to the guacd service.
+        /// </param>
+        public GuacdProtocol(Stream stream)
+        {
+            this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        }
+
+        /// <summary>
+        /// Asynchronously sends an instruction to the remote end.
+        /// </summary>
+        /// <param name="opcode">
+        /// The opcode of the instruction.
+        /// </param>
+        /// <param name="args">
+        /// The arguments for the instruction.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public Task SendInstructionAsync(string opcode, string[] args, CancellationToken cancellationToken)
+        {
+            StringBuilder instructionBuilder = new StringBuilder();
+
+            Encode(instructionBuilder, opcode);
+
+            foreach (var arg in args)
+            {
+                instructionBuilder.Append(",");
+                Encode(instructionBuilder, arg);
+            }
+
+            instructionBuilder.Append(";");
+
+            var data = Encoding.UTF8.GetBytes(instructionBuilder.ToString());
+            return this.stream.WriteAsync(data, 0, data.Length, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously reads an instruction.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> array which contains the opcode and arguments.
+        /// </returns>
+        public async Task<string[]> ReadInstructionAsync(CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[1024];
+
+            int read = await this.stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            string command = Encoding.UTF8.GetString(buffer, 0, read);
+            string[] args = command.Split(new char[] { ',', ';' });
+
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                var separator = args[i].IndexOf('.');
+                var length = int.Parse(args[i].Substring(0, separator));
+                var value = args[i].Substring(separator + 1);
+
+                Debug.Assert(length == value.Length, "Incorrect length");
+
+                args[i] = value;
+            }
+
+            return args;
+        }
+
+        private static void Encode(StringBuilder instructionBuilder, string command)
+        {
+            instructionBuilder.Append(command.Length);
+            instructionBuilder.Append(".");
+            instructionBuilder.Append(command);
+        }
+    }
+}

--- a/src/chart/Chart.yaml
+++ b/src/chart/Chart.yaml
@@ -10,6 +10,8 @@ appVersion: "1.16.0"
 dependencies:
   - name: "usbmuxd"
     version: "1.0.0"
+  - name: "guacamole"
+    version: "1.0.0"
 
 maintainers:
   - name: Frederik Carlier

--- a/src/chart/charts/guacamole/Chart.yaml
+++ b/src/chart/charts/guacamole/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: guacamole
+description: Apache Guacamole is a clientless remote desktop gateway. It supports standard protocols like VNC, RDP, and SSH.
+home: https://guacamole.apache.org/
+
+type: application
+version: 1.0.0
+appVersion: "1.3.0"
+
+maintainers:
+  - name: Frederik Carlier
+    email: frederik.carlier@quamotion.mobi

--- a/src/chart/charts/guacamole/templates/_helpers.tpl
+++ b/src/chart/charts/guacamole/templates/_helpers.tpl
@@ -1,0 +1,108 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "guacamole.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "guacamole.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "guacamole.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Guacamole: Full Name
+*/}}
+{{- define "guacamole.guacamole.fullname" -}}
+{{- printf "%s-guacamole" (include "guacamole.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Guacamole: Selector labels
+*/}}
+{{- define "guacamole.guacamole.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "guacamole.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "guacamole"
+{{- end }}
+
+{{/*
+Guacamole: Common labels
+*/}}
+{{- define "guacamole.guacamole.labels" -}}
+helm.sh/chart: {{ include "guacamole.chart" . }}
+{{ include "guacamole.guacamole.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Guacamole: Service Name
+*/}}
+{{- define "guacamole.guacamole.service.fullname" -}}
+{{- printf "%s-guacamole-service" (include "guacamole.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Guacamole: Service Name
+*/}}
+{{- define "guacamole.guacamole.ingress.fullname" -}}
+{{- printf "%s-guacamole-ingress" (include "guacamole.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+guacd: Full Name
+*/}}
+{{- define "guacamole.guacd.fullname" -}}
+{{- printf "%s-guacd" (include "guacamole.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+guacd: Selector labels
+*/}}
+{{- define "guacamole.guacd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "guacamole.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "guacd"
+{{- end }}
+
+{{/*
+guacd: Common labels
+*/}}
+{{- define "guacamole.guacd.labels" -}}
+helm.sh/chart: {{ include "guacamole.chart" . }}
+{{ include "guacamole.guacd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+guacd: Service Name
+*/}}
+{{- define "guacamole.guacd.service.fullname" -}}
+{{- printf "%s-guacd-service" (include "guacamole.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/src/chart/charts/guacamole/templates/guacamole-deployment.yaml
+++ b/src/chart/charts/guacamole/templates/guacamole-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "guacamole.guacamole.fullname" . }}
+  labels:
+    {{- include "guacamole.guacamole.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "guacamole.guacamole.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "guacamole.guacamole.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "guacamole"
+          image: "{{ .Values.guacamole.image.repository }}:{{ tpl .Values.guacamole.image.tag . }}"
+          env:
+          - name: GUACD_HOSTNAME
+            value: {{ include "guacamole.guacd.service.fullname" . }}
+          - name: AUTH_REST_SERVICE_URL
+            value: {{ .Values.guacamole.authenticationServiceUrl }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP

--- a/src/chart/charts/guacamole/templates/guacamole-ingress.yaml
+++ b/src/chart/charts/guacamole/templates/guacamole-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "guacamole.guacamole.ingress.fullname" . }}
+  labels:
+    helm.sh/chart: {{ include "guacamole.chart" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /guacamole
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "guacamole.guacamole.service.fullname" . }}
+            port:
+              number: 80

--- a/src/chart/charts/guacamole/templates/guacamole-service.yaml
+++ b/src/chart/charts/guacamole/templates/guacamole-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "guacamole.guacamole.service.fullname" . }}
+  labels:
+    {{- include "guacamole.guacamole.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "guacamole.guacamole.selectorLabels" . | nindent 4 }}

--- a/src/chart/charts/guacamole/templates/guacd-deployment.yaml
+++ b/src/chart/charts/guacamole/templates/guacd-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "guacamole.guacd.fullname" . }}
+  labels:
+    {{- include "guacamole.guacd.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "guacamole.guacd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "guacamole.guacd.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "guacd"
+          image: "{{ .Values.guacd.image.repository }}:{{ tpl .Values.guacd.image.tag . }}"
+          ports:
+            - name: guacd
+              containerPort: 4822
+              protocol: TCP

--- a/src/chart/charts/guacamole/templates/guacd-service.yaml
+++ b/src/chart/charts/guacamole/templates/guacd-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "guacamole.guacd.service.fullname" . }}
+  labels:
+    {{- include "guacamole.guacd.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4822
+      targetPort: guacd
+      protocol: TCP
+      name: guacd
+  selector:
+    {{- include "guacamole.guacd.selectorLabels" . | nindent 4 }}

--- a/src/chart/charts/guacamole/values.yaml
+++ b/src/chart/charts/guacamole/values.yaml
@@ -1,0 +1,10 @@
+guacamole:
+  image:
+    repository: quay.io/kaponata/guacamole
+    tag: 1.3.0
+  authenticationServiceUrl: http://kaponata-api-service/api/guacamole
+
+guacd:
+  image:
+    repository: guacamole/guacd
+    tag: 1.3.0


### PR DESCRIPTION
This PR:

- Adds a back-end service to the Kaponata API controller (at `/guacamole`) which can be used to authenticate Guacamole users and list all of the connections available to them. For now, this service accepts _any_ username and password and returns an _empty_ list of connections
- Adds guacd and guacamole to the Helm chart (as a subchart), including services and an ingress rule for the Guacamole client
- Adds a couple of unit tests for the Guacamole Helm chart (handshake with guacd, login to Guacamole).