### PR TITLE
Store iOS development identities, provisioning profiles in Kubernetes using secrets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -233,6 +233,12 @@ jobs:
         run: kubectl logs -l app.kubernetes.io/component=api,app.kubernetes.io/name=kaponata --tail=-1
         if: always()
 
+      - name: Kubernetes - dump Guacamole logs
+        run: |
+          kubectl describe pod -l app.kubernetes.io/name=guacamole,app.kubernetes.io/component=guacamole
+          kubectl logs -l app.kubernetes.io/name=guacamole,app.kubernetes.io/component=guacamole --tail=-1
+        if: always()
+
       - name: Kubernetes - dump usbmuxd logs
         run: |
           kubectl describe pod -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd

--- a/src/Kaponata.Chart.Tests/GuacamoleTests.cs
+++ b/src/Kaponata.Chart.Tests/GuacamoleTests.cs
@@ -20,6 +20,8 @@ namespace Kaponata.Chart.Tests
     /// </summary>
     public class GuacamoleTests
     {
+        private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(2);
+
         private readonly ITestOutputHelper output;
         private readonly ILoggerFactory loggerFactory;
 
@@ -65,7 +67,7 @@ namespace Kaponata.Chart.Tests
                 var pod = pods.Items[0];
 
                 // The pod is in the running state
-                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+                pod = await client.WaitForPodRunningAsync(pod, Timeout, default).ConfigureAwait(false);
                 Assert.Equal("Running", pod.Status.Phase);
 
                 // Try to perform a handshake
@@ -113,7 +115,7 @@ namespace Kaponata.Chart.Tests
                 var pod = pods.Items[0];
 
                 // The pod is in the running state
-                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+                pod = await client.WaitForPodRunningAsync(pod, Timeout, default).ConfigureAwait(false);
                 Assert.Equal("Running", pod.Status.Phase);
 
                 // Try to perform a handshake
@@ -161,7 +163,7 @@ namespace Kaponata.Chart.Tests
                 var pod = pods.Items[0];
 
                 // The pod is in the running state
-                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(5), default).ConfigureAwait(false);
+                pod = await client.WaitForPodRunningAsync(pod, Timeout, default).ConfigureAwait(false);
                 Assert.Equal("Running", pod.Status.Phase);
             }
 

