### PR TITLE
Grant API server list, get permissions on mobiledevice objects

### DIFF
--- a/src/chart/templates/_helpers.tpl
+++ b/src/chart/templates/_helpers.tpl
@@ -45,6 +45,20 @@ API: Service Account Full Name
 {{- end }}
 
 {{/*
+API: Role Full Name
+*/}}
+{{- define "api.role.fullname" -}}
+{{- printf "%s-api-role" (include "kaponata.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+API: Role Binding Full Name
+*/}}
+{{- define "api.roleBinding.fullname" -}}
+{{- printf "%s-api-rolebinding" (include "kaponata.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 API: Common labels
 */}}
 {{- define "api.labels" -}}

--- a/src/chart/templates/api-role.yaml
+++ b/src/chart/templates/api-role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "api.role.fullname" . }}
+  labels:
+    {{- include "api.labels" . | nindent 4 }}
+rules:
+- apiGroups: [ "kaponata.io" ]
+  resources: [ "mobiledevices" ]
+  verbs: [ "get", "list" ]

--- a/src/chart/templates/api-roleBinding.yaml
+++ b/src/chart/templates/api-roleBinding.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "api.roleBinding.fullname" . }}
+  labels:
+    {{- include "api.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "api.role.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "api.serviceAccount.fullname" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The API server will enumerate all mobile device objects and expose the VNC configuration to the Guacamole server, so it needs to access these mobile device objects.