### PR TITLE
Scaffold Kaponata.Sidecar project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,6 +114,12 @@ jobs:
           make
         working-directory: src/Kaponata.Api/
 
+      - name: Package sidecars
+        run: |
+          dotnet publish -c Release
+          make
+        working-directory: src/Kaponata.Sidecars/
+
       - name: Package UI
         run: |
           export PATH="$PATH:/usr/local/lib/npm/bin/"
@@ -256,6 +262,11 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: make push
         working-directory: src/Kaponata.Api/
+
+      - name: Publish Sidecar container image
+        if: github.ref == 'refs/heads/main'
+        run: make push
+        working-directory: src/Kaponata.Sidecar/
 
       - name: Publish chart CI website
         if: github.ref == 'refs/heads/main'

--- a/src/Kaponata.Kubernetes.Tests/LabelSelectorTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/LabelSelectorTests.cs
@@ -6,6 +6,7 @@ using k8s;
 using k8s.Models;
 using Kaponata.Kubernetes.Models;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Kaponata.Kubernetes.Tests
@@ -16,7 +17,7 @@ namespace Kaponata.Kubernetes.Tests
     public class LabelSelectorTests
     {
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when <see langword="null"/> is passed.
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when <see langword="null"/> is passed.
         /// </summary>
         [Fact]
         public void Create_Null_ReturnsNull()
@@ -25,7 +26,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an expression is passed when
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when an expression is passed when
         /// always returns <see langword="true"/>.
         /// </summary>
         [Fact]
@@ -35,7 +36,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an expression is passed when
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when an expression is passed when
         /// always returns <see langword="true"/>.
         /// </summary>
         [Fact]
@@ -45,7 +46,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an expression is passed when
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when an expression is passed when
         /// always returns <see langword="true"/>.
         /// </summary>
         [Fact]
@@ -55,7 +56,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when no label is embedded in the expression.
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when no label is embedded in the expression.
         /// </summary>
         [Fact]
         public void Create_NoLabel_ReturnsNull()
@@ -64,7 +65,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns a correct label selector when a single label is present.
+        /// <see cref="LabelSelector.Create{T}"/> returns a correct label selector when a single label is present.
         /// </summary>
         [Fact]
         public void Create_SingleLabel_Works()
@@ -73,7 +74,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns a correct label selector when a two labels are present.
+        /// <see cref="LabelSelector.Create{T}"/> returns a correct label selector when a two labels are present.
         /// </summary>
         [Fact]
         public void Create_TwoLabels_Works()
@@ -84,7 +85,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns a correct label selector when a three labels are present.
+        /// <see cref="LabelSelector.Create{T}"/> returns a correct label selector when a three labels are present.
         /// </summary>
         [Fact]
         public void Create_ThreeLabels_Works()
@@ -96,7 +97,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> throws an exception when the label value is not a constant.
+        /// <see cref="LabelSelector.Create{T}"/> throws an exception when the label value is not a constant.
         /// </summary>
         [Fact]
         public void Create_ValueNotConstant_Throws()
@@ -107,7 +108,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an incorrect method is being called
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when an incorrect method is being called
         /// on the Labels property.
         /// </summary>
         [Fact]
@@ -117,7 +118,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create"/> returns <see langword="null"/> when an dictionary indexer is being called
+        /// <see cref="LabelSelector.Create{T}"/> returns <see langword="null"/> when an dictionary indexer is being called
         /// on the Labels property.
         /// </summary>
         [Fact]
@@ -127,7 +128,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// Calling <see cref="LabelSelector.Create"/> on a pod object which is not the parameter returns
+        /// Calling <see cref="LabelSelector.Create{T}"/> on a pod object which is not the parameter returns
         /// <see langword="null"/>.
         /// </summary>
         [Fact]
@@ -137,7 +138,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// Calling <see cref="LabelSelector.Create"/> which reads a wrong property returns
+        /// Calling <see cref="LabelSelector.Create{T}"/> which reads a wrong property returns
         /// <see langword="null"/>.
         /// </summary>
         [Fact]
@@ -147,7 +148,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// Calling <see cref="LabelSelector.Create"/> which reads a label using a non-constant
+        /// Calling <see cref="LabelSelector.Create{T}"/> which reads a label using a non-constant
         /// expression returns <see langword="null"/>.
         /// </summary>
         [Fact]
@@ -157,7 +158,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// Calling <see cref="LabelSelector.Create"/> works with custom object types.
+        /// Calling <see cref="LabelSelector.Create{T}"/> works with custom object types.
         /// </summary>
         [Fact]
         public void Create_CustomType_Works()
@@ -166,12 +167,64 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// Calling <see cref="LabelSelector.Create"/> throws an error if not operating on (IKubernetesObject).Metadata.Labels.
+        /// Calling <see cref="LabelSelector.Create{T}"/> throws an error if not operating on (IKubernetesObject).Metadata.Labels.
         /// </summary>
         [Fact]
         public void NotAKubeType_ReturnsNull()
         {
             Assert.Null(LabelSelector.Create<CustomObject>(s => s.Child.Metadata.Labels[Annotations.ManagedBy] == "test"));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void FromDictionary_ValidatesArgument()
+        {
+            Assert.Throws<ArgumentNullException>("values", () => LabelSelector.Create((Dictionary<string, string>)null));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> returns an empty selector when passed
+        /// an empty dictionary.
+        /// </summary>
+        [Fact]
+        public void FromDictionary_EmptyDictionary_ReturnsEmptySelector()
+        {
+            Assert.Equal(string.Empty, LabelSelector.Create(new Dictionary<string, string>()));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> returns a valid selector when passed
+        /// a single key/value pair.
+        /// </summary>
+        [Fact]
+        public void FromDictionary_SingleValue_ReturnsSelector()
+        {
+            Assert.Equal(
+                "app.kubernetes.io/managed-by=test",
+                LabelSelector.Create(
+                    new Dictionary<string, string>()
+                    {
+                        { Annotations.ManagedBy,  "test" },
+                    }));
+        }
+
+        /// <summary>
+        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> returns a valid selector when passed
+        /// two key/value pairs.
+        /// </summary>
+        [Fact]
+        public void FromDictionary_TwoValues_ReturnsSelector()
+        {
+            Assert.Equal(
+                "app.kubernetes.io/managed-by=test,kubernetes.io/arch=arm64",
+                LabelSelector.Create(
+                    new Dictionary<string, string>()
+                    {
+                        { Annotations.ManagedBy,  "test" },
+                        { Annotations.Arch, "arm64" },
+                    }));
         }
 
         private class CustomObject : IKubernetesObject<V1ObjectMeta>

--- a/src/Kaponata.Kubernetes/LabelSelector.cs
+++ b/src/Kaponata.Kubernetes/LabelSelector.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Text;
 
 #nullable disable
 
@@ -40,6 +41,37 @@ namespace Kaponata.Kubernetes
             }
 
             return ToLabelSelector(predicate.Body);
+        }
+
+        /// <summary>
+        /// Converts a dictionary to a label selector.
+        /// </summary>
+        /// <param name="values">
+        /// The label selector, as a dictionary.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> which represents the label selector.
+        /// </returns>
+        public static string Create(Dictionary<string, string> values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            StringBuilder builder = new StringBuilder();
+
+            foreach (var pair in values)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(",");
+                }
+
+                builder.AppendFormat("{0}={1}", pair.Key, pair.Value);
+            }
+
+            return builder.ToString();
         }
 
         // Operates on the root expression. We support either a binary Equal expression

