### PR TITLE
Operator: Support two-way feedback

### DIFF
--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorBuilderTests.cs
@@ -139,23 +139,24 @@ namespace Kaponata.Operator.Tests.Operators
                     var session = context.Parent;
                     var pod = context.Child;
 
-                    JsonPatchDocument<WebDriverSession> patch;
+                    Feedback<WebDriverSession, V1Pod> feedback;
 
                     if (session.Status?.SessionId != null)
                     {
-                        patch = null;
+                        feedback = null;
                     }
                     else if (pod.Status.Phase != "Running" || !pod.Status.ContainerStatuses.All(c => c.Ready))
                     {
-                        patch = null;
+                        feedback = null;
                     }
                     else
                     {
-                        patch = new JsonPatchDocument<WebDriverSession>();
-                        patch.Add(s => s.Status, new WebDriverSessionStatus() { SessionId = Guid.NewGuid().ToString() });
+                        feedback = new Feedback<WebDriverSession, V1Pod>();
+                        feedback.ParentFeedback = new JsonPatchDocument<WebDriverSession>();
+                        feedback.ParentFeedback.Add(s => s.Status, new WebDriverSessionStatus() { SessionId = Guid.NewGuid().ToString() });
                     }
 
-                    return Task.FromResult(patch);
+                    return Task.FromResult(feedback);
                 }).Build();
         }
     }

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Ingress.cs
@@ -292,13 +292,14 @@ namespace Kaponata.Operator.Tests.Operators
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(
-                result.Operations,
+                result.ParentFeedback.Operations,
                 o =>
                 {
                     Assert.Equal(OperationType.Add, o.OperationType);
                     Assert.Equal("/status/ingressReady", o.path);
                     Assert.Equal(true, o.value);
                 });
+            Assert.Null(result.ChildFeedback);
         }
     }
 }

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.Service.cs
@@ -183,13 +183,14 @@ namespace Kaponata.Operator.Tests.Operators
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(
-                result.Operations,
+                result.ParentFeedback.Operations,
                 o =>
                 {
                     Assert.Equal(OperationType.Add, o.OperationType);
                     Assert.Equal("/status/serviceReady", o.path);
                     Assert.Equal(true, o.value);
                 });
+            Assert.Null(result.ChildFeedback);
         }
     }
 }

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorTests.cs
@@ -361,7 +361,7 @@ namespace Kaponata.Operator.Tests.Operators
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(
-                result.Operations,
+                result.ParentFeedback.Operations,
                 o =>
                 {
                     Assert.Equal(OperationType.Add, o.OperationType);
@@ -391,6 +391,7 @@ namespace Kaponata.Operator.Tests.Operators
                     Assert.Equal("/status/capabilities", o.path);
                     Assert.Equal("{}", o.value);
                 });
+            Assert.Null(result.ChildFeedback);
 
             handler.Verify();
         }
@@ -449,7 +450,7 @@ namespace Kaponata.Operator.Tests.Operators
 
             var result = await feedback(context, default).ConfigureAwait(false);
             Assert.Collection(
-                result.Operations,
+                result.ParentFeedback.Operations,
                 o =>
                 {
                     Assert.Equal(OperationType.Add, o.OperationType);
@@ -476,6 +477,7 @@ namespace Kaponata.Operator.Tests.Operators
                     // Data can be an arbitrary object, so a string is serialized with quotes.
                     Assert.Equal("\"data\"", o.value);
                 });
+            Assert.Null(result.ChildFeedback);
 
             handler.Verify();
         }

--- a/src/Kaponata.Operator.Tests/Operators/UIAutomatorOperatorsTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/UIAutomatorOperatorsTests.cs
@@ -242,7 +242,7 @@ namespace Kaponata.Operator.Tests.Operators
             this.adbClient.Verify();
 
             Assert.Collection(
-                patch.Operations,
+                patch.ParentFeedback.Operations,
                 o =>
                 {
                     Assert.Equal(OperationType.Add, o.OperationType);
@@ -272,6 +272,7 @@ namespace Kaponata.Operator.Tests.Operators
                     Assert.Equal("/status/capabilities", o.path);
                     Assert.Equal("{}", o.value);
                 });
+            Assert.Null(patch.ChildFeedback);
         }
     }
 }

