### PR TITLE
GuacamoleController: Add configurations for MobileDevice objects

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,8 +218,13 @@ jobs:
           --logger "junit;LogFileName=${{ github.workspace }}/bin/chart-{assembly}.TestResults.xml"
           --filter "TestCategory=IntegrationTest"
         working-directory: src/
+        
+      - name: Kubernetes - dump API server logs
+        run: kubectl logs -l app.kubernetes.io/component=api,app.kubernetes.io/name=kaponata --tail=-1
+        if: always()
 
       - name: Delete k3d cluster
+        if: always()
         run: |
           k3d cluster delete
 

--- a/src/Kaponata.Api.Tests/GuacamoleControllerTests.cs
+++ b/src/Kaponata.Api.Tests/GuacamoleControllerTests.cs
@@ -2,9 +2,16 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using k8s.Models;
 using Kaponata.Api.Guacamole;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Kaponata.Api.Tests
@@ -15,13 +22,156 @@ namespace Kaponata.Api.Tests
     public class GuacamoleControllerTests
     {
         /// <summary>
-        /// <see cref="GuacamoleController.Authorize(AuthorizationRequest)"/> always returns an empty list.
+        /// Retrieves tests data for the <see cref="AuthorizeAsync_SkipsDeviceWithoutVnc_Async"/> test.
         /// </summary>
-        [Fact]
-        public void Authorize_ReturnsEmptyList()
+        /// <returns>
+        /// Tests data for the <see cref="AuthorizeAsync_SkipsDeviceWithoutVnc_Async"/> test.
+        /// </returns>
+        public static IEnumerable<object[]> AuthorizeAsync_SkipsDeviceWithoutVnc_Data()
         {
-            var controller = new GuacamoleController(NullLogger<GuacamoleController>.Instance);
-            var result = controller.Authorize(new AuthorizationRequest());
+            yield return new object[]
+            {
+                new MobileDevice()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "device",
+                    },
+                    Status = null,
+                },
+            };
+
+            yield return new object[]
+            {
+                new MobileDevice()
+                {
+                    Metadata = new V1ObjectMeta()
+                    {
+                        Name = "device",
+                    },
+                    Status = new MobileDeviceStatus()
+                    {
+                        VncHost = null,
+                        VncPassword = null,
+                    },
+                },
+            };
+        }
+
+        /// <summary>
+        /// <see cref="GuacamoleController.AuthorizeAsync(AuthorizationRequest, CancellationToken)"/> always returns an empty list.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task AuthorizeAsync_ReturnsEmptyList_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
+            deviceClient
+                .Setup(d => d.ListAsync(null, null, null, null, default))
+                .ReturnsAsync(new ItemList<MobileDevice>() { Items = new List<MobileDevice>() });
+
+            kubernetes.Setup(c => c.GetClient<MobileDevice>()).Returns(deviceClient.Object);
+
+            var controller = new GuacamoleController(NullLogger<GuacamoleController>.Instance, kubernetes.Object);
+            var result = await controller.AuthorizeAsync(new AuthorizationRequest(), default).ConfigureAwait(false);
+            var objectResult = Assert.IsType<OkObjectResult>(result);
+
+            var authorizationResult = Assert.IsType<AuthorizationResult>(objectResult.Value);
+            Assert.True(authorizationResult.Authorized);
+            Assert.Empty(authorizationResult.Configurations);
+        }
+
+        /// <summary>
+        /// <see cref="GuacamoleController.AuthorizeAsync(AuthorizationRequest, CancellationToken)"/> always returns an empty list.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task AuthorizeAsync_ReturnsList_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
+            deviceClient
+                .Setup(d => d.ListAsync(null, null, null, null, default))
+                .ReturnsAsync(
+                    new ItemList<MobileDevice>()
+                    {
+                        Items = new List<MobileDevice>()
+                        {
+                            new MobileDevice()
+                            {
+                                Metadata = new V1ObjectMeta()
+                                {
+                                    Name = "device",
+                                },
+                                Status = new MobileDeviceStatus()
+                                {
+                                    VncHost = "1.2.3.4",
+                                    VncPassword = "abc",
+                                },
+                            },
+                        },
+                    });
+
+            kubernetes.Setup(c => c.GetClient<MobileDevice>()).Returns(deviceClient.Object);
+
+            var controller = new GuacamoleController(NullLogger<GuacamoleController>.Instance, kubernetes.Object);
+            var result = await controller.AuthorizeAsync(new AuthorizationRequest(), default).ConfigureAwait(false);
+            var objectResult = Assert.IsType<OkObjectResult>(result);
+
+            var authorizationResult = Assert.IsType<AuthorizationResult>(objectResult.Value);
+            Assert.True(authorizationResult.Authorized);
+            var configuration = Assert.Single(authorizationResult.Configurations);
+            Assert.Equal("device", configuration.Key);
+
+            Assert.Equal("VNC", configuration.Value.Protocol);
+            Assert.Collection(
+                configuration.Value.Parameters,
+                c =>
+                {
+                    Assert.Equal("hostname", c.Key);
+                    Assert.Equal("1.2.3.4", c.Value);
+                },
+                c =>
+                {
+                    Assert.Equal("port", c.Key);
+                    Assert.Equal(5900, c.Value);
+                },
+                c =>
+                {
+                    Assert.Equal("password", c.Key);
+                    Assert.Equal(string.Empty, c.Value);
+                });
+        }
+
+        /// <summary>
+        /// <see cref="GuacamoleController.AuthorizeAsync(AuthorizationRequest, CancellationToken)"/> skips devices without valid VNC data.
+        /// </summary>
+        /// <param name="device">
+        /// A device for which the VNC configuration is incomplete.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(AuthorizeAsync_SkipsDeviceWithoutVnc_Data))]
+        public async Task AuthorizeAsync_SkipsDeviceWithoutVnc_Async(MobileDevice device)
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
+            deviceClient
+                .Setup(d => d.ListAsync(null, null, null, null, default))
+                .ReturnsAsync(
+                    new ItemList<MobileDevice>()
+                    {
+                        Items = new List<MobileDevice>()
+                        {
+                            device,
+                        },
+                    });
+
+            kubernetes.Setup(c => c.GetClient<MobileDevice>()).Returns(deviceClient.Object);
+
+            var controller = new GuacamoleController(NullLogger<GuacamoleController>.Instance, kubernetes.Object);
+            var result = await controller.AuthorizeAsync(new AuthorizationRequest(), default).ConfigureAwait(false);
             var objectResult = Assert.IsType<OkObjectResult>(result);
 
             var authorizationResult = Assert.IsType<AuthorizationResult>(objectResult.Value);

--- a/src/Kaponata.Api/Startup.cs
+++ b/src/Kaponata.Api/Startup.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using Kaponata.Kubernetes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -26,6 +27,7 @@ namespace Kaponata.Api
         {
             services.AddHealthChecks();
             services.AddControllers();
+            services.AddKubernetes();
         }
 
         /// <summary>


### PR DESCRIPTION
Update the GuacamoleController to actually return Connection objects for each MobileDevice which has an active VNC host.