--- a/src/Kaponata.Kubernetes.Tests/DeveloperProfiles/KubernetesDeveloperProfileTests.ProvisioningProfile.cs
+++ b/src/Kaponata.Kubernetes.Tests/DeveloperProfiles/KubernetesDeveloperProfileTests.ProvisioningProfile.cs
@@ -1,0 +1,223 @@
+﻿// <copyright file="KubernetesDeveloperProfileTests.ProvisioningProfile.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Kubernetes.DeveloperProfiles;
+using Kaponata.Kubernetes.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography.Pkcs;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.DeveloperProfiles
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesDeveloperProfile"/> class.
+    /// </summary>
+    public partial class KubernetesDeveloperProfileTests
+    {
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.GetProvisioningProfilesAsync(CancellationToken)"/>
+        /// returns a profile list.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetProvisioningProfilesAsync_ReturnsProvisioningProfile_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            secretClient
+                .Setup(s => s.ListAsync(null, null, "kaponata.io/developerProfile=profile", null, default))
+                .ReturnsAsync(
+                new ItemList<V1Secret>()
+                {
+                    Items = new List<V1Secret>()
+                    {
+                        GetProvisioningProfileSecret(),
+                    },
+                });
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            var profiles = await developerProfile.GetProvisioningProfilesAsync(default).ConfigureAwait(false);
+
+            var profile = Assert.Single(profiles);
+            Assert.Equal("CN=Apple iPhone OS Provisioning Profile Signing, O=Apple Inc., C=US", profile.SignerInfos[0].Certificate.Subject);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.GetProvisioningProfileAsync(Guid, CancellationToken)"/> returns
+        /// the requested profile.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetProvisioningProfileAsync_Found_ReturnsProvisioningProfile_Async()
+        {
+            var guid = Guid.NewGuid();
+
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            secretClient
+                .Setup(s => s.TryReadAsync(guid.ToString(), "kaponata.io/developerProfile=profile", default))
+                .ReturnsAsync(GetProvisioningProfileSecret());
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            var profile = await developerProfile.GetProvisioningProfileAsync(guid, default).ConfigureAwait(false);
+            Assert.Equal("CN=Apple iPhone OS Provisioning Profile Signing, O=Apple Inc., C=US", profile.SignerInfos[0].Certificate.Subject);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.GetProvisioningProfileAsync(Guid, CancellationToken)"/>
+        /// returns <see langword="null"/> if the requested profile does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetProvisioningProfileAsync_NotFound_ReturnsNull_Async()
+        {
+            var guid = Guid.NewGuid();
+
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            secretClient
+                .Setup(s => s.TryReadAsync(guid.ToString(), "kaponata.io/developerProfile=profile", default))
+                .ReturnsAsync((V1Secret)null);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            Assert.Null(await developerProfile.GetProvisioningProfileAsync(guid, default).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.AddProvisioningProfileAsync(SignedCms, CancellationToken)"/>
+        /// validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task AddProvisioningProfileAsync_ValidatesArgument_Async()
+        {
+            var developerProfile = new KubernetesDeveloperProfile(Mock.Of<KubernetesClient>(), NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => developerProfile.AddProvisioningProfileAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.AddProvisioningProfileAsync(SignedCms, CancellationToken)"/>
+        /// adds a <see cref="V1Secret"/> which matches the profile.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task AddProvisioningProfileAsync_Works_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+            secretClient
+                .Setup(s => s.CreateAsync(It.IsAny<V1Secret>(), default))
+                .Callback<V1Secret, CancellationToken>((secret, ct) =>
+                {
+                    Assert.Equal("98264c6b-5151-4349-8d0f-66691e48ae35", secret.Metadata.Name);
+                    Assert.Equal(Annotations.ProvisioningProfile, secret.Metadata.Labels[Annotations.DeveloperProfileComponent]);
+
+                    Assert.Equal("kaponata.io/signedData", secret.Type);
+                    Assert.NotNull(secret.Data["signedData"]);
+                })
+                .ReturnsAsync(new V1Secret())
+                .Verifiable();
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            var profile = new SignedCms();
+            profile.Decode(File.ReadAllBytes("DeveloperProfiles/test.mobileprovision"));
+            await developerProfile.AddProvisioningProfileAsync(profile, default).ConfigureAwait(false);
+
+            secretClient.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.DeleteProvisioningProfileAsync(Guid, CancellationToken)"/> throws an
+        /// exception when no secret matching the certificat exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteProvisioningProfileAsync_NotFound_Throws_Async()
+        {
+            var guid = Guid.NewGuid();
+
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            secretClient
+                .Setup(c => c.TryReadAsync(guid.ToString(), "kaponata.io/developerProfile=profile", default))
+                .ReturnsAsync((V1Secret)null)
+                .Verifiable();
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => developerProfile.DeleteProvisioningProfileAsync(guid, default)).ConfigureAwait(false);
+
+            secretClient.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.DeleteProvisioningProfileAsync(Guid, CancellationToken)"/> deletes
+        /// the underlying secret.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteProvisioningProfileAsync_Works_Async()
+        {
+            var guid = Guid.NewGuid();
+
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var secret = new V1Secret();
+            secretClient
+                .Setup(c => c.TryReadAsync(guid.ToString(), "kaponata.io/developerProfile=profile", default))
+                .ReturnsAsync(secret)
+                .Verifiable();
+
+            secretClient
+                .Setup(c => c.DeleteAsync(secret, TimeSpan.FromMinutes(1), default))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await developerProfile.DeleteProvisioningProfileAsync(guid, default).ConfigureAwait(false);
+
+            secretClient.Verify();
+        }
+
+        private static V1Secret GetProvisioningProfileSecret()
+        {
+            var secret = new V1Secret()
+            {
+                Data = new Dictionary<string, byte[]>(),
+                Type = "kaponata.io/signedData",
+            };
+
+            secret.Data["signedData"] = File.ReadAllBytes("DeveloperProfiles/test.mobileprovision");
+
+            return secret;
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/DeveloperProfiles/KubernetesDeveloperProfileTests.X509Certificate2.cs
+++ b/src/Kaponata.Kubernetes.Tests/DeveloperProfiles/KubernetesDeveloperProfileTests.X509Certificate2.cs
@@ -1,0 +1,229 @@
+﻿// <copyright file="KubernetesDeveloperProfileTests.X509Certificate2.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Kubernetes.DeveloperProfiles;
+using Kaponata.Kubernetes.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.DeveloperProfiles
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesDeveloperProfile"/> class.
+    /// </summary>
+    public partial class KubernetesDeveloperProfileTests
+    {
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.GetCertificatesAsync(CancellationToken)"/>
+        /// returns a certificate list.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetCertificatesAsync_ReturnsCertificate_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            secretClient
+                .Setup(s => s.ListAsync(null, null, "kaponata.io/developerProfile=identity", null, default))
+                .ReturnsAsync(
+                new ItemList<V1Secret>()
+                {
+                    Items = new List<V1Secret>()
+                    {
+                        GetSecret(),
+                    },
+                });
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            var certificates = await developerProfile.GetCertificatesAsync(default).ConfigureAwait(false);
+
+            var certificate = Assert.Single(certificates);
+            Assert.Equal("CN=Test", certificate.Subject);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.GetCertificateAsync(string, CancellationToken)"/> returns
+        /// the requested certificate.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetCertificateAsync_Found_ReturnsCertificate_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            secretClient
+                .Setup(s => s.TryReadAsync("1234", "kaponata.io/developerProfile=identity", default))
+                .ReturnsAsync(GetSecret());
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            var certificate = await developerProfile.GetCertificateAsync("1234", default).ConfigureAwait(false);
+            Assert.Equal("CN=Test", certificate.Subject);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.GetCertificateAsync(string, CancellationToken)"/>
+        /// returns <see langword="null"/> if the requested certificate does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetCertificateAsync_NotFound_ReturnsNull_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            secretClient
+                .Setup(s => s.TryReadAsync("1234", "kaponata.io/developerProfile=identity", default))
+                .ReturnsAsync((V1Secret)null);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            Assert.Null(await developerProfile.GetCertificateAsync("1234", default).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.AddCertificateAsync(X509Certificate2, CancellationToken)"/>
+        /// validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task AddCertificateAsync_ValidatesArgument_Async()
+        {
+            var developerProfile = new KubernetesDeveloperProfile(Mock.Of<KubernetesClient>(), NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => developerProfile.AddCertificateAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.AddCertificateAsync(X509Certificate2, CancellationToken)"/>
+        /// adds a <see cref="V1Secret"/> which matches the certificate.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task AddCertificateAsync_Works_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+            secretClient
+                .Setup(s => s.CreateAsync(It.IsAny<V1Secret>(), default))
+                .Callback<V1Secret, CancellationToken>((secret, ct) =>
+                {
+                    Assert.Equal("c973377d7991bebbe3d85dffe838a61f5283d621", secret.Metadata.Name);
+                    Assert.Equal(Annotations.DeveloperIdentity, secret.Metadata.Labels[Annotations.DeveloperProfileComponent]);
+
+                    Assert.Equal("kubernetes.io/tls", secret.Type);
+                    Assert.NotNull(secret.Data["tls.key"]);
+                    Assert.NotNull(secret.Data["tls.crt"]);
+                })
+                .ReturnsAsync(new V1Secret())
+                .Verifiable();
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            var certificate = X509Certificate2.CreateFromPemFile("DeveloperProfiles/tls.crt", "DeveloperProfiles/tls.key");
+            await developerProfile.AddCertificateAsync(certificate, default).ConfigureAwait(false);
+
+            secretClient.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.DeleteCertificateAsync(string, CancellationToken)"/> validates its
+        /// arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCertificateAsync_ValidatesArgument_Async()
+        {
+            var developerProfile = new KubernetesDeveloperProfile(Mock.Of<KubernetesClient>(), NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => developerProfile.DeleteCertificateAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.DeleteCertificateAsync(string, CancellationToken)"/> throws an
+        /// exception when no secret matching the certificat exists.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCertificateAsync_NotFound_Throws_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            secretClient
+                .Setup(c => c.TryReadAsync("abc", "kaponata.io/developerProfile=identity", default))
+                .ReturnsAsync((V1Secret)null)
+                .Verifiable();
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => developerProfile.DeleteCertificateAsync("abc", default)).ConfigureAwait(false);
+
+            secretClient.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesDeveloperProfile.DeleteCertificateAsync(string, CancellationToken)"/> deletes
+        /// the underlying secret.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteCertificateAsync_Works_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+
+            kubernetes.Setup(k => k.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            var secret = new V1Secret();
+            secretClient
+                .Setup(c => c.TryReadAsync("c973377d7991bebbe3d85dffe838a61f5283d621", "kaponata.io/developerProfile=identity", default))
+                .ReturnsAsync(secret)
+                .Verifiable();
+
+            secretClient
+                .Setup(c => c.DeleteAsync(secret, TimeSpan.FromMinutes(1), default))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var developerProfile = new KubernetesDeveloperProfile(kubernetes.Object, NullLogger<KubernetesDeveloperProfile>.Instance);
+
+            await developerProfile.DeleteCertificateAsync("c973377d7991bebbe3d85dffe838a61f5283d621", default).ConfigureAwait(false);
+
+            secretClient.Verify();
+        }
+
+        private static V1Secret GetSecret()
+        {
+            var secret = new V1Secret()
+            {
+                Data = new Dictionary<string, byte[]>(),
+                Type = "kubernetes.io/tls",
+            };
+
+            secret.Data["tls.crt"] = File.ReadAllBytes("DeveloperProfiles/tls.crt");
+            secret.Data["tls.key"] = File.ReadAllBytes("DeveloperProfiles/tls.key");
+
+            return secret;
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/DeveloperProfiles/KubernetesDeveloperProfileTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/DeveloperProfiles/KubernetesDeveloperProfileTests.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="KubernetesDeveloperProfileTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes.DeveloperProfiles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.DeveloperProfiles
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesDeveloperProfile"/> class.
+    /// </summary>
+    public partial class KubernetesDeveloperProfileTests
+    {
+        /// <summary>
+        /// The <see cref="KubernetesDeveloperProfile"/> constructor validates the arguments.
+        /// </summary>
+        [Fact]
+        public void Construtor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new KubernetesDeveloperProfile(null, NullLogger<KubernetesDeveloperProfile>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new KubernetesDeveloperProfile(Mock.Of<KubernetesClient>(), null));
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/Annotations.cs
+++ b/src/Kaponata.Kubernetes/Annotations.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using k8s.Models;
 using Kaponata.Kubernetes.Models;
 
 namespace Kaponata.Kubernetes
@@ -11,6 +12,25 @@ namespace Kaponata.Kubernetes
     /// </summary>
     public class Annotations
     {
+        /// <summary>
+        /// Applied to <see cref="V1Secret"/> objects, to indicate which aspect of a developer
+        /// profile the secret represents. Possible values are <see cref="DeveloperIdentity"/>
+        /// or <see cref="ProvisioningProfile"/>.
+        /// </summary>
+        public const string DeveloperProfileComponent = "kaponata.io/developerProfile";
+
+        /// <summary>
+        /// The secret contains a developer identity (an X.509 certificate).
+        /// </summary>
+        /// <seealso cref="DeveloperProfileComponent"/>.
+        public const string DeveloperIdentity = "identity";
+
+        /// <summary>
+        /// The secret contains a provisioning profile.
+        /// </summary>
+        /// <seealso cref="DeveloperProfileComponent"/>.
+        public const string ProvisioningProfile = "profile";
+
         /// <summary>
         /// The name of the application.
         /// </summary>

--- a/src/Kaponata.Kubernetes/DeveloperProfiles/KubernetesDeveloperProfile.ProvisioningProfile.cs
+++ b/src/Kaponata.Kubernetes/DeveloperProfiles/KubernetesDeveloperProfile.ProvisioningProfile.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="KubernetesDeveloperProfile.ProvisioningProfile.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DeveloperProfiles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.Pkcs;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Kubernetes.DeveloperProfiles
+{
+    /// <summary>
+    /// Emulates an iOS developer profile and stores the developer certificates (identities) and provisioning profiles
+    /// as secrets in the Kubernetes cluster.
+    /// </summary>
+    public partial class KubernetesDeveloperProfile
+    {
+        private static readonly string ProvisioningProfileLabelSelector = LabelSelector.Create(
+                    new Dictionary<string, string>()
+                    {
+                        { Annotations.DeveloperProfileComponent, Annotations.ProvisioningProfile },
+                    });
+
+        /// <summary>
+        /// Asynchronously lists all provisioning profiles which are stored in this cluster.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<IList<SignedCms>> GetProvisioningProfilesAsync(CancellationToken cancellationToken)
+        {
+            var response = await this.secretClient.ListAsync(
+                labelSelector: ProvisioningProfileLabelSelector,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            return response.Items.Select(s => s.AsSignedCms()).ToList();
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves an individual provisioning profile from the cluster.
+        /// </summary>
+        /// <param name="uuid">
+        /// The UUID of the provisioning profile to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<SignedCms?> GetProvisioningProfileAsync(Guid uuid, CancellationToken cancellationToken)
+        {
+            var secret = await this.secretClient.TryReadAsync(uuid.ToString(), ProvisioningProfileLabelSelector, cancellationToken).ConfigureAwait(false);
+
+            if (secret == null)
+            {
+                return null;
+            }
+
+            return secret.AsSignedCms();
+        }
+
+        /// <summary>
+        /// Asynchronously adds a provisioning profile to the cluster.
+        /// </summary>
+        /// <param name="profile">
+        /// A <see cref="SignedCms"/> object which represents the provisioning profile to add.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task AddProvisioningProfileAsync(SignedCms profile, CancellationToken cancellationToken)
+        {
+            if (profile == null)
+            {
+                throw new ArgumentNullException(nameof(profile));
+            }
+
+            var secret = profile.AsSecret();
+            var signedProfile = ProvisioningProfile.Read(profile);
+
+            secret.Metadata.Name = signedProfile.Uuid.ToString();
+            secret.Metadata.Labels[Annotations.DeveloperProfileComponent] = Annotations.ProvisioningProfile;
+
+            await this.secretClient.CreateAsync(secret, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a provisioning profile from the cluster.
+        /// </summary>
+        /// <param name="uuid">
+        /// The UUID of the provisioning profile to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task DeleteProvisioningProfileAsync(Guid uuid, CancellationToken cancellationToken)
+        {
+            var secret = await this.secretClient.TryReadAsync(uuid.ToString(), ProvisioningProfileLabelSelector, cancellationToken).ConfigureAwait(false);
+
+            if (secret == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            await this.secretClient.DeleteAsync(secret, TimeSpan.FromMinutes(1), cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/DeveloperProfiles/KubernetesDeveloperProfile.X509Certificate2.cs
+++ b/src/Kaponata.Kubernetes/DeveloperProfiles/KubernetesDeveloperProfile.X509Certificate2.cs
@@ -1,0 +1,114 @@
+﻿// <copyright file="KubernetesDeveloperProfile.X509Certificate2.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Kubernetes.DeveloperProfiles
+{
+    /// <summary>
+    /// Emulates an iOS developer profile and stores the developer certificates (identities) and provisioning profiles
+    /// as secrets in the Kubernetes cluster.
+    /// </summary>
+    public partial class KubernetesDeveloperProfile
+    {
+        private static readonly string DeveloperIdentityLabelSelector = LabelSelector.Create(
+                    new Dictionary<string, string>()
+                    {
+                        { Annotations.DeveloperProfileComponent, Annotations.DeveloperIdentity },
+                    });
+
+        /// <summary>
+        /// Asynchronously lists all iOS development certificates in this cluster.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<IList<X509Certificate2>> GetCertificatesAsync(CancellationToken cancellationToken)
+        {
+            var response = await this.secretClient.ListAsync(
+                labelSelector: DeveloperIdentityLabelSelector,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            return response.Items.Select(s => s.AsX509Certificate2()).ToList();
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves an individual certificate from the cluster.
+        /// </summary>
+        /// <param name="thumbprint">
+        /// The thumbprint of the certificate.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<X509Certificate2?> GetCertificateAsync(string thumbprint, CancellationToken cancellationToken)
+        {
+            var secret = await this.secretClient.TryReadAsync(thumbprint, DeveloperIdentityLabelSelector, cancellationToken).ConfigureAwait(false);
+
+            if (secret == null)
+            {
+                return null;
+            }
+
+            return secret.AsX509Certificate2();
+        }
+
+        /// <summary>
+        /// Asynchronously adds a certificate to the cluster.
+        /// </summary>
+        /// <param name="certificate">
+        /// The certificate to add to the cluster.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task AddCertificateAsync(X509Certificate2 certificate, CancellationToken cancellationToken)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            var secret = certificate.AsSecret();
+            secret.Metadata.Labels[Annotations.DeveloperProfileComponent] = Annotations.DeveloperIdentity;
+
+            await this.secretClient.CreateAsync(secret, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a certificate from the cluster.
+        /// </summary>
+        /// <param name="thumbprint">
+        /// The thumbprint of the certificate to delete.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task DeleteCertificateAsync(string thumbprint, CancellationToken cancellationToken)
+        {
+            if (thumbprint == null)
+            {
+                throw new ArgumentNullException(nameof(thumbprint));
+            }
+
+            var secret = await this.secretClient.TryReadAsync(thumbprint, DeveloperIdentityLabelSelector, cancellationToken).ConfigureAwait(false);
+
+            if (secret == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            await this.secretClient.DeleteAsync(secret, TimeSpan.FromMinutes(1), cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/DeveloperProfiles/KubernetesDeveloperProfile.cs
+++ b/src/Kaponata.Kubernetes/DeveloperProfiles/KubernetesDeveloperProfile.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="KubernetesDeveloperProfile.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Kaponata.Kubernetes.DeveloperProfiles
+{
+    /// <summary>
+    /// Emulates an iOS developer profile and stores the developer certificates (identities) and provisioning profiles
+    /// as secrets in the Kubernetes cluster.
+    /// </summary>
+    public partial class KubernetesDeveloperProfile
+    {
+        private readonly KubernetesClient kubernetes;
+        private readonly NamespacedKubernetesClient<V1Secret> secretClient;
+        private readonly ILogger<KubernetesDeveloperProfile> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesDeveloperProfile"/> class.
+        /// </summary>
+        /// <param name="kubernetes">
+        /// A <see cref="KubernetesClient"/> which represents the connection to the Kubernetes cluster.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which can be used when logging.
+        /// </param>
+        public KubernetesDeveloperProfile(KubernetesClient kubernetes, ILogger<KubernetesDeveloperProfile> logger)
+        {
+            this.kubernetes = kubernetes ?? throw new ArgumentNullException(nameof(kubernetes));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.secretClient = kubernetes.GetClient<V1Secret>();
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.cs
@@ -59,6 +59,7 @@ namespace Kaponata.Kubernetes
             this.knownTypes.Add(typeof(WebDriverSession), WebDriverSession.KubeMetadata);
             this.knownTypes.Add(typeof(V1Pod), new KindMetadata("core", V1Pod.KubeApiVersion, V1Pod.KubeKind, "pods"));
             this.knownTypes.Add(typeof(V1Service), new KindMetadata("core", V1Service.KubeApiVersion, V1Service.KubeKind, "services"));
+            this.knownTypes.Add(typeof(V1Secret), new KindMetadata("core", V1Secret.KubeApiVersion, V1Secret.KubeKind, "secrets"));
             this.knownTypes.Add(typeof(V1Ingress), new KindMetadata(V1Ingress.KubeGroup, V1Ingress.KubeApiVersion, V1Ingress.KubeKind, "ingresses"));
         }
 

--- a/src/chart/charts/guacamole/templates/guacamole-deployment.yaml
+++ b/src/chart/charts/guacamole/templates/guacamole-deployment.yaml
@@ -25,3 +25,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /guacamole/
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /guacamole/
+              port: http


### PR DESCRIPTION
This commit introduces the KubernetesDeveloperProfile as a class
for interacting with developer profile components (certificates and
provisioning profiles) stored in a Kubernetes cluster.