### PR TITLE
Add the KubernetesPairingRecordsStore

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/PairingRecords/KubernetesPairingRecordStoreIntegrationTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/PairingRecords/KubernetesPairingRecordStoreIntegrationTests.cs
@@ -1,0 +1,90 @@
+﻿// <copyright file="KubernetesPairingRecordStoreIntegrationTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+using k8s;
+using Kaponata.iOS.Lockdown;
+using Kaponata.Kubernetes.PairingRecords;
+using Kaponata.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Kubernetes.Tests.PairingRecords
+{
+    /// <summary>
+    /// Integration tests for the <see cref="KubernetesPairingRecordStore"/> class.
+    /// </summary>
+    public class KubernetesPairingRecordStoreIntegrationTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesPairingRecordStoreIntegrationTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// The test output helper which will be used to log to xunit.
+        /// </param>
+        public KubernetesPairingRecordStoreIntegrationTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerFactory = LogFactory.Create(output);
+        }
+
+        /// <summary>
+        /// Tests the lifecycle of a pairing record, by adding, reading and deleting the record.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task PairingRecord_Lifecycle_Async()
+        {
+            var key = Convert.FromBase64String(
+                "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JR0pBb0dCQUorNXVIQjJycllw" +
+                "VEt4SWNGUnJxR1ZqTHRNQ2wyWHhmTVhJeEhYTURrM01jV2hxK2RtWkcvWW0KeDJuTGZq" +
+                "WWJPeUduQ1BxQktxcUU5Q2tyQy9DUi9mTlgwNjJqMU1pUHJYY2RnQ0tiNzB2bmVlMFNF" +
+                "T2FmNVhEQworZWFZeGdjWTYvbjBXODNrSklXMGF0czhMWmUwTW9XNXpXSTh6cnM4eDIw" +
+                "UFFJK1RGU1p4QWdNQkFBRT0KLS0tLS1FTkQgUlNBIFBVQkxJQyBLRVktLS0tLQo=");
+
+            var udid = "pairingrecord-lifecycle";
+            var buid = Guid.NewGuid().ToString();
+
+            var record = PairingRecordGenerator.Generate(key, buid);
+
+            using (var client = this.CreateKubernetesClient())
+            {
+                var store = new KubernetesPairingRecordStore(client, this.loggerFactory.CreateLogger<KubernetesPairingRecordStore>());
+
+                // The record should not exist.
+                Assert.Null(await store.ReadAsync(udid, default).ConfigureAwait(false));
+
+                // Write the record; it can be retrieved afterwards
+                await store.WriteAsync(udid, record, default).ConfigureAwait(false);
+                var record2 = await store.ReadAsync(udid, default).ConfigureAwait(false);
+
+                Assert.NotNull(record2);
+                Assert.Equal(record.ToByteArray(), record2.ToByteArray());
+
+                // Delete the record; it can no longer be retrieved afterwardss
+                await store.DeleteAsync(udid, default).ConfigureAwait(false);
+                Assert.Null(await store.ReadAsync(udid, default).ConfigureAwait(false));
+            }
+        }
+
+        private KubernetesClient CreateKubernetesClient()
+        {
+            return new KubernetesClient(
+                new KubernetesProtocol(
+                    KubernetesClientConfiguration.BuildDefaultConfig(),
+                    this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                    this.loggerFactory),
+                KubernetesOptions.Default,
+                this.loggerFactory.CreateLogger<KubernetesClient>(),
+                this.loggerFactory);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/PairingRecords/KubernetesPairingRecordStoreTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/PairingRecords/KubernetesPairingRecordStoreTests.cs
@@ -1,0 +1,171 @@
+﻿// <copyright file="KubernetesPairingRecordStoreTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.iOS.Lockdown;
+using Kaponata.Kubernetes.PairingRecords;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.PairingRecords
+{
+    /// <summary>
+    /// Tests the <see cref="KubernetesPairingRecordStore"/> class.
+    /// </summary>
+    public class KubernetesPairingRecordStoreTests
+    {
+        /// <summary>
+        /// The <see cref="KubernetesPairingRecordStore"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new KubernetesPairingRecordStore(null, NullLogger<KubernetesPairingRecordStore>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new KubernetesPairingRecordStore(Mock.Of<KubernetesClient>(), null));
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesPairingRecordStore.DeleteAsync(string, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteAsync_ValidatesArguments_Async()
+        {
+            var store = new KubernetesPairingRecordStore(Mock.Of<KubernetesClient>(), NullLogger<KubernetesPairingRecordStore>.Instance);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => store.DeleteAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesPairingRecordStore.ReadAsync(string, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReadAsync_ValidatesArguments_Async()
+        {
+            var store = new KubernetesPairingRecordStore(Mock.Of<KubernetesClient>(), NullLogger<KubernetesPairingRecordStore>.Instance);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => store.ReadAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesPairingRecordStore.WriteAsync(string, PairingRecord, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WriteAsync_ValidatesArguments_Async()
+        {
+            var store = new KubernetesPairingRecordStore(Mock.Of<KubernetesClient>(), NullLogger<KubernetesPairingRecordStore>.Instance);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => store.WriteAsync(null, new PairingRecord(), default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => store.WriteAsync("abc", null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesPairingRecordStore.DeleteAsync(string, CancellationToken)"/> works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteAsync_Works_Async()
+        {
+            var client = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            client.Setup(c => c.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            secretClient
+                .Setup(c => c.TryDeleteAsync("abc", TimeSpan.FromMinutes(1), default))
+                .Returns(Task.FromResult((V1Secret)null))
+                .Verifiable();
+
+            var store = new KubernetesPairingRecordStore(client.Object, NullLogger<KubernetesPairingRecordStore>.Instance);
+
+            await store.DeleteAsync("abc", default);
+
+            secretClient.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesPairingRecordStore.ReadAsync(string, CancellationToken)"/> works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ReadAsync_Works_Async()
+        {
+            var key = Convert.FromBase64String(
+                "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JR0pBb0dCQUorNXVIQjJycllw" +
+                "VEt4SWNGUnJxR1ZqTHRNQ2wyWHhmTVhJeEhYTURrM01jV2hxK2RtWkcvWW0KeDJuTGZq" +
+                "WWJPeUduQ1BxQktxcUU5Q2tyQy9DUi9mTlgwNjJqMU1pUHJYY2RnQ0tiNzB2bmVlMFNF" +
+                "T2FmNVhEQworZWFZeGdjWTYvbjBXODNrSklXMGF0czhMWmUwTW9XNXpXSTh6cnM4eDIw" +
+                "UFFJK1RGU1p4QWdNQkFBRT0KLS0tLS1FTkQgUlNBIFBVQkxJQyBLRVktLS0tLQo=");
+
+            var pairingRecord = PairingRecordGenerator.Generate(key, "abc");
+            var secret = pairingRecord.AsSecret();
+
+            var client = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            client.Setup(c => c.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            secretClient
+                .Setup(c => c.TryReadAsync("abc", default))
+                .Returns(Task.FromResult(secret))
+                .Verifiable();
+
+            var store = new KubernetesPairingRecordStore(client.Object, NullLogger<KubernetesPairingRecordStore>.Instance);
+
+            var value = await store.ReadAsync("abc", default);
+
+            // Basic assertions
+            Assert.NotNull(value.DeviceCertificate);
+            Assert.NotNull(value.HostCertificate);
+            Assert.NotNull(value.RootCertificate);
+
+            secretClient.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="KubernetesPairingRecordStore.WriteAsync(string, PairingRecord, CancellationToken)"/> works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WriteAsync_Works_Async()
+        {
+            var key = Convert.FromBase64String(
+                "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JR0pBb0dCQUorNXVIQjJycllw" +
+                "VEt4SWNGUnJxR1ZqTHRNQ2wyWHhmTVhJeEhYTURrM01jV2hxK2RtWkcvWW0KeDJuTGZq" +
+                "WWJPeUduQ1BxQktxcUU5Q2tyQy9DUi9mTlgwNjJqMU1pUHJYY2RnQ0tiNzB2bmVlMFNF" +
+                "T2FmNVhEQworZWFZeGdjWTYvbjBXODNrSklXMGF0czhMWmUwTW9XNXpXSTh6cnM4eDIw" +
+                "UFFJK1RGU1p4QWdNQkFBRT0KLS0tLS1FTkQgUlNBIFBVQkxJQyBLRVktLS0tLQo=");
+
+            var pairingRecord = PairingRecordGenerator.Generate(key, "abc");
+            var secret = pairingRecord.AsSecret();
+
+            var client = new Mock<KubernetesClient>(MockBehavior.Strict);
+            var secretClient = new Mock<NamespacedKubernetesClient<V1Secret>>(MockBehavior.Strict);
+            client.Setup(c => c.GetClient<V1Secret>()).Returns(secretClient.Object);
+
+            secretClient
+                .Setup(c => c.CreateAsync(It.IsAny<V1Secret>(), default))
+                .Callback<V1Secret, CancellationToken>(
+                (value, ct) =>
+                {
+                    Assert.NotNull(value);
+                    Assert.Equal("abc", value.Metadata.Name);
+                    Assert.NotNull(value.Data["tls.crt"]);
+                    Assert.NotNull(value.Data["tls.key"]);
+                })
+                .Returns(Task.FromResult(secret))
+                .Verifiable();
+
+            var store = new KubernetesPairingRecordStore(client.Object, NullLogger<KubernetesPairingRecordStore>.Instance);
+
+            await store.WriteAsync("abc", pairingRecord, default);
+
+            secretClient.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/PairingRecords/V1SecretExtensionsTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/PairingRecords/V1SecretExtensionsTests.cs
@@ -1,0 +1,119 @@
+﻿// <copyright file="V1SecretExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.iOS.Lockdown;
+using Kaponata.Kubernetes.PairingRecords;
+using System;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.PairingRecords
+{
+    /// <summary>
+    /// Tests the <see cref="V1SecretExtensions"/> class.
+    /// </summary>
+    public class V1SecretExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="V1SecretExtensions.AsPairingRecord(V1Secret)"/> returns <see langword="null"/>
+        /// when passed <see langword="null"/> values.
+        /// </summary>
+        [Fact]
+        public void AsPairingRecord_Null_ReturnsNull()
+        {
+            Assert.Null(V1SecretExtensions.AsPairingRecord(null));
+        }
+
+        /// <summary>
+        /// <see cref="V1SecretExtensions.AsSecret(PairingRecord)"/> returns <see langword="null"/>
+        /// when passed <see langword="null"/> values.
+        /// </summary>
+        [Fact]
+        public void AsSecret_Null_ReturnsNull()
+        {
+            Assert.Null(V1SecretExtensions.AsSecret(null));
+        }
+
+        /// <summary>
+        /// <see cref="V1SecretExtensions.AsPairingRecord(V1Secret?)"/> generates a secret which round-trips
+        /// successfully.
+        /// </summary>
+        [Fact]
+        public void AsSecret_Minimal_Roundtrip()
+        {
+            var systemBuid = Guid.NewGuid().ToString();
+            var key = Convert.FromBase64String(
+                "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JR0pBb0dCQUorNXVIQjJycllw" +
+                "VEt4SWNGUnJxR1ZqTHRNQ2wyWHhmTVhJeEhYTURrM01jV2hxK2RtWkcvWW0KeDJuTGZq" +
+                "WWJPeUduQ1BxQktxcUU5Q2tyQy9DUi9mTlgwNjJqMU1pUHJYY2RnQ0tiNzB2bmVlMFNF" +
+                "T2FmNVhEQworZWFZeGdjWTYvbjBXODNrSklXMGF0czhMWmUwTW9XNXpXSTh6cnM4eDIw" +
+                "UFFJK1RGU1p4QWdNQkFBRT0KLS0tLS1FTkQgUlNBIFBVQkxJQyBLRVktLS0tLQo=");
+
+            var pairingRecord = PairingRecordGenerator.Generate(key, systemBuid);
+            var secret = V1SecretExtensions.AsSecret(pairingRecord);
+
+            Assert.NotNull(secret.Data["ca.crt"]);
+            Assert.NotNull(secret.Data["ca.key"]);
+            Assert.NotNull(secret.Data["tls.crt"]);
+            Assert.NotNull(secret.Data["tls.key"]);
+            Assert.NotNull(secret.Data["device.crt"]);
+
+            Assert.NotNull(secret.Data["hostId"]);
+            Assert.NotNull(secret.Data["systemBuid"]);
+
+            var roundtripRecord = V1SecretExtensions.AsPairingRecord(secret);
+            Assert.Equal(pairingRecord.DeviceCertificate, roundtripRecord.DeviceCertificate);
+            Assert.Equal(pairingRecord.RootCertificate, roundtripRecord.RootCertificate);
+            Assert.Equal(pairingRecord.RootPrivateKey.ExportPkcs8PrivateKey(), roundtripRecord.RootPrivateKey.ExportPkcs8PrivateKey());
+            Assert.Equal(pairingRecord.HostCertificate, roundtripRecord.HostCertificate);
+            Assert.Equal(pairingRecord.HostPrivateKey.ExportPkcs8PrivateKey(), roundtripRecord.HostPrivateKey.ExportPkcs8PrivateKey());
+            Assert.Equal(pairingRecord.HostId, roundtripRecord.HostId);
+            Assert.Equal(pairingRecord.SystemBUID, roundtripRecord.SystemBUID);
+            Assert.Null(roundtripRecord.EscrowBag);
+            Assert.Null(roundtripRecord.WiFiMacAddress);
+        }
+
+        /// <summary>
+        /// <see cref="V1SecretExtensions.AsPairingRecord(V1Secret?)"/> generates a secret which round-trips
+        /// successfully.
+        /// </summary>
+        [Fact]
+        public void AsSecret_Complete_Roundtrip()
+        {
+            var systemBuid = Guid.NewGuid().ToString();
+            var key = Convert.FromBase64String(
+                "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JR0pBb0dCQUorNXVIQjJycllw" +
+                "VEt4SWNGUnJxR1ZqTHRNQ2wyWHhmTVhJeEhYTURrM01jV2hxK2RtWkcvWW0KeDJuTGZq" +
+                "WWJPeUduQ1BxQktxcUU5Q2tyQy9DUi9mTlgwNjJqMU1pUHJYY2RnQ0tiNzB2bmVlMFNF" +
+                "T2FmNVhEQworZWFZeGdjWTYvbjBXODNrSklXMGF0czhMWmUwTW9XNXpXSTh6cnM4eDIw" +
+                "UFFJK1RGU1p4QWdNQkFBRT0KLS0tLS1FTkQgUlNBIFBVQkxJQyBLRVktLS0tLQo=");
+
+            var pairingRecord = PairingRecordGenerator.Generate(key, systemBuid);
+            pairingRecord.EscrowBag = new byte[] { 1, 2, 3, 4 };
+            pairingRecord.WiFiMacAddress = "aa:bb:cc:dd";
+
+            var secret = V1SecretExtensions.AsSecret(pairingRecord);
+
+            Assert.NotNull(secret.Data["ca.crt"]);
+            Assert.NotNull(secret.Data["ca.key"]);
+            Assert.NotNull(secret.Data["tls.crt"]);
+            Assert.NotNull(secret.Data["tls.key"]);
+            Assert.NotNull(secret.Data["device.crt"]);
+
+            Assert.NotNull(secret.Data["hostId"]);
+            Assert.NotNull(secret.Data["systemBuid"]);
+
+            var roundtripRecord = V1SecretExtensions.AsPairingRecord(secret);
+            Assert.Equal(pairingRecord.DeviceCertificate, roundtripRecord.DeviceCertificate);
+            Assert.Equal(pairingRecord.RootCertificate, roundtripRecord.RootCertificate);
+            Assert.Equal(pairingRecord.RootPrivateKey.ExportPkcs8PrivateKey(), roundtripRecord.RootPrivateKey.ExportPkcs8PrivateKey());
+            Assert.Equal(pairingRecord.HostCertificate, roundtripRecord.HostCertificate);
+            Assert.Equal(pairingRecord.HostPrivateKey.ExportPkcs8PrivateKey(), roundtripRecord.HostPrivateKey.ExportPkcs8PrivateKey());
+            Assert.Equal(pairingRecord.HostId, roundtripRecord.HostId);
+            Assert.Equal(pairingRecord.SystemBUID, roundtripRecord.SystemBUID);
+            Assert.Equal(pairingRecord.EscrowBag, roundtripRecord.EscrowBag);
+            Assert.Equal(pairingRecord.WiFiMacAddress, roundtripRecord.WiFiMacAddress);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/PairingRecords/KubernetesPairingRecordStore.cs
+++ b/src/Kaponata.Kubernetes/PairingRecords/KubernetesPairingRecordStore.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="KubernetesPairingRecordStore.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.iOS.Lockdown;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Kubernetes.PairingRecords
+{
+    /// <summary>
+    /// Stores <see cref="PairingRecord"/> in a Kubernetes cluster as <see cref="V1Secret"/> objects.
+    /// </summary>
+    public class KubernetesPairingRecordStore : PairingRecordStore
+    {
+        private readonly KubernetesClient client;
+        private readonly NamespacedKubernetesClient<V1Secret> secretClient;
+        private readonly ILogger<KubernetesPairingRecordStore> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesPairingRecordStore"/> class.
+        /// </summary>
+        /// <param name="client">
+        /// A <see cref="KubernetesClient"/> which can be used to connect to the Kubernetes cluster.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which can be used when logging.</param>
+        public KubernetesPairingRecordStore(KubernetesClient client, ILogger<KubernetesPairingRecordStore> logger)
+        {
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            this.secretClient = this.client.GetClient<V1Secret>();
+        }
+
+        /// <inheritdoc/>
+        public override Task DeleteAsync(string udid, CancellationToken cancellationToken)
+        {
+            if (udid == null)
+            {
+                throw new ArgumentNullException(nameof(udid));
+            }
+
+            return this.secretClient.TryDeleteAsync(udid, TimeSpan.FromMinutes(1), cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override async Task<PairingRecord?> ReadAsync(string udid, CancellationToken cancellationToken)
+        {
+            if (udid == null)
+            {
+                throw new ArgumentNullException(nameof(udid));
+            }
+
+            var secret = await this.secretClient.TryReadAsync(udid, cancellationToken).ConfigureAwait(false);
+            return secret.AsPairingRecord();
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(string udid, PairingRecord pairingRecord, CancellationToken cancellationToken)
+        {
+            if (udid == null)
+            {
+                throw new ArgumentNullException(nameof(udid));
+            }
+
+            if (pairingRecord == null)
+            {
+                throw new ArgumentNullException(nameof(pairingRecord));
+            }
+
+            var secret = pairingRecord.AsSecret();
+            secret.Metadata.Name = udid;
+
+            return this.secretClient.CreateAsync(secret, cancellationToken);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/PairingRecords/V1SecretExtensions.PairingRecord.cs
+++ b/src/Kaponata.Kubernetes/PairingRecords/V1SecretExtensions.PairingRecord.cs
@@ -1,0 +1,140 @@
+﻿// <copyright file="V1SecretExtensions.PairingRecord.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.iOS.Lockdown;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Kaponata.Kubernetes.PairingRecords
+{
+    /// <summary>
+    /// Provides methods for storing <see cref="PairingRecord"/> objects as <see cref="V1Secret"/> objects.
+    /// </summary>
+    public static class V1SecretExtensions
+    {
+        private const string TlsCertificateKey = "tls.crt";
+        private const string TlsPrivateKey = "tls.key";
+
+        private const string CaCertificateKey = "ca.crt";
+        private const string CaPrivateKey = "ca.key";
+
+        private const string DeviceCertificateKey = "device.crt";
+
+        private const string EscrowBagKey = "escrow.key";
+        private const string HostIdKey = "hostId";
+        private const string SystemBuidKey = "systemBuid";
+        private const string WifiMacAddressKey = "wifiMacAddress";
+
+        private const string TlsType = "kubernetes.io/tls";
+
+        /// <summary>
+        /// Converts a <see cref="PairingRecord"/> to a <see cref="V1Secret"/> object.
+        /// </summary>
+        /// <param name="pairingRecord">
+        /// The pairing record to convert.
+        /// </param>
+        /// <returns>
+        /// A <see cref="V1Secret"/> which represents the <see cref="PairingRecord"/>.
+        /// </returns>
+        [return: NotNullIfNotNull("pairingRecord")]
+        public static V1Secret? AsSecret(this PairingRecord? pairingRecord)
+        {
+            if (pairingRecord == null)
+            {
+                return null;
+            }
+
+            var secret = new V1Secret()
+            {
+                ApiVersion = V1Secret.KubeApiVersion,
+                Kind = V1Secret.KubeKind,
+                Type = TlsType,
+                Metadata = new V1ObjectMeta(),
+                Data = new Dictionary<string, byte[]>(),
+                Immutable = true,
+            };
+
+            secret.Data[TlsCertificateKey] =
+                Encoding.UTF8.GetBytes(
+                    PemEncoding.Write(
+                        "CERTIFICATE",
+                        pairingRecord.HostCertificate.Export(X509ContentType.Cert)));
+
+            secret.Data[TlsPrivateKey] =
+                Encoding.UTF8.GetBytes(
+                    PemEncoding.Write(
+                        "PRIVATE KEY",
+                        pairingRecord.HostPrivateKey.ExportPkcs8PrivateKey()));
+
+            secret.Data[CaCertificateKey] =
+                Encoding.UTF8.GetBytes(
+                    PemEncoding.Write(
+                        "CERTIFICATE",
+                        pairingRecord.RootCertificate.Export(X509ContentType.Cert)));
+
+            secret.Data[CaPrivateKey] =
+                Encoding.UTF8.GetBytes(
+                    PemEncoding.Write(
+                        "PRIVATE KEY",
+                        pairingRecord.RootPrivateKey.ExportPkcs8PrivateKey()));
+
+            secret.Data[DeviceCertificateKey] =
+                Encoding.UTF8.GetBytes(
+                    PemEncoding.Write(
+                        "CERTIFICATE",
+                        pairingRecord.DeviceCertificate.Export(X509ContentType.Cert)));
+
+            secret.Data[EscrowBagKey] = pairingRecord.EscrowBag;
+            secret.Data[HostIdKey] = Encoding.UTF8.GetBytes(pairingRecord.HostId);
+            secret.Data[SystemBuidKey] = Encoding.UTF8.GetBytes(pairingRecord.SystemBUID);
+            secret.Data[WifiMacAddressKey] = pairingRecord.WiFiMacAddress == null ? null : Encoding.UTF8.GetBytes(pairingRecord.WiFiMacAddress);
+
+            return secret;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="V1Secret"/> to a <see cref="PairingRecord"/>.
+        /// </summary>
+        /// <param name="secret">
+        /// A <see cref="V1Secret"/> which represents a pairing record.
+        /// </param>
+        /// <returns>
+        /// An equivalent <see cref="PairingRecord"/>.
+        /// </returns>
+        public static PairingRecord? AsPairingRecord(this V1Secret? secret)
+        {
+            if (secret == null)
+            {
+                return null;
+            }
+
+            return new PairingRecord()
+            {
+                HostCertificate = new X509Certificate2(secret.Data[TlsCertificateKey]),
+                HostPrivateKey = DeserializePrivateKey(secret.Data[TlsPrivateKey]),
+
+                RootCertificate = new X509Certificate2(secret.Data[CaCertificateKey]),
+                RootPrivateKey = DeserializePrivateKey(secret.Data[CaPrivateKey]),
+
+                DeviceCertificate = new X509Certificate2(secret.Data[DeviceCertificateKey]),
+
+                EscrowBag = secret.Data[EscrowBagKey] != null && secret.Data[EscrowBagKey].Length > 0 ? secret.Data[EscrowBagKey] : null,
+                HostId = Encoding.UTF8.GetString(secret.Data[HostIdKey]),
+                SystemBUID = Encoding.UTF8.GetString(secret.Data[SystemBuidKey]),
+                WiFiMacAddress = secret.Data.ContainsKey(WifiMacAddressKey) && secret.Data[WifiMacAddressKey] != null && secret.Data[WifiMacAddressKey].Length > 0 ? Encoding.UTF8.GetString(secret.Data[WifiMacAddressKey]) : null,
+            };
+        }
+
+        private static RSA DeserializePrivateKey(byte[] data)
+        {
+            var rsa = RSA.Create();
+            rsa.ImportFromPem(Encoding.UTF8.GetString(data));
+            return rsa;
+        }
+    }
+}


### PR DESCRIPTION
This enables storing pairing records in a Kubernetes cluster, as opposed to locally.