### PR TITLE
Vagrant box: Use k3s instead of k3d

### DIFF
--- a/ci/kaponata/Vagrantfile
+++ b/ci/kaponata/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/focal64"
   config.vm.network "forwarded_port", guest: 5000, host: 5000, id: "registry"
   config.vm.network "forwarded_port", guest: 2375, host: 2375, id: "docker"
-  config.vm.network "forwarded_port", guest: 6433, host: 6433, id: "k8s_api"
+  config.vm.network "forwarded_port", guest: 6443, host: 6443, id: "k8s_api"
   config.vm.network "forwarded_port", guest: 80, host: 80, id: "k8s_loadbalancer"
 
   config.vm.provider "virtualbox" do |vb|
@@ -14,6 +14,7 @@ Vagrant.configure("2") do |config|
     vb.cpus = 8
 
     vb.customize ["modifyvm", :id, "--usbxhci", "on"]
+    vb.customize ["usbfilter", "add", "0", "--target", :id, "--name", "iPod", "--vendorid", "05AC", "--productid", "12AA" ]
   end
 
   # By default, Vagrant will install Ansible using the Ansible's Ubuntu PPA,
@@ -25,12 +26,13 @@ Vagrant.configure("2") do |config|
     pip3 install docker
     
     export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles
-    ansible-galaxy install geerlingguy.docker
-    ansible-galaxy install andrewrothstein.k3d
-    ansible-galaxy install andrewrothstein.kubectl'
-  config.vm.provision :shell, inline: ""
+    ansible-galaxy install geerlingguy.docker'
 
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "playbook.yml"
   end
+
+  config.vm.provision :shell, :inline  => '
+    curl -sfL https://get.k3s.io | sh -s - --docker
+    cp /etc/rancher/k3s/k3s.yaml /vagrant/'
 end

--- a/ci/kaponata/playbook.yml
+++ b/ci/kaponata/playbook.yml
@@ -9,12 +9,6 @@
         docker_users:
           - "vagrant"
 
-    # Install the k3d binary
-    - role: andrewrothstein.k3d
-
-    # Install kubectl
-    - role: andrewrothstein.kubectl
-
   tasks:
   - name: Expose Docker on port 2375
     docker_container:

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,3 @@
+$env:PATH="$PSScriptRoot\tools;${env:PATH}"
+$env:KUBECONFIG="$PSScriptRoot\ci\kaponata\k3s.yaml"
+$env:DOCKER_HOST="tcp://127.0.0.1:2375"

--- a/src/Kaponata.Api/Makefile
+++ b/src/Kaponata.Api/Makefile
@@ -14,7 +14,6 @@ clean:
 
 deploy: all
 	docker tag $(registry)/$(image):$(version)-amd64 $(registry)/$(image):latest-amd64
-	k3d image import $(registry)/$(image):latest-amd64
 	kubectl delete pod -l app.kubernetes.io/component=$(image),app.kubernetes.io/name=kaponata
   
 push: all

--- a/src/Kaponata.Operator/Makefile
+++ b/src/Kaponata.Operator/Makefile
@@ -14,7 +14,6 @@ clean:
 
 deploy: all
 	docker tag $(registry)/$(image):$(version)-amd64 $(registry)/$(image):latest-amd64
-	k3d image import $(registry)/$(image):latest-amd64
 	kubectl delete pod -l app.kubernetes.io/component=$(image),app.kubernetes.io/name=kaponata
   
 push: all

--- a/src/Kaponata.Sidecars/Makefile
+++ b/src/Kaponata.Sidecars/Makefile
@@ -14,7 +14,6 @@ clean:
 
 deploy: all
 	docker tag $(registry)/$(image):$(version)-amd64 $(registry)/$(image):latest-amd64
-	k3d image import $(registry)/$(image):latest-amd64
 # As an exception to the general rule, delete all usbmuxd pods since they rely on the sidecar image.
 	kubectl delete pod -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd
   

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,10 @@
+clean:
+	$(MAKE) -C Kaponata.Api clean
+	$(MAKE) -C Kaponata.Operator clean
+	$(MAKE) -C Kaponata.Sidecars clean
+
+deploy:
+	$(MAKE) -C Kaponata.Api deploy
+	$(MAKE) -C Kaponata.Operator deploy
+	$(MAKE) -C Kaponata.Sidecars deploy
+	$(MAKE) -C chart deploy

--- a/src/usbmuxd/Makefile
+++ b/src/usbmuxd/Makefile
@@ -3,6 +3,10 @@ image=usbmuxd
 
 all: .arm64.docker-id .amd64.docker-id .amd64.udev.docker-id .version
 
+deploy: all
+	docker tag $(registry)/$(image):latest-amd64 $(registry)/$(image):$(shell cat .version)
+	kubectl delete pod -l app.kubernetes.io/component=$(image),app.kubernetes.io/instance=kaponata
+
 push: all
 	docker push $(registry)/$(image):latest-amd64
 	docker push $(registry)/$(image):latest-arm64


### PR DESCRIPTION
The Vagrant box was using k3d (k3s-in-docker) to provision k3s. As a result, pods run
inside containerd inside Docker. A limitation of this setup is that usb
hotplug does not work correctly: newly attached devices are not discoverable
inside the container.

This PR reworks the Vagrant setup to use "native" k3s, and forces k3s to use
Docker as the container runtime (simplifying the setup a bit).