### PR TITLE
usbmuxd: Skip preflight

### DIFF
--- a/src/usbmuxd/Dockerfile.template
+++ b/src/usbmuxd/Dockerfile.template
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM debian:10 AS build
 ARG libusb_version=1.0.23
 ARG libplist_version=2.2.0
 ARG libusbmuxd_version=2.0.2
-ARG libimobiledevice_version=1.3.0
 ARG usbmuxd_version=b1a7c7ebf110aece7175b0c4d032608a00a7b55b
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -23,23 +22,16 @@ RUN apt-get update \
 # Install the cross-compiler toolchain if cross-compiling
 RUN if [ -n "$host" ]; then apt-get install -y g++-$host; fi
 
-# Install libssl for the host architecture
-RUN apt-get install -y libssl-dev:$arch
-
 # Install libudev
 RUN apt-get install -y libudev-dev
 
 WORKDIR /src
 RUN curl -L https://github.com/libusb/libusb/archive/v${libusb_version}.tar.gz --output libusb-${libusb_version}.tar.gz
 RUN curl -L https://github.com/libimobiledevice/libplist/archive/${libplist_version}.tar.gz --output libplist-${libplist_version}.tar.gz
-RUN curl -L https://github.com/libimobiledevice/libusbmuxd/archive/${libusbmuxd_version}.tar.gz --output libusbmuxd-${libusbmuxd_version}.tar.gz
-RUN curl -L https://github.com/libimobiledevice/libimobiledevice/archive/${libimobiledevice_version}.tar.gz --output libimobiledevice-${libimobiledevice_version}.tar.gz
 RUN curl -L https://github.com/libimobiledevice/usbmuxd/archive/${usbmuxd_version}.tar.gz --output usbmuxd-${usbmuxd_version}.tar.gz
 
 RUN tar -xvzf libusb-${libusb_version}.tar.gz
 RUN tar -xvzf libplist-${libplist_version}.tar.gz
-RUN tar -xvzf libusbmuxd-${libusbmuxd_version}.tar.gz
-RUN tar -xvzf libimobiledevice-${libimobiledevice_version}.tar.gz
 RUN tar -xvzf usbmuxd-${usbmuxd_version}.tar.gz
 
 WORKDIR /src/libusb-${libusb_version}
@@ -54,21 +46,9 @@ RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$host
 && make \
 && make install
 
-WORKDIR /src/libusbmuxd-${libusbmuxd_version}
-
-RUN ./autogen.sh --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
-&& make \
-&& make install
-
-WORKDIR /src/libimobiledevice-${libimobiledevice_version}
-
-RUN ./autogen.sh --without-cython --enable-static=no --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
-&& make \
-&& make install
-
 WORKDIR /src/usbmuxd-${usbmuxd_version}
 
-RUN ./autogen.sh --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
+RUN ./autogen.sh --without-preflight --build=$build --host=$host --prefix=/usr --libdir=/usr/lib/$host \
 && make \
 && make install
 
@@ -98,11 +78,6 @@ LABEL org.opencontainers.image.ref.name=$GIT_REF
 
 COPY --from=build /usr/lib/$host/libusb-1.0.so.0 /usr/lib/$host/
 COPY --from=build /usr/lib/$host/libplist-2.0.so.3 /usr/lib/$host/
-COPY --from=build /usr/lib/$host/libusbmuxd-2.0.so.6 /usr/lib/$host/
-COPY --from=build /usr/lib/$host/libimobiledevice-1.0.so.6 /usr/lib/$host/
-COPY --from=build /usr/bin/idevice_id /usr/bin/
-COPY --from=build /usr/bin/idevicepair /usr/bin/
-COPY --from=build /usr/bin/ideviceinfo /usr/bin/
 
 COPY --from=build /usr/sbin/usbmuxd /usr/sbin/usbmuxd
 
@@ -110,7 +85,7 @@ ENV USBMUXD_SOCKET_ADDRESS=127.0.0.1:27015
 
 {{- if (ds "config").install_packages }}
 RUN apt-get update \
-&& apt-get install -y libudev1 libssl1.1 \
+&& apt-get install -y libudev1 \
 && rm -rf /var/lib/apt/lists/*
 {{- end }}
 

--- a/src/usbmuxd/Makefile
+++ b/src/usbmuxd/Makefile
@@ -17,7 +17,7 @@ push: all
 	docker push $(registry)/$(image):latest-udev-amd64
 
 .version: .amd64.docker-id
-	docker run --rm -i $(shell cat .amd64.docker-id) /usr/bin/usbmuxd --version | awk '{ print $$2 }' | tee .version
+	docker run --rm -i $(shell cat .amd64.docker-id) /usr/bin/usbmuxd --version | awk "{ print $$2 }" | tee .version
 
 Dockerfile.default: Dockerfile.template default.yaml
 	gomplate -d config=./default.yaml -f Dockerfile.template -o Dockerfile.default


### PR DESCRIPTION
The usbmuxd sidecar will take care of creating the pairing
records for iOS devices (and store them in the Kubernetes cluster).

As a result, we can skip the dependency on libimobiledevice
and reduce the overall container size.