### PR TITLE
Add sidecar to usbmuxd pod

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -233,6 +233,13 @@ jobs:
         run: kubectl logs -l app.kubernetes.io/component=api,app.kubernetes.io/name=kaponata --tail=-1
         if: always()
 
+      - name: Kubernetes - dump usbmuxd logs
+        run: |
+          kubectl describe pod -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd
+          kubectl logs -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd --tail=-1 -c usbmuxd
+          kubectl logs -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd --tail=-1 -c sidecar
+        if: always()
+
       - name: Delete k3d cluster
         if: always()
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,6 +135,7 @@ jobs:
           yq e '.appVersion="${{ steps.nbgv.outputs.SemVer2 }}"' -i Chart.yaml
           yq e '.operator.image.tag="${{ steps.nbgv.outputs.SemVer2 }}"' -i values.yaml
           yq e '.api.image.tag="${{ steps.nbgv.outputs.SemVer2 }}"' -i values.yaml
+          yq e '.sidecar.image.tag="${{ steps.nbgv.outputs.SemVer2 }}"' -i charts/usbmuxd/values.yaml
 
           helm lint .
           helm package . -d ${{ github.workspace }}/bin/charts
@@ -166,6 +167,9 @@ jobs:
 
           docker tag quay.io/kaponata/api:${{ steps.nbgv.outputs.SemVer2 }}-amd64 quay.io/kaponata/api:${{ steps.nbgv.outputs.SemVer2 }}
           k3d image import quay.io/kaponata/api:${{ steps.nbgv.outputs.SemVer2 }}
+
+          docker tag quay.io/kaponata/sidecar:${{ steps.nbgv.outputs.SemVer2 }}-amd64 quay.io/kaponata/sidecar:${{ steps.nbgv.outputs.SemVer2 }}
+          k3d image import quay.io/kaponata/sidecar:${{ steps.nbgv.outputs.SemVer2 }}
 
       # Override the usbmuxd image tag in the usbmuxd subchart to
       # latest-udev-amd64. This fixes an issue where usbmuxd will fail
@@ -266,7 +270,7 @@ jobs:
       - name: Publish Sidecar container image
         if: github.ref == 'refs/heads/main'
         run: make push
-        working-directory: src/Kaponata.Sidecar/
+        working-directory: src/Kaponata.Sidecars/
 
       - name: Publish chart CI website
         if: github.ref == 'refs/heads/main'

--- a/src/Kaponata.Chart.Tests/UsbmuxdTests.cs
+++ b/src/Kaponata.Chart.Tests/UsbmuxdTests.cs
@@ -69,7 +69,7 @@ namespace Kaponata.Chart.Tests
                 var pod = pods.Items[0];
 
                 // The pod is in the running state
-                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(2), default).ConfigureAwait(false);
                 Assert.Equal("Running", pod.Status.Phase);
 
                 // We can connect to port 27015 and retrieve an empty device list

--- a/src/Kaponata.Sidecars/Program.cs
+++ b/src/Kaponata.Sidecars/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 
@@ -44,7 +45,14 @@ namespace Kaponata.Sidecars
 
         private static CommandLineBuilder BuildCommandLine()
         {
-            return new CommandLineBuilder(null);
+            var root = new RootCommand();
+            root.Handler = CommandHandler.Create<IHost>(RunAsync);
+            return new CommandLineBuilder(root);
+        }
+
+        private static async Task RunAsync(IHost host)
+        {
+            await host.WaitForShutdownAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/chart/charts/usbmuxd/templates/_helpers.tpl
+++ b/src/chart/charts/usbmuxd/templates/_helpers.tpl
@@ -50,3 +50,24 @@ app.kubernetes.io/name: {{ include "usbmuxd.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: "usbmuxd"
 {{- end }}
+
+{{/*
+API: Service Account Full Name
+*/}}
+{{- define "usbmuxd.serviceAccount.fullname" -}}
+{{- printf "%s-usbmuxd-account" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+API: Role Full Name
+*/}}
+{{- define "usbmuxd.role.fullname" -}}
+{{- printf "%s-usbmuxd-role" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+API: Role Binding Full Name
+*/}}
+{{- define "usbmuxd.roleBinding.fullname" -}}
+{{- printf "%s-usbmuxd-rolebinding" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/src/chart/charts/usbmuxd/templates/daemonset.yaml
+++ b/src/chart/charts/usbmuxd/templates/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      serviceAccountName: {{ template "usbmuxd.serviceAccount.fullname" . }}
       containers:
       - name: usbmuxd
         image: {{ .Values.usbmuxd.image.repository }}:{{ .Values.usbmuxd.image.tag }}
@@ -34,6 +35,18 @@ spec:
         # Listen on 0.0.0.0:27015
         - "-S"
         - "0.0.0.0:27015"
+
+      - name: sidecar
+        image: {{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}
+        command: [ "dotnet", "/app/Kaponata.Sidecars.dll" ]
+        args:
+        - "--pod-name"
+        - "$(POD_NAME)"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
 
       # Required volumes
       volumes:

--- a/src/chart/charts/usbmuxd/templates/usbmuxd-role.yaml
+++ b/src/chart/charts/usbmuxd/templates/usbmuxd-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "usbmuxd.role.fullname" . }}
+  labels:
+    {{- include "usbmuxd.labels" . | nindent 4 }}
+rules:
+- apiGroups: [ "" ]
+  resources: [ "pods" ]
+  verbs: [ "get", "list" ]
+- apiGroups: [ "kaponata.io" ]
+  resources: [ "mobiledevices" ]
+  verbs: [ "get", "list", "create", "delete" ]

--- a/src/chart/charts/usbmuxd/templates/usbmuxd-roleBinding.yaml
+++ b/src/chart/charts/usbmuxd/templates/usbmuxd-roleBinding.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "usbmuxd.roleBinding.fullname" . }}
+  labels:
+    {{- include "usbmuxd.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "usbmuxd.role.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "usbmuxd.serviceAccount.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/src/chart/charts/usbmuxd/templates/usbmuxd-serviceAccount.yaml
+++ b/src/chart/charts/usbmuxd/templates/usbmuxd-serviceAccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "usbmuxd.serviceAccount.fullname" . }}
+  labels:
+    {{- include "usbmuxd.labels" . | nindent 4 }}

--- a/src/chart/charts/usbmuxd/values.yaml
+++ b/src/chart/charts/usbmuxd/values.yaml
@@ -2,3 +2,8 @@ usbmuxd:
   image:
     repository: quay.io/kaponata/usbmuxd
     tag: 1.1.2
+
+sidecar:
+  image:
+    repository: quay.io/kaponata/sidecar
+    tag: latest-amd64


### PR DESCRIPTION
This adds the sidecar to the usbmuxd pod, and grants the usbmuxd pod CRUD permissions on mobiledevice objects and permissions to get/list pods (this allows the pod to find its own identity, which is used to set the ownership on the mobiledevice object).