### PR TITLE
Add MuxerClient.DeletePairingRecordAsync

### DIFF
--- a/src/Kaponata.iOS.Tests/Muxer/DeletePairingRecordMessageTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/DeletePairingRecordMessageTests.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="DeletePairingRecordMessageTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="DeletePairingRecordMessage"/> class.
+    /// </summary>
+    public class DeletePairingRecordMessageTests
+    {
+        /// <summary>
+        /// <see cref="DeletePairingRecordMessage.ToPropertyList"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToPropertyList_Works()
+        {
+            var dict = new DeletePairingRecordMessage()
+            {
+                PairRecordID = "abc",
+            }.ToPropertyList();
+
+            Assert.Collection(
+                dict,
+                k =>
+                {
+                    Assert.Equal("BundleID", k.Key);
+                    Assert.Equal("Kaponata.iOS", k.Value.ToObject());
+                },
+                k =>
+                {
+                    Assert.Equal("ClientVersionString", k.Key);
+                    Assert.Equal(ThisAssembly.AssemblyInformationalVersion, k.Value.ToObject());
+                },
+                k =>
+                {
+                    Assert.Equal("MessageType", k.Key);
+                    Assert.Equal("DeletePairRecord", k.Value.ToObject());
+                },
+                k =>
+                {
+                    Assert.Equal("ProgName", k.Key);
+                    Assert.Equal("Kaponata.iOS", k.Value.ToObject());
+                },
+                k =>
+                {
+                    Assert.Equal("PairRecordID", k.Key);
+                    Assert.Equal("abc", k.Value.ToObject());
+                });
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/DeletePairingRecordMessage.cs
+++ b/src/Kaponata.iOS/Muxer/DeletePairingRecordMessage.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="DeletePairingRecordMessage.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// Represents a request to delete a pairing record.
+    /// </summary>
+    public class DeletePairingRecordMessage : RequestMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeletePairingRecordMessage"/> class.
+        /// </summary>
+        public DeletePairingRecordMessage()
+        {
+            this.MessageType = MuxerMessageType.DeletePairRecord;
+        }
+
+        /// <summary>
+        /// Gets or sets the UDID of the device for which to delete the pairing record.
+        /// </summary>
+        public string PairRecordID { get; set; }
+
+        /// <inheritdoc/>
+        public override NSDictionary ToPropertyList()
+        {
+            var dict = base.ToPropertyList();
+            dict.Add(nameof(this.PairRecordID), this.PairRecordID);
+            return dict;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerClient.PairingRecord.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerClient.PairingRecord.cs
@@ -107,5 +107,41 @@ namespace Kaponata.iOS.Muxer
                 }
             }
         }
+
+        /// <summary>
+        /// Asynchronously deletes the pair record for a device.
+        /// </summary>
+        /// <param name="udid">
+        /// The UDID of the device for which to delete the pair record.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task DeletePairingRecordAsync(string udid, CancellationToken cancellationToken)
+        {
+            if (udid == null)
+            {
+                throw new ArgumentNullException(nameof(udid));
+            }
+
+            await using (var protocol = await this.TryConnectToMuxerAsync(cancellationToken).ConfigureAwait(false))
+            {
+                await protocol.WriteMessageAsync(
+                    new DeletePairingRecordMessage()
+                    {
+                        MessageType = MuxerMessageType.DeletePairRecord,
+                        PairRecordID = udid,
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                var response = (ResultMessage)await protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
+
+                if (response.Number != MuxerError.Success)
+                {
+                    throw new MuxerException($"An error occurred while saving the pairing record for device {udid}: {response.Number}.", response.Number);
+                }
+            }
+        }
     }
 }

--- a/src/Kaponata.iOS/Muxer/MuxerMessageType.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerMessageType.cs
@@ -68,5 +68,10 @@ namespace Kaponata.iOS.Muxer
         /// Saves the pair record for the device.
         /// </summary>
         SavePairRecord = 103,
+
+        /// <summary>
+        /// Deletes the pair record for the device.
+        /// </summary>
+        DeletePairRecord = 104,
     }
 }


### PR DESCRIPTION
Supports deleting pair records stored on the server.