### PR TITLE
Add the PairingRecordStore

### DIFF
--- a/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.PairingRecords.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.PairingRecords.cs
@@ -26,6 +26,7 @@ namespace Kaponata.iOS.Tests.Muxer
         public async Task ReadPairingRecordAsync_ValidatesArguments_Async()
         {
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             var muxer = muxerMock.Object;
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => muxer.ReadPairingRecordAsync(null, default));
@@ -75,6 +76,7 @@ namespace Kaponata.iOS.Tests.Muxer
         {
             var protocol = new Mock<MuxerProtocol>();
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             muxerMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
             var muxer = muxerMock.Object;
 
@@ -109,6 +111,7 @@ namespace Kaponata.iOS.Tests.Muxer
         {
             var protocol = new Mock<MuxerProtocol>();
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             muxerMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
             var muxer = muxerMock.Object;
             var pairingRecord = PairingRecord.Read(File.ReadAllBytes("Lockdown/0123456789abcdef0123456789abcdef01234567.plist"));
@@ -144,6 +147,7 @@ namespace Kaponata.iOS.Tests.Muxer
         public async Task SavePairingRecordAsync_ValidatesArguments_Async()
         {
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             var muxer = muxerMock.Object;
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => muxer.SavePairingRecordAsync(null, new PairingRecord(), default));
@@ -159,6 +163,7 @@ namespace Kaponata.iOS.Tests.Muxer
         {
             var protocol = new Mock<MuxerProtocol>();
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             muxerMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
             var muxer = muxerMock.Object;
             var pairingRecord = PairingRecord.Read(File.ReadAllBytes("Lockdown/0123456789abcdef0123456789abcdef01234567.plist"));
@@ -222,6 +227,7 @@ namespace Kaponata.iOS.Tests.Muxer
         public async Task DeleteRecordAsync_ValidatesArguments_Async()
         {
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             var muxer = muxerMock.Object;
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => muxer.DeletePairingRecordAsync(null, default));
@@ -236,6 +242,7 @@ namespace Kaponata.iOS.Tests.Muxer
         {
             var protocol = new Mock<MuxerProtocol>();
             var muxerMock = new Mock<MuxerClient>();
+            muxerMock.CallBase = true;
             muxerMock.Setup(c => c.TryConnectToMuxerAsync(default)).ReturnsAsync(protocol.Object);
             var muxer = muxerMock.Object;
 

--- a/src/Kaponata.iOS.Tests/Muxer/MuxerPairingRecordStoreTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerPairingRecordStoreTests.cs
@@ -1,0 +1,88 @@
+﻿// <copyright file="MuxerPairingRecordStoreTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="MuxerPairingRecordStore"/> class.
+    /// </summary>
+    public class MuxerPairingRecordStoreTests
+    {
+        /// <summary>
+        /// The <see cref="MuxerPairingRecordStore"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MuxerPairingRecordStore(null, NullLogger<MuxerPairingRecordStore>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new MuxerPairingRecordStore(Mock.Of<MuxerClient>(), null));
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerPairingRecordStore.DeleteAsync(string, CancellationToken)"/> forwards request
+        /// to the muxer.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteAsync_Works_Async()
+        {
+            var muxerClient = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxerClient.Setup(c => c.DeletePairingRecordAsync("abc", default)).Returns(Task.CompletedTask);
+
+            var store = new MuxerPairingRecordStore(muxerClient.Object, NullLogger<MuxerPairingRecordStore>.Instance);
+
+            await store.DeleteAsync("abc", default).ConfigureAwait(false);
+
+            muxerClient.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerPairingRecordStore.ReadAsync(string, CancellationToken)"/> forwards request
+        /// to the muxer.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReadAsync_Works_Async()
+        {
+            var record = new PairingRecord();
+            var muxerClient = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxerClient.Setup(c => c.ReadPairingRecordAsync("abc", default)).Returns(Task.FromResult(record));
+
+            var store = new MuxerPairingRecordStore(muxerClient.Object, NullLogger<MuxerPairingRecordStore>.Instance);
+
+            var result = await store.ReadAsync("abc", default).ConfigureAwait(false);
+            Assert.Same(record, result);
+
+            muxerClient.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="MuxerPairingRecordStore.WriteAsync(string, PairingRecord, CancellationToken)"/> forwards request
+        /// to the muxer.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WriteAsync_Works_Async()
+        {
+            var record = new PairingRecord();
+            var muxerClient = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxerClient.Setup(c => c.SavePairingRecordAsync("abc", record, default)).Returns(Task.FromResult(record));
+
+            var store = new MuxerPairingRecordStore(muxerClient.Object, NullLogger<MuxerPairingRecordStore>.Instance);
+
+            await store.WriteAsync("abc", record, default).ConfigureAwait(false);
+
+            muxerClient.Verify();
+        }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/PairingRecordStore.cs
+++ b/src/Kaponata.iOS/Lockdown/PairingRecordStore.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="PairingRecordStore.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <summary>
+    /// A generic store for pairing records.
+    /// </summary>
+    public abstract class PairingRecordStore
+    {
+        /// <summary>
+        /// Asynchronously retrieves the pairing record for a device.
+        /// </summary>
+        /// <param name="udid">
+        /// The UDID of the device for which to retrieve the pairing record.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// If found, the requested <see cref="PairingRecord"/>; otherwise, <see langword="null"/>.
+        /// </returns>
+        public abstract Task<PairingRecord> ReadAsync(string udid, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously saves the pairing record for a device.
+        /// </summary>
+        /// <param name="udid">
+        /// The UDID of the device for which to store the pairing record.
+        /// </param>
+        /// <param name="pairingRecord">
+        /// The pairing record to store.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public abstract Task WriteAsync(string udid, PairingRecord pairingRecord, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously deletes a pairing record for a device.
+        /// </summary>
+        /// <param name="udid">
+        /// The UDID of the device for which to delete the pairing record.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to delete the pairing record.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public abstract Task DeleteAsync(string udid, CancellationToken cancellationToken);
+    }
+}

--- a/src/Kaponata.iOS/Muxer/MuxerClient.PairingRecord.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerClient.PairingRecord.cs
@@ -27,7 +27,7 @@ namespace Kaponata.iOS.Muxer
         /// A <see cref="Task"/> which represents the asynchronous operation, and which returns the pairing
         /// record.
         /// </returns>
-        public async Task<PairingRecord> ReadPairingRecordAsync(string udid, CancellationToken cancellationToken)
+        public async virtual Task<PairingRecord> ReadPairingRecordAsync(string udid, CancellationToken cancellationToken)
         {
             if (udid == null)
             {
@@ -75,7 +75,7 @@ namespace Kaponata.iOS.Muxer
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task SavePairingRecordAsync(string udid, PairingRecord pairingRecord, CancellationToken cancellationToken)
+        public async virtual Task SavePairingRecordAsync(string udid, PairingRecord pairingRecord, CancellationToken cancellationToken)
         {
             if (udid == null)
             {
@@ -118,7 +118,7 @@ namespace Kaponata.iOS.Muxer
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task DeletePairingRecordAsync(string udid, CancellationToken cancellationToken)
+        public async virtual Task DeletePairingRecordAsync(string udid, CancellationToken cancellationToken)
         {
             if (udid == null)
             {

--- a/src/Kaponata.iOS/Muxer/MuxerPairingRecordStore.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerPairingRecordStore.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="MuxerPairingRecordStore.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.Muxer
+{
+    /// <summary>
+    /// A <see cref="PairingRecordStore"/> which reads and writes pairing records for the muxer.
+    /// </summary>
+    public class MuxerPairingRecordStore : PairingRecordStore
+    {
+        private readonly MuxerClient muxer;
+        private readonly ILogger<MuxerPairingRecordStore> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MuxerPairingRecordStore"/> class.
+        /// </summary>
+        /// <param name="muxer">
+        /// A <see cref="MuxerClient"/> which represents the connectivity to the muxer.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which can be used to log messages.
+        /// </param>
+        public MuxerPairingRecordStore(MuxerClient muxer, ILogger<MuxerPairingRecordStore> logger)
+        {
+            this.muxer = muxer ?? throw new ArgumentNullException(nameof(muxer));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public override Task DeleteAsync(string udid, CancellationToken cancellationToken)
+        {
+            return this.muxer.DeletePairingRecordAsync(udid, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task<PairingRecord> ReadAsync(string udid, CancellationToken cancellationToken)
+        {
+            return this.muxer.ReadPairingRecordAsync(udid, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(string udid, PairingRecord pairingRecord, CancellationToken cancellationToken)
+        {
+            return this.muxer.SavePairingRecordAsync(udid, pairingRecord, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
This class can serve as a base class for classes which provide access
to a repository in which pairing records can be stored, such as
an usbmuxd instance (part of this PR) or a Kubernetes cluster
(part of a follow-up PR).