### PR TITLE
LockdownClient.Pair: Return EscrowBag data, too.

### DIFF
--- a/src/Kaponata.iOS.Tests/Muxer/PairResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/PairResponseTests.cs
@@ -1,0 +1,57 @@
+﻿// <copyright file="PairResponseTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.Lockdown;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Muxer
+{
+    /// <summary>
+    /// Tests the <see cref="PairResponse"/> class.
+    /// </summary>
+    public class PairResponseTests
+    {
+        /// <summary>
+        /// <see cref="PairResponse.Read(NSDictionary)"/> validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Read_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => PairResponse.Read(null));
+        }
+
+        /// <summary>
+        /// <see cref="PairResponse.Read(NSDictionary)"/> parses the escrow bag.
+        /// </summary>
+        [Fact]
+        public void Read_WithEscrowBag_Works()
+        {
+            var dict = new NSDictionary();
+            byte[] data = new byte[] { 1, 2, 3, 4 };
+
+            dict.Add("EscrowBag", data);
+
+            var value = PairResponse.Read(dict);
+
+            Assert.Null(value.Error);
+            Assert.Equal(data, value.EscrowBag);
+        }
+
+        /// <summary>
+        /// <see cref="PairResponse.Read(NSDictionary)"/> parses the error data.
+        /// </summary>
+        [Fact]
+        public void Read_WithError_Works()
+        {
+            var dict = new NSDictionary();
+            dict.Add("Error", "SomeError");
+
+            var value = PairResponse.Read(dict);
+            Assert.Equal("SomeError", value.Error);
+            Assert.Null(value.EscrowBag);
+        }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/PairResponse.Serialization.cs
+++ b/src/Kaponata.iOS/Lockdown/PairResponse.Serialization.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="PairResponse.Serialization.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System;
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <content>
+    /// Serialization-related data for the <see cref="PairResponse"/> class.
+    /// </content>
+    public partial class PairResponse
+    {
+        /// <summary>
+        /// Reads a <see cref="PairResponse"/> from a <see cref="NSDictionary"/>.
+        /// </summary>
+        /// <param name="data">
+        /// The message data.
+        /// </param>
+        /// <returns>
+        /// A <see cref="PairResponse"/> object.
+        /// </returns>
+        public static PairResponse Read(NSDictionary data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            PairResponse value = new PairResponse();
+            value.Error = data.GetString(nameof(Error));
+            value.EscrowBag = data.GetData(nameof(EscrowBag));
+
+            return value;
+        }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/PairResponse.cs
+++ b/src/Kaponata.iOS/Lockdown/PairResponse.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="PairResponse.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <summary>
+    /// Represents the device's response to a <see cref="PairRequest"/>.
+    /// </summary>
+    public partial class PairResponse
+    {
+        /// <summary>
+        /// Gets or sets the error message, if any.
+        /// </summary>
+        public string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the escrow bag, if any.
+        /// </summary>
+        public byte[] EscrowBag { get; set; }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/PairingResult.cs
+++ b/src/Kaponata.iOS/Lockdown/PairingResult.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="PairingResult.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.Lockdown
+{
+    /// <summary>
+    /// Captures the result of a pairing operation.
+    /// </summary>
+    public class PairingResult
+    {
+        /// <summary>
+        /// Gets or sets the status of the operation, indicating whether the operation completed succesfully
+        /// or with an error message.
+        /// </summary>
+        public PairingStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the escrow bag.
+        /// </summary>
+        /// <remarks>
+        /// When a pair request completed successfully, this value will contain the escrow bag, which can be used
+        /// to access services which are usually only available when the device is unlocked.
+        /// </remarks>
+        public byte[] EscrowBag { get; set; }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/PairingStatus.cs
+++ b/src/Kaponata.iOS/Lockdown/PairingStatus.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PairResult.cs" company="Quamotion bv">
+﻿// <copyright file="PairingStatus.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -10,7 +10,7 @@ namespace Kaponata.iOS.Lockdown
     /// The result of a <see cref="LockdownClient.PairAsync(PairingRecord, CancellationToken)"/>
     /// operation.
     /// </summary>
-    public enum PairResult
+    public enum PairingStatus
     {
         /// <summary>
         /// The operation completed successfully. The host and device have paired successfully.
@@ -27,5 +27,10 @@ namespace Kaponata.iOS.Lockdown
         /// is waiting for the server to accept or deny the pairing request.
         /// </summary>
         PairingDialogResponsePending,
+
+        /// <summary>
+        /// An inavlid pair record was presented to the device.
+        /// </summary>
+        InvalidPairRecord,
     }
 }


### PR DESCRIPTION
The device will respond with an escrow bag when pairing succeeds; make sure to return this data as well, so that it can be added to the pairing record when needed.