--- a/src/Kaponata.Operator/Operators/FakeOperators.cs
+++ b/src/Kaponata.Operator/Operators/FakeOperators.cs
@@ -167,7 +167,7 @@ namespace Kaponata.Operator.Operators
                 })
                 .PostsFeedback((context, cancellationToken) =>
                 {
-                    JsonPatchDocument<WebDriverSession> patch = null;
+                    Feedback<WebDriverSession, V1Ingress> feedback = null;
 
                     var session = context.Parent;
                     var ingress = context.Child;
@@ -179,11 +179,12 @@ namespace Kaponata.Operator.Operators
                     }
                     else if (!session.Status.IngressReady)
                     {
-                        patch = new JsonPatchDocument<WebDriverSession>();
-                        patch.Add(s => s.Status.IngressReady, true);
+                        feedback = new Feedback<WebDriverSession, V1Ingress>();
+                        feedback.ParentFeedback = new JsonPatchDocument<WebDriverSession>();
+                        feedback.ParentFeedback.Add(s => s.Status.IngressReady, true);
                     }
 
-                    return Task.FromResult(patch);
+                    return Task.FromResult(feedback);
                 });
         }
 
@@ -234,18 +235,22 @@ namespace Kaponata.Operator.Operators
                 })
                 .PostsFeedback((context, cancellationToken) =>
                 {
-                    JsonPatchDocument<WebDriverSession> patch = null;
+                    Feedback<WebDriverSession, V1Service> feedback = null;
 
                     var session = context.Parent;
                     var service = context.Child;
 
                     if (service != null && !session.Status.ServiceReady)
                     {
-                        patch = new JsonPatchDocument<WebDriverSession>();
-                        patch.Add(s => s.Status.ServiceReady, true);
+                        feedback = new Feedback<WebDriverSession, V1Service>()
+                        {
+                            ParentFeedback = new JsonPatchDocument<WebDriverSession>(),
+                        };
+
+                        feedback.ParentFeedback.Add(s => s.Status.ServiceReady, true);
                     }
 
-                    return Task.FromResult(patch);
+                    return Task.FromResult(feedback);
                 });
         }
     }

--- a/src/Kaponata.Operator/Operators/Feedback.cs
+++ b/src/Kaponata.Operator/Operators/Feedback.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="Feedback.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s;
+using k8s.Models;
+using Microsoft.AspNetCore.JsonPatch;
+
+namespace Kaponata.Operator.Operators
+{
+    /// <summary>
+    /// Represents feedback of an operator to the state of a parent child pair.
+    /// </summary>
+    /// <typeparam name="TParent">
+    /// The type of the parent object.
+    /// </typeparam>
+    /// <typeparam name="TChild">
+    /// The type of the child object.
+    /// </typeparam>
+    public class Feedback<TParent, TChild>
+        where TParent : class, IKubernetesObject<V1ObjectMeta>, new()
+        where TChild : class, IKubernetesObject<V1ObjectMeta>, new()
+    {
+        /// <summary>
+        /// Gets or sets the feedback to apply to the parent object.
+        /// </summary>
+        public JsonPatchDocument<TParent> ParentFeedback { get; set; }
+
+        /// <summary>
+        /// Gets or sets the feedback to apply to the child object.
+        /// </summary>
+        public JsonPatchDocument<TChild> ChildFeedback { get; set; }
+    }
+}

--- a/src/Kaponata.Operator/Operators/FeedbackLoop.cs
+++ b/src/Kaponata.Operator/Operators/FeedbackLoop.cs
@@ -28,11 +28,11 @@ namespace Kaponata.Operator.Operators
     /// The type of object to create (such as <see cref="V1Service"/>).
     /// </typeparam>
     /// <returns>
-    /// A <see cref="Task"/> which represents the asynchronous operation, and returns a <see cref="JsonPatchDocument{TModel}"/>
-    /// which describes the feedback if the child provides feedback to the parent (and the parent state should be alterated);
-    /// otherwise, <see langword="null"/>.
+    /// A <see cref="Task"/> which represents the asynchronous operation, and returns a <see cref="Feedback{TParent, TChild}"/>
+    /// which describes the feedback if the child provides feedback to the parent (and the parent state should be alterated)
+    /// and vice versa; otherwise, <see langword="null"/>.
     /// </returns>
-    public delegate Task<JsonPatchDocument<TParent>> FeedbackLoop<TParent, TChild>(
+    public delegate Task<Feedback<TParent, TChild>> FeedbackLoop<TParent, TChild>(
         ChildOperatorContext<TParent, TChild> context,
         CancellationToken cancellationToken)
         where TParent : class, IKubernetesObject<V1ObjectMeta>, new()


### PR DESCRIPTION
So far, the operators supported on-way feedback (from the child to the parent).

This PR adds two-way feedback, so that the child can also react to status changes in the parent.

For example, consider the Redroid operator, which creates `MobileDevice` objects for redroid pods.
If the pod is restarted or otherwise changes the IP address, the IP field of the `MobileDevice` object will need to be updated too (unless we create a service object in between).