### PR TITLE
GuacamoleController: Fix spelling of "vnc"

### DIFF
--- a/src/Kaponata.Api.Tests/GuacamoleControllerTests.cs
+++ b/src/Kaponata.Api.Tests/GuacamoleControllerTests.cs
@@ -124,7 +124,7 @@ namespace Kaponata.Api.Tests
             var configuration = Assert.Single(authorizationResult.Configurations);
             Assert.Equal("device", configuration.Key);
 
-            Assert.Equal("VNC", configuration.Value.Protocol);
+            Assert.Equal("vnc", configuration.Value.Protocol);
             Assert.Collection(
                 configuration.Value.Parameters,
                 c =>

--- a/src/Kaponata.Api/GuacamoleController.cs
+++ b/src/Kaponata.Api/GuacamoleController.cs
@@ -71,7 +71,7 @@ namespace Kaponata.Api
                         device.Metadata.Name,
                         new Configuration()
                         {
-                            Protocol = "VNC",
+                            Protocol = "vnc",
                             Parameters = new Dictionary<string, object>()
                             {
                                 { "hostname", device.Status.VncHost },


### PR DESCRIPTION
Guacamole uses lower-case spellings of protocol names.