--- a/src/Kaponata.Sidecars.Tests/Kaponata.Sidecars.Tests.csproj
+++ b/src/Kaponata.Sidecars.Tests/Kaponata.Sidecars.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Kaponata.Sidecars/Dockerfile
+++ b/src/Kaponata.Sidecars/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
+
+ARG GIT_COMMIT_DATE
+ARG GIT_COMMIT_ID
+ARG GIT_REF
+ARG GIT_REMOTE
+ARG VERSION
+ARG EXPIRES
+
+LABEL org.opencontainers.image.title="Kaponata Sidecar"
+LABEL org.opencontainers.image.description="The Kaponata Sidecar connects runs inside a pod which hosts usbmuxd or adb, and publishes MobileDevice objects to the Kubernetes cluster."
+LABEL org.opencontainers.image.licenses="MIT"
+
+LABEL org.opencontainers.image.created=$GIT_COMMIT_DATE
+LABEL org.opencontainers.image.authors="Frederik Carlier <frederik.carlier@quamotion.mobi>"
+LABEL org.opencontainers.image.vendor="Quamotion bv <info@quamotion.mobi>"
+LABEL org.opencontainers.image.url="https://www.kaponata.io/"
+LABEL org.opencontainers.image.source=$GIT_REMOTE
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$GIT_COMMIT_ID
+LABEL org.opencontainers.image.ref.name=$GIT_REF
+
+LABEL quay.expires-after=$EXPIRES
+
+WORKDIR /app
+
+COPY bin/Release/net5.0/publish /app/
+
+ENTRYPOINT ["dotnet", "/app/Kaponata.Sidecars.dll"]

