### PR TITLE
PairingRecordGenerator: Make sure that HostID is upper-case

### DIFF
--- a/src/Kaponata.iOS.Tests/Lockdown/PairingRecordGeneratorTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/PairingRecordGeneratorTests.cs
@@ -62,6 +62,10 @@ namespace Kaponata.iOS.Tests.Lockdown
             Assert.NotNull(pairingRecord.RootCertificate);
             Assert.NotNull(pairingRecord.RootPrivateKey);
 
+            // The host ID must be a well-formed, upper-case UUID
+            Assert.True(Guid.TryParse(pairingRecord.HostId, out Guid hostId));
+            Assert.Equal(hostId.ToString("D").ToUpperInvariant(), pairingRecord.HostId);
+
             var rootSubjectKeyIdentifier = pairingRecord.RootCertificate.Extensions.OfType<X509SubjectKeyIdentifierExtension>().Single();
 
             // Validate the root certificate

--- a/src/Kaponata.iOS/Lockdown/PairingRecordGenerator.cs
+++ b/src/Kaponata.iOS/Lockdown/PairingRecordGenerator.cs
@@ -130,6 +130,8 @@ namespace Kaponata.iOS.Lockdown
                 notAfter: notAfter,
                 serialNumber: new byte[] { 0 });
 
+            var hostId = Guid.NewGuid();
+
             return new PairingRecord()
             {
                 DeviceCertificate = deviceCertificate,
@@ -138,7 +140,7 @@ namespace Kaponata.iOS.Lockdown
                 RootPrivateKey = rootKeyPair,
                 RootCertificate = rootCert,
                 SystemBUID = systemBuid,
-                HostId = Guid.NewGuid().ToString(),
+                HostId = hostId.ToString("D").ToUpperInvariant(),
             };
         }
 


### PR DESCRIPTION
Attempting to pair with a device when `HostID` has lowercase characters will result in the pair dialog being displayed on the device, but pairing will fail to complete with a `InvalidPairRecord` error when the user taps the `Trust` button.