### PR TITLE
LockdownClient: Add StartSession/StopSession support

### DIFF
--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="LockdownClientTests.Session.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Lockdown
+{
+    /// <content>
+    /// Tests the Session-related methods of the <see cref="LockdownClient"/> class.
+    /// </content>
+    public partial class LockdownClientTests
+    {
+        /// <summary>
+        /// <see cref="LockdownClient.StartSessionAsync(PairingRecord, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task StartSessionAsync_ValidatesArguments_Async()
+        {
+            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.StartSessionAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="LockdownClient.StartSessionAsync(PairingRecord, CancellationToken)"/> works.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task StartSessionAsync_Works_Async()
+        {
+            var protocol = new Mock<LockdownProtocol>();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<LockdownMessage>(), default))
+                .Callback<LockdownMessage, CancellationToken>(
+                (message, ct) =>
+                {
+                    var startSessionRequest = Assert.IsType<StartSessionRequest>(message);
+
+                    Assert.Equal("buid", startSessionRequest.SystemBUID);
+                    Assert.Equal("id", startSessionRequest.HostID);
+                })
+                .Returns(Task.CompletedTask);
+
+            var dict = new NSDictionary();
+            dict.Add("SessionID", "123");
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(dict);
+
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            {
+                var response = await client.StartSessionAsync(
+                    new PairingRecord()
+                    {
+                        SystemBUID = "buid",
+                        HostId = "id",
+                    },
+                    default).ConfigureAwait(false);
+
+                Assert.Equal("123", response.SessionID);
+                Assert.False(response.EnableSessionSSL);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="LockdownClient.StartSessionAsync(PairingRecord, CancellationToken)"/> throws an error when
+        /// the device returns an error.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task StartSessionAsync_ThrowsOnError_Async()
+        {
+            var protocol = new Mock<LockdownProtocol>();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<LockdownMessage>(), default))
+                .Callback<LockdownMessage, CancellationToken>(
+                (message, ct) =>
+                {
+                    var startSessionRequest = Assert.IsType<StartSessionRequest>(message);
+
+                    Assert.Equal("buid", startSessionRequest.SystemBUID);
+                    Assert.Equal("id", startSessionRequest.HostID);
+                })
+                .Returns(Task.CompletedTask);
+
+            var response = new NSDictionary();
+            response.Add("Error", "error");
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            {
+                await Assert.ThrowsAsync<LockdownException>(
+                    () => client.StartSessionAsync(
+                    new PairingRecord()
+                    {
+                        SystemBUID = "buid",
+                        HostId = "id",
+                    },
+                    default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="LockdownClient.StopSessionAsync(string, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task StopSessionAsync_ValidatesArguments_Async()
+        {
+            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.StopSessionAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="LockdownClient.StopSessionAsync(string, CancellationToken)"/> throws when the device
+        /// returns an error.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task StopSessionAsync_ThrowsOnError_Async()
+        {
+            var protocol = new Mock<LockdownProtocol>();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<LockdownMessage>(), default))
+                .Callback<LockdownMessage, CancellationToken>(
+                (message, ct) =>
+                {
+                    var stopSessionRequest = Assert.IsType<StopSessionRequest>(message);
+
+                    Assert.Equal("1234", stopSessionRequest.SessionID);
+                })
+                .Returns(Task.CompletedTask);
+
+            var response = new NSDictionary();
+            response.Add("Error", "error");
+            protocol
+                .Setup(p => p.ReadMessageAsync(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            {
+                await Assert.ThrowsAsync<LockdownException>(
+                    () => client.StopSessionAsync("1234", default)).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Lockdown/StartSessionRequestTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/StartSessionRequestTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="StartSessionRequestTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Lockdown
+{
+    /// <summary>
+    /// Tests the <see cref="StartSessionRequest" /> class.
+    /// </summary>
+    public class StartSessionRequestTests
+    {
+        /// <summary>
+        /// <see cref="StartSessionRequest.ToDictionary"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToDictionary_Works()
+        {
+            var dict = new StartSessionRequest()
+            {
+                HostID = "hostId",
+                SystemBUID = "systemBuid",
+            }.ToDictionary();
+
+            Assert.Collection(
+                dict,
+                (k) =>
+                {
+                    Assert.Equal("Label", k.Key);
+                    Assert.Equal("Kaponata.iOS", k.Value.ToObject());
+                },
+                (k) =>
+                {
+                    Assert.Equal("ProtocolVersion", k.Key);
+                    Assert.Equal("2", k.Value.ToObject());
+                },
+                (k) =>
+                {
+                    Assert.Equal("HostID", k.Key);
+                    Assert.Equal("hostId", k.Value.ToObject());
+                },
+                (k) =>
+                {
+                    Assert.Equal("SystemBUID", k.Key);
+                    Assert.Equal("systemBuid", k.Value.ToObject());
+                });
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Lockdown/StartSessionResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/StartSessionResponseTests.cs
@@ -1,0 +1,79 @@
+﻿// <copyright file="StartSessionResponseTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Lockdown;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Lockdown
+{
+    /// <summary>
+    /// Tests the <see cref="StartSessionResponse"/> class.
+    /// </summary>
+    public class StartSessionResponseTests
+    {
+        /// <summary>
+        /// <see cref="StartSessionResponse.Read(NSDictionary)"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Read_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => StartSessionResponse.Read(null));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="StartSessionResponse.Read(NSDictionary)"/> method.
+        /// </summary>
+        [Fact]
+        public void Read_Works()
+        {
+            var dict = new NSDictionary();
+            dict.Add("Request", "StartSession");
+            dict.Add("SessionID", "abc");
+
+            var response = StartSessionResponse.Read(dict);
+
+            Assert.Equal("StartSession", response.Request);
+            Assert.False(response.EnableSessionSSL);
+            Assert.Equal("abc", response.SessionID);
+            Assert.Null(response.Error);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="StartSessionResponse.Read(NSDictionary)"/> method.
+        /// </summary>
+        [Fact]
+        public void Read_WithSSL_Works()
+        {
+            var dict = new NSDictionary();
+            dict.Add("Request", "StartSession");
+            dict.Add("EnableSessionSSL", true);
+            dict.Add("SessionID", "abc");
+
+            var response = StartSessionResponse.Read(dict);
+
+            Assert.Equal("StartSession", response.Request);
+            Assert.True(response.EnableSessionSSL);
+            Assert.Equal("abc", response.SessionID);
+            Assert.Null(response.Error);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="StartSessionResponse.Read(NSDictionary)"/> method.
+        /// </summary>
+        [Fact]
+        public void Read_WithError_Works()
+        {
+            var dict = new NSDictionary();
+            dict.Add("Request", "StartSession");
+            dict.Add("Error", "abc");
+
+            var response = StartSessionResponse.Read(dict);
+
+            Assert.Equal("StartSession", response.Request);
+            Assert.Equal("abc", response.Error);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Lockdown/StopSessionRequestTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/StopSessionRequestTests.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="StopSessionRequestTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Lockdown
+{
+    /// <summary>
+    /// Tests the <see cref="StopSessionRequest" /> class.
+    /// </summary>
+    public class StopSessionRequestTests
+    {
+        /// <summary>
+        /// <see cref="StartSessionRequest.ToDictionary"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToDictionary_Works()
+        {
+            var dict = new StopSessionRequest()
+            {
+                SessionID = "abc",
+            }.ToDictionary();
+
+            Assert.Collection(
+                dict,
+                (k) =>
+                {
+                    Assert.Equal("Label", k.Key);
+                    Assert.Equal("Kaponata.iOS", k.Value.ToObject());
+                },
+                (k) =>
+                {
+                    Assert.Equal("ProtocolVersion", k.Key);
+                    Assert.Equal("2", k.Value.ToObject());
+                },
+                (k) =>
+                {
+                    Assert.Equal("SessionID", k.Key);
+                    Assert.Equal("abc", k.Value.ToObject());
+                });
+        }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/StartSessionRequest.cs
+++ b/src/Kaponata.iOS/Lockdown/StartSessionRequest.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="StartSessionRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <summary>
+    /// Represents a message which requests the lockdown service on the device to start a new session.
+    /// </summary>
+    public class StartSessionRequest : LockdownMessage
+    {
+        /// <summary>
+        /// Gets or sets the Host ID of this computer, as stored in <see cref="PairingRecord.HostId"/>.
+        /// </summary>
+        public string HostID
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the System BUID of this computer, as stored in <see cref="PairingRecord.SystemBUID"/>.
+        /// </summary>
+        public string SystemBUID
+        {
+            get;
+            set;
+        }
+
+        /// <inheritdoc/>
+        public override NSDictionary ToDictionary()
+        {
+            var dict = base.ToDictionary();
+            dict.Add(nameof(this.HostID), this.HostID);
+            dict.Add(nameof(this.SystemBUID), this.SystemBUID);
+            return dict;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/StartSessionResponse.cs
+++ b/src/Kaponata.iOS/Lockdown/StartSessionResponse.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="StartSessionResponse.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System;
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <summary>
+    /// Represents the resopnse to a <see cref="StartSessionRequest"/> request.
+    /// </summary>
+    public class StartSessionResponse
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether SSL should be enabled.
+        /// </summary>
+        public bool EnableSessionSSL
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the original request.
+        /// </summary>
+        public string Request
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a ID which uniquely identifies this session.
+        /// </summary>
+        public string SessionID
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets an error message which describes why the session could not be started.
+        /// </summary>
+        public string Error
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Reads a <see cref="StartSessionResponse"/> from a <see cref="NSDictionary"/>.
+        /// </summary>
+        /// <param name="dict">
+        /// The dictionary from which to read the data.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StartSessionResponse"/> object which represents the deserialized data.
+        /// </returns>
+        public static StartSessionResponse Read(NSDictionary dict)
+        {
+            if (dict == null)
+            {
+                throw new ArgumentNullException(nameof(dict));
+            }
+
+            return new StartSessionResponse()
+            {
+                EnableSessionSSL = dict.GetNullableBoolean(nameof(EnableSessionSSL)) ?? false,
+                Error = dict.GetString(nameof(Error)),
+                Request = dict.GetString(nameof(Request)),
+                SessionID = dict.GetString(nameof(SessionID)),
+            };
+        }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/StopSessionRequest.cs
+++ b/src/Kaponata.iOS/Lockdown/StopSessionRequest.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="StopSessionRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <summary>
+    /// Represents a request to stop a lockdown session.
+    /// </summary>
+    public class StopSessionRequest : LockdownMessage
+    {
+        /// <summary>
+        /// Gets or sets the ID of the session to stop.
+        /// </summary>
+        public string SessionID
+        {
+            get;
+            set;
+        }
+
+        /// <inheritdoc/>
+        public override NSDictionary ToDictionary()
+        {
+            var dict = base.ToDictionary();
+            dict.Add(nameof(this.SessionID), this.SessionID);
+            return dict;
+        }
+    }
+}


### PR DESCRIPTION
At the moment without support for enabling session SSL.