--- a/src/Kaponata.Sidecars/Kaponata.Sidecars.csproj
+++ b/src/Kaponata.Sidecars/Kaponata.Sidecars.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20574.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kaponata.iOS\Kaponata.iOS.csproj" />
+    <ProjectReference Include="..\Kaponata.Kubernetes\Kaponata.Kubernetes.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Kaponata.Sidecars/Makefile
+++ b/src/Kaponata.Sidecars/Makefile
@@ -1,0 +1,57 @@
+registry=quay.io/kaponata
+image=sidecar
+version=$(shell nbgv get-version -v SemVer2)
+
+# Set tags to expire in 2 weeks (duration of a sprint) in quay.io;
+# exception for tags built from release branches, which never expire.
+branch=$(shell git rev-parse --abbrev-ref HEAD)
+expires=$(if $(patsubst releases/,,$(branch)),2w,)
+
+all: .arm64.docker-id .amd64.docker-id
+
+clean:
+	rm -f .arm64.docker-id .amd64.docker-id
+
+deploy: all
+	docker tag $(registry)/$(image):$(version)-amd64 $(registry)/$(image):latest-amd64
+	k3d image import $(registry)/$(image):latest-amd64
+# As an exception to the general rule, delete all usbmuxd pods since they rely on the sidecar image.
+	kubectl delete pod -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd
+  
+push: all
+	docker push $(registry)/$(image):$(version)-amd64
+	docker push $(registry)/$(image):$(version)-arm64
+	docker manifest create --amend $(registry)/$(image):$(version) $(registry)/$(image):$(version)-amd64 $(registry)/$(image):$(version)-arm64
+	docker manifest push $(registry)/$(image):$(version)
+
+bin/Release/net5.0/publish/Kaponata.Sidecars.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
+	dotnet publish -c Release
+
+.amd64.docker-id: Dockerfile bin/Release/net5.0/publish/Kaponata.Sidecars.dll
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg host= \
+		--build-arg arch= \
+		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
+		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
+		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
+		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
+		--build-arg VERSION="$(version)" \
+		--build-arg EXPIRES=$(expires) \
+		. \
+		-t $(registry)/$(image):$(version)-amd64
+	docker images --no-trunc --quiet $(registry)/$(image):$(version)-amd64 > .amd64.docker-id
+
+.arm64.docker-id: Dockerfile bin/Release/net5.0/publish/Kaponata.Sidecars.dll
+	docker buildx build --platform linux/arm64 \
+		--build-arg host=aarch64-linux-gnu \
+		--build-arg arch=arm64 \
+		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
+		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
+		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
+		--build-arg GIT_REMOTE="$(shell git remote get-url $(shell git remote))" \
+		--build-arg VERSION="$(version)" \
+		--build-arg EXPIRES=$(expires) \
+		. \
+		-t $(registry)/$(image):$(version)-arm64
+	docker images --no-trunc --quiet $(registry)/$(image):$(version)-arm64 > .arm64.docker-id

