### PR TITLE
Update Makefiles to be Windows/PowerShell compatible

### DIFF
--- a/src/Kaponata.Api/Makefile
+++ b/src/Kaponata.Api/Makefile
@@ -23,7 +23,7 @@ push: all
 	docker manifest create --amend $(registry)/$(image):$(version) $(registry)/$(image):$(version)-amd64 $(registry)/$(image):$(version)-arm64
 	docker manifest push $(registry)/$(image):$(version)
 
-bin/Release/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -name "*.cs" -type f)
+bin/Release/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
 	dotnet publish -c Release
 
 .amd64.docker-id: Dockerfile bin/Release/net5.0/publish/Kaponata.Api.dll

--- a/src/Kaponata.Operator/Makefile
+++ b/src/Kaponata.Operator/Makefile
@@ -23,7 +23,7 @@ push: all
 	docker manifest create --amend $(registry)/$(image):$(version) $(registry)/$(image):$(version)-amd64 $(registry)/$(image):$(version)-arm64
 	docker manifest push $(registry)/$(image):$(version)
 
-bin/Release/net5.0/publish/Kaponata.Operator.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -name "*.cs" -type f)
+bin/Release/net5.0/publish/Kaponata.Operator.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
 	dotnet publish -c Release
 
 .amd64.docker-id: Dockerfile bin/Release/net5.0/publish/Kaponata.Operator.dll


### PR DESCRIPTION
For some reason, the `-name "*.cs"` filter does not work when using Make on native Windows (e.g. _not_ WSL), but the `-regex '.*\.cs'` filter does work.

This PR replaces the filter. With this change, you can now run commands such as `make deploy` from a Windows command-line prompt, if you have `make`, `find`, `kubectl`, `k3d`, `docker` and `docker-buildx` available in your PATH.