### PR TITLE
usbmuxd: Use a global SystemBUID value

### DIFF
--- a/src/chart/Makefile
+++ b/src/chart/Makefile
@@ -7,5 +7,8 @@ deploy:
 		--set api.imagePullPolicy=Never \
 		kaponata .
 
+upgrade:
+	helm upgrade kaponata .
+
 lint:
 	helm lint .

--- a/src/chart/charts/usbmuxd/templates/_helpers.tpl
+++ b/src/chart/charts/usbmuxd/templates/_helpers.tpl
@@ -52,22 +52,29 @@ app.kubernetes.io/component: "usbmuxd"
 {{- end }}
 
 {{/*
-API: Service Account Full Name
+usbmuxd: Service Account Full Name
 */}}
 {{- define "usbmuxd.serviceAccount.fullname" -}}
 {{- printf "%s-usbmuxd-account" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-API: Role Full Name
+usbmuxd: Role Full Name
 */}}
 {{- define "usbmuxd.role.fullname" -}}
 {{- printf "%s-usbmuxd-role" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-API: Role Binding Full Name
+usbmuxd: Role Binding Full Name
 */}}
 {{- define "usbmuxd.roleBinding.fullname" -}}
 {{- printf "%s-usbmuxd-rolebinding" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+usbmuxd: ConfigMap Full Name
+*/}}
+{{- define "usbmuxd.configMap.fullname" -}}
+{{- printf "%s-usbmuxd-configmap" (include "usbmuxd.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/src/chart/charts/usbmuxd/templates/daemonset.yaml
+++ b/src/chart/charts/usbmuxd/templates/daemonset.yaml
@@ -26,6 +26,10 @@ spec:
             name: usb
           - mountPath: /var/lib/lockdown
             name: lockdown
+          - mountPath: /var/lib/lockdown/SystemConfiguration.plist
+            name: config
+            subPath: SystemConfiguration.plist
+            readOnly: true
         command: [ "/usr/sbin/usbmuxd" ]
         args:
         # Verbose logging
@@ -57,3 +61,9 @@ spec:
         hostPath:
           path: /var/lib/lockdown
           type: DirectoryOrCreate
+      - name: config
+        configMap:
+          name: {{ template "usbmuxd.configMap.fullname" . }}
+          items:
+          - key: SystemConfiguration.plist
+            path: SystemConfiguration.plist

--- a/src/chart/charts/usbmuxd/templates/usbmuxd-configMap.yaml
+++ b/src/chart/charts/usbmuxd/templates/usbmuxd-configMap.yaml
@@ -1,0 +1,24 @@
+{{- $systemConfiguration := (lookup "v1" "ConfigMap" .Release.Namespace (include "usbmuxd.configMap.fullname" .)) -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "usbmuxd.configMap.fullname" . }}
+  labels:
+    {{- include "usbmuxd.labels" . | nindent 4 }}
+{{ if $systemConfiguration -}}
+data:
+  SystemConfiguration.plist: |
+    {{ index $systemConfiguration "data" "SystemConfiguration.plist" | nindent 4 }}
+{{ else -}}
+data:
+  SystemConfiguration.plist: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>SystemBUID</key>
+        <string>{{ uuidv4 }}</string>
+    </dict>
+    </plist>
+{{ end }}


### PR DESCRIPTION
Use a ConfigMap to store the `/var/lib/lockdown/SystemConfiguration.plist`
configuration file, so that all usbmuxd instances return the same SystemBUID value.