--- a/src/Kaponata.Sidecars/Program.cs
+++ b/src/Kaponata.Sidecars/Program.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="Program.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Hosting;
+using System.CommandLine.Parsing;
+using System.Threading.Tasks;
+
+namespace Kaponata.Sidecars
+{
+    /// <summary>
+    /// Represents the main entry point to the Kaponata.Sidecars program.
+    /// </summary>
+    public class Program
+    {
+        /// <summary>
+        /// Runs the Kaponata Sidecar.
+        /// </summary>
+        /// <param name="args">
+        /// The command line arguments.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public static async Task Main(string[] args) => await BuildCommandLine()
+            .UseHost(
+                _ => Host.CreateDefaultBuilder(),
+                host =>
+                {
+                    host.ConfigureServices(services =>
+                    {
+                        services.AddLogging();
+                        services.AddKubernetes();
+                    });
+                })
+            .UseDefaults()
+            .Build()
+            .InvokeAsync(args);
+
+        private static CommandLineBuilder BuildCommandLine()
+        {
+            return new CommandLineBuilder(null);
+        }
+    }
+}

--- a/src/Kaponata.sln
+++ b/src/Kaponata.sln
@@ -29,9 +29,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Kubernetes", "Kapo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Kubernetes.Tests", "Kaponata.Kubernetes.Tests\Kaponata.Kubernetes.Tests.csproj", "{13F56EC8-811D-4E26-A72E-DB5DCC17AA7E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kaponata.Multimedia", "Kaponata.Multimedia\Kaponata.Multimedia.csproj", "{0648AAC2-6B75-491D-B12E-2A891DD6912C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Multimedia", "Kaponata.Multimedia\Kaponata.Multimedia.csproj", "{0648AAC2-6B75-491D-B12E-2A891DD6912C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kaponata.Multimedia.Tests", "Kaponata.Multimedia.Tests\Kaponata.Multimedia.Tests.csproj", "{D0C399C8-2CF9-4912-823A-A27B30CC8FF8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Multimedia.Tests", "Kaponata.Multimedia.Tests\Kaponata.Multimedia.Tests.csproj", "{D0C399C8-2CF9-4912-823A-A27B30CC8FF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Sidecars", "Kaponata.Sidecars\Kaponata.Sidecars.csproj", "{71FB6509-B223-4A39-8077-59B1047DE0CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaponata.Sidecars.Tests", "Kaponata.Sidecars.Tests\Kaponata.Sidecars.Tests.csproj", "{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -199,6 +203,30 @@ Global
 		{D0C399C8-2CF9-4912-823A-A27B30CC8FF8}.Release|x64.Build.0 = Release|Any CPU
 		{D0C399C8-2CF9-4912-823A-A27B30CC8FF8}.Release|x86.ActiveCfg = Release|Any CPU
 		{D0C399C8-2CF9-4912-823A-A27B30CC8FF8}.Release|x86.Build.0 = Release|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Debug|x64.Build.0 = Debug|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Debug|x86.Build.0 = Debug|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Release|x64.ActiveCfg = Release|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Release|x64.Build.0 = Release|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{71FB6509-B223-4A39-8077-59B1047DE0CA}.Release|x86.Build.0 = Release|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Debug|x64.Build.0 = Debug|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Debug|x86.Build.0 = Debug|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Release|x64.Build.0 = Release|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -217,6 +245,8 @@ Global
 		{13F56EC8-811D-4E26-A72E-DB5DCC17AA7E} = {3C4D2817-BEF8-410D-89F4-DE685E1DB3D0}
 		{0648AAC2-6B75-491D-B12E-2A891DD6912C} = {E46AA4D7-736B-46D2-80BA-30A5A6FB2FD0}
 		{D0C399C8-2CF9-4912-823A-A27B30CC8FF8} = {3C4D2817-BEF8-410D-89F4-DE685E1DB3D0}
+		{71FB6509-B223-4A39-8077-59B1047DE0CA} = {E46AA4D7-736B-46D2-80BA-30A5A6FB2FD0}
+		{65F69F4B-9F5B-4FF8-8F5E-D0F9F519D9D6} = {3C4D2817-BEF8-410D-89F4-DE685E1DB3D0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {734C5F7F-BA19-499C-B9F5-2C3E206557BC}


### PR DESCRIPTION
The sidecars will be used to publish `MobileDevice` objects into the Kubernetes cluster, based on devices available in `usbmuxd`.

This PR scaffolds the sidecars project and publishes the container to the quay registry.