### PR TITLE
LockdownClient: Move `ConnectAsync` to a factory class, add logging

### DIFF
--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientFactoryTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientFactoryTests.cs
@@ -1,0 +1,58 @@
+﻿// <copyright file="LockdownClientFactoryTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.Lockdown
+{
+    /// <summary>
+    /// Tests the <see cref="LockdownClientFactory"/> class.
+    /// </summary>
+    public class LockdownClientFactoryTests
+    {
+        /// <summary>
+        /// <see cref="LockdownClientFactory"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new LockdownClientFactory(null, Mock.Of<DeviceContext>(), NullLogger<LockdownClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new LockdownClientFactory(Mock.Of<MuxerClient>(), null, NullLogger<LockdownClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new LockdownClientFactory(Mock.Of<MuxerClient>(), Mock.Of<DeviceContext>(), null));
+        }
+
+        /// <summary>
+        /// The <see cref="LockdownClientFactory.CreateAsync(CancellationToken)"/> method works.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task Connect_Works_Async()
+        {
+            // Sample traffic from https://www.theiphonewiki.com/wiki/Usbmux ("lockdownd protocol")
+            var muxer = new Mock<MuxerClient>();
+            var device = new MuxerDevice();
+
+            using (var traceStream = new TraceStream("Lockdown/connect-device.bin", "Lockdown/connect-host.bin"))
+            {
+                muxer
+                    .Setup(m => m.ConnectAsync(device, 0xF27E, default))
+                    .ReturnsAsync(traceStream);
+
+                var factory = new LockdownClientFactory(muxer.Object, new DeviceContext() { Device = device }, NullLogger<LockdownClient>.Instance);
+
+                await using (await factory.CreateAsync(default))
+                {
+                    // The trace stream will assert the correct data is exchanged.
+                }
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
@@ -4,7 +4,6 @@
 
 using Claunia.PropertyList;
 using Kaponata.iOS.Lockdown;
-using Kaponata.iOS.Muxer;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
@@ -47,7 +46,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var value = await client.GetValueAsync("my-key", default).ConfigureAwait(false);
                 Assert.Equal("my-value", value);
@@ -83,7 +82,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var value = await client.GetValueAsync<string>("my-domain", "my-key", default).ConfigureAwait(false);
                 Assert.Equal("my-value", value);
@@ -120,7 +119,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(() => client.GetValueAsync<string>("my-domain", "my-key", default)).ConfigureAwait(false);
             }
@@ -161,7 +160,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await client.GetPublicKeyAsync(default).ConfigureAwait(false);
                 Assert.Equal(key, result);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
@@ -5,6 +5,7 @@
 using Claunia.PropertyList;
 using Kaponata.iOS.Lockdown;
 using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Threading;
@@ -46,7 +47,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 var value = await client.GetValueAsync("my-key", default).ConfigureAwait(false);
                 Assert.Equal("my-value", value);
@@ -82,7 +83,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 var value = await client.GetValueAsync<string>("my-domain", "my-key", default).ConfigureAwait(false);
                 Assert.Equal("my-value", value);
@@ -119,7 +120,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(() => client.GetValueAsync<string>("my-domain", "my-key", default)).ConfigureAwait(false);
             }
@@ -160,7 +161,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 var result = await client.GetPublicKeyAsync(default).ConfigureAwait(false);
                 Assert.Equal(key, result);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
@@ -5,6 +5,7 @@
 using Claunia.PropertyList;
 using Kaponata.iOS.Lockdown;
 using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Threading;
@@ -25,7 +26,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task PairAsync_ValidatesArguments_Async()
         {
-            await using (var lockdown = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(Mock.Of<LockdownProtocol>(), NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>("pairingRecord", () => lockdown.PairAsync(null, default)).ConfigureAwait(false);
             }
@@ -62,7 +63,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.PairAsync(pairingRecord, default).ConfigureAwait(false);
                 Assert.Equal(PairingStatus.Success, result.Status);
@@ -102,7 +103,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.PairAsync(pairingRecord, default).ConfigureAwait(false);
                 Assert.Equal(PairingStatus.Success, result.Status);
@@ -133,7 +134,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.PairAsync(pairingRecord, default).ConfigureAwait(false);
                 Assert.Equal(PairingStatus.PairingDialogResponsePending, result.Status);
@@ -162,7 +163,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(() => lockdown.PairAsync(pairingRecord, default)).ConfigureAwait(false);
             }
@@ -188,7 +189,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync((NSDictionary)null);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.PairAsync(pairingRecord, default).ConfigureAwait(false);
                 Assert.Null(result);
@@ -225,7 +226,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.UnpairAsync(pairingRecord, default).ConfigureAwait(false);
                 Assert.Equal(PairingStatus.Success, result.Status);
@@ -262,7 +263,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.ValidatePairAsync(pairingRecord, default).ConfigureAwait(false);
                 Assert.Equal(PairingStatus.Success, result.Status);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -4,7 +4,6 @@
 
 using Claunia.PropertyList;
 using Kaponata.iOS.Lockdown;
-using Kaponata.iOS.Muxer;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
@@ -26,7 +25,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task StartSessionAsync_ValidatesArguments_Async()
         {
-            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance);
+            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), NullLogger<LockdownClient>.Instance);
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.StartSessionAsync(null, default)).ConfigureAwait(false);
         }
 
@@ -57,7 +56,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var response = await client.StartSessionAsync(
                     new PairingRecord()
@@ -100,7 +99,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(
                     () => client.StartSessionAsync(
@@ -120,7 +119,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task StopSessionAsync_ValidatesArguments_Async()
         {
-            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance);
+            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), NullLogger<LockdownClient>.Instance);
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.StopSessionAsync(null, default)).ConfigureAwait(false);
         }
 
@@ -151,7 +150,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
+            await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(
                     () => client.StopSessionAsync("1234", default)).ConfigureAwait(false);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -5,6 +5,7 @@
 using Claunia.PropertyList;
 using Kaponata.iOS.Lockdown;
 using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Threading;
@@ -25,7 +26,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task StartSessionAsync_ValidatesArguments_Async()
         {
-            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice());
+            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance);
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.StartSessionAsync(null, default)).ConfigureAwait(false);
         }
 
@@ -56,7 +57,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 var response = await client.StartSessionAsync(
                     new PairingRecord()
@@ -99,7 +100,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(
                     () => client.StartSessionAsync(
@@ -119,7 +120,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task StopSessionAsync_ValidatesArguments_Async()
         {
-            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice());
+            var client = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance);
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.StopSessionAsync(null, default)).ConfigureAwait(false);
         }
 
@@ -150,7 +151,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);
 
-            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var client = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice(), NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(
                     () => client.StopSessionAsync("1234", default)).ConfigureAwait(false);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.StartService.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.StartService.cs
@@ -5,6 +5,7 @@
 using Claunia.PropertyList;
 using Kaponata.iOS.Lockdown;
 using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Threading;
@@ -25,7 +26,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task StartServiceAsync_ValidatesArguments_Async()
         {
-            await using (var lockdown = new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(Mock.Of<LockdownProtocol>(), NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>(() => lockdown.StartServiceAsync(null, default)).ConfigureAwait(false);
             }
@@ -58,7 +59,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.StartServiceAsync("test", default).ConfigureAwait(false);
 
@@ -93,7 +94,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync((NSDictionary)null);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.StartServiceAsync("test", default).ConfigureAwait(false);
                 Assert.Null(result);
@@ -128,7 +129,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
-            await using (var lockdown = new LockdownClient(protocol.Object, Mock.Of<MuxerClient>(), new MuxerDevice()))
+            await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(() => lockdown.StartServiceAsync("test", default)).ConfigureAwait(false);
             }

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.cs
@@ -3,12 +3,10 @@
 // </copyright>
 
 using Kaponata.iOS.Lockdown;
-using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Kaponata.iOS.Tests.Lockdown
@@ -24,48 +22,11 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new LockdownClient((Stream)null, Mock.Of<MuxerClient>(), new MuxerDevice()));
-            Assert.Throws<ArgumentNullException>(() => new LockdownClient(Stream.Null, null, new MuxerDevice()));
-            Assert.Throws<ArgumentNullException>(() => new LockdownClient(Stream.Null, Mock.Of<MuxerClient>(), null));
+            Assert.Throws<ArgumentNullException>(() => new LockdownClient((Stream)null, NullLogger<LockdownClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new LockdownClient(Stream.Null, null));
 
-            Assert.Throws<ArgumentNullException>(() => new LockdownClient((LockdownProtocol)null, Mock.Of<MuxerClient>(), new MuxerDevice()));
-            Assert.Throws<ArgumentNullException>(() => new LockdownClient(Mock.Of<LockdownProtocol>(), null, new MuxerDevice()));
-            Assert.Throws<ArgumentNullException>(() => new LockdownClient(Mock.Of<LockdownProtocol>(), Mock.Of<MuxerClient>(), null));
-        }
-
-        /// <summary>
-        /// <see cref="LockdownClient.ConnectAsync(MuxerClient, MuxerDevice, CancellationToken)"/> validates its arguments.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ConnectAsync_ValidatesArguments_Async()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(() => LockdownClient.ConnectAsync(null, new MuxerDevice(), default));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => LockdownClient.ConnectAsync(Mock.Of<MuxerClient>(), null, default));
-        }
-
-        /// <summary>
-        /// The <see cref="LockdownClient.ConnectAsync(MuxerClient, MuxerDevice, CancellationToken)"/> method works.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task Connect_Works_Async()
-        {
-            // Sample traffic from https://www.theiphonewiki.com/wiki/Usbmux ("lockdownd protocol")
-            var muxer = new Mock<MuxerClient>();
-            var device = new MuxerDevice();
-
-            using (var traceStream = new TraceStream("Lockdown/connect-device.bin", "Lockdown/connect-host.bin"))
-            {
-                muxer
-                    .Setup(m => m.ConnectAsync(device, 0xF27E, default))
-                    .ReturnsAsync(traceStream);
-
-                await using (await LockdownClient.ConnectAsync(muxer.Object, device, default))
-                {
-                    // The trace stream will assert the correct data is exchanged.
-                }
-            }
+            Assert.Throws<ArgumentNullException>(() => new LockdownClient((LockdownProtocol)null, NullLogger<LockdownClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new LockdownClient(Mock.Of<LockdownProtocol>(), null));
         }
     }
 }

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownProtocolTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownProtocolTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Kaponata.iOS.Lockdown;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
 using System.Threading;
@@ -23,7 +24,7 @@ namespace Kaponata.iOS.Tests.Lockdown
         [Fact]
         public async Task WriteMessageAsync_ValidatesArgumentsAsync()
         {
-            await using (var protocol = new LockdownProtocol(Stream.Null, false))
+            await using (var protocol = new LockdownProtocol(Stream.Null, false, NullLogger.Instance))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>(() => protocol.WriteMessageAsync(null, default)).ConfigureAwait(false);
             }

--- a/src/Kaponata.iOS.Tests/NotificationProxy/NotificationProxyClientTests.cs
+++ b/src/Kaponata.iOS.Tests/NotificationProxy/NotificationProxyClientTests.cs
@@ -5,6 +5,7 @@
 using Claunia.PropertyList;
 using Kaponata.iOS.NotificationProxy;
 using Kaponata.iOS.PropertyLists;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.IO;
@@ -25,8 +26,10 @@ namespace Kaponata.iOS.Tests.NotificationProxy
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new NotificationProxyClient((Stream)null));
-            Assert.Throws<ArgumentNullException>(() => new NotificationProxyClient((PropertyListProtocol)null));
+            Assert.Throws<ArgumentNullException>(() => new NotificationProxyClient(null, NullLogger<NotificationProxyClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new NotificationProxyClient(Stream.Null, null));
+
+            Assert.Throws<ArgumentNullException>(() => new NotificationProxyClient(null));
         }
 
         /// <summary>
@@ -38,7 +41,7 @@ namespace Kaponata.iOS.Tests.NotificationProxy
         public async Task ObserveNotificationAsync_Works_Async()
         {
             await using (MemoryStream stream = new MemoryStream())
-            await using (NotificationProxyClient client = new NotificationProxyClient(stream))
+            await using (NotificationProxyClient client = new NotificationProxyClient(stream, NullLogger<NotificationProxyClient>.Instance))
             {
                 await client.ObserveNotificationAsync("com.apple.mobile.application_installed", default).ConfigureAwait(false);
 
@@ -57,7 +60,7 @@ namespace Kaponata.iOS.Tests.NotificationProxy
         public async Task ReadRelayNotificationAsync_Works_Async()
         {
             await using (Stream stream = File.OpenRead("NotificationProxy/notificationproxy-device.bin"))
-            await using (NotificationProxyClient client = new NotificationProxyClient(stream))
+            await using (NotificationProxyClient client = new NotificationProxyClient(stream, NullLogger<NotificationProxyClient>.Instance))
             {
                 var notification = await client.ReadRelayNotificationAsync(default).ConfigureAwait(false);
                 Assert.Equal("com.apple.mobile.application_installed", notification);

--- a/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.cs
+++ b/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.cs
@@ -4,6 +4,7 @@
 
 using Claunia.PropertyList;
 using Kaponata.iOS.PropertyLists;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
 using System.Threading;
@@ -23,7 +24,8 @@ namespace Kaponata.iOS.Tests.PropertyLists
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("stream", () => new PropertyListProtocol(null, true));
+            Assert.Throws<ArgumentNullException>("stream", () => new PropertyListProtocol(null, true, NullLogger<PropertyListProtocol>.Instance));
+            Assert.Throws<ArgumentNullException>("stream", () => new PropertyListProtocol(Stream.Null, true, null));
         }
 
         /// <summary>
@@ -33,7 +35,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
         [Fact]
         public async Task Write_ValidatesArguments_Async()
         {
-            var protocol = new PropertyListProtocol(Stream.Null, false);
+            var protocol = new PropertyListProtocol(Stream.Null, false, NullLogger<PropertyListProtocol>.Instance);
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => protocol.WriteMessageAsync(null, default)).ConfigureAwait(false);
         }
@@ -47,7 +49,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
         public async Task Write_Works_Async()
         {
             await using (MemoryStream stream = new MemoryStream())
-            await using (var protocol = new PropertyListProtocol(stream, false))
+            await using (var protocol = new PropertyListProtocol(stream, false, NullLogger<PropertyListProtocol>.Instance))
             {
                 var dict = new NSDictionary();
                 dict.Add("Request", "QueryType");
@@ -67,7 +69,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
         public async Task Read_Works_Async()
         {
             await using (Stream stream = File.OpenRead("PropertyLists/message.bin"))
-            await using (var protocol = new PropertyListProtocol(stream, false))
+            await using (var protocol = new PropertyListProtocol(stream, false, NullLogger<PropertyListProtocol>.Instance))
             {
                 var dict = await protocol.ReadMessageAsync(default);
 
@@ -85,7 +87,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
         public async Task Read_PartialRead_ReturnsNull_Async()
         {
             await using (var stream = new MemoryStream(File.ReadAllBytes("PropertyLists/message.bin")))
-            await using (var protocol = new PropertyListProtocol(stream, false))
+            await using (var protocol = new PropertyListProtocol(stream, false, NullLogger<PropertyListProtocol>.Instance))
             {
                 // Let's pretend the last 4 bytes are missing.
                 stream.SetLength(stream.Length - 4);
@@ -102,7 +104,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
         [Fact]
         public async Task Read_EndOfStream_ReturnsNull_Async()
         {
-            await using (var protocol = new PropertyListProtocol(Stream.Null, false))
+            await using (var protocol = new PropertyListProtocol(Stream.Null, false, NullLogger<PropertyListProtocol>.Instance))
             {
                 Assert.Null(await protocol.ReadMessageAsync(default).ConfigureAwait(false));
             }

--- a/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.cs
+++ b/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.cs
@@ -25,7 +25,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
         public void Constructor_ValidatesArguments()
         {
             Assert.Throws<ArgumentNullException>("stream", () => new PropertyListProtocol(null, true, NullLogger<PropertyListProtocol>.Instance));
-            Assert.Throws<ArgumentNullException>("stream", () => new PropertyListProtocol(Stream.Null, true, null));
+            Assert.Throws<ArgumentNullException>("logger", () => new PropertyListProtocol(Stream.Null, true, null));
         }
 
         /// <summary>

--- a/src/Kaponata.iOS/ClientFactory.cs
+++ b/src/Kaponata.iOS/ClientFactory.cs
@@ -1,0 +1,71 @@
+﻿// <copyright file="ClientFactory.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS
+{
+    /// <summary>
+    /// The base class for a factory which can create a client for a service running on an iOS
+    /// device, which is accessible via the USB interface.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of the client being accessed.
+    /// </typeparam>
+    public abstract class ClientFactory<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientFactory{T}"/> class.
+        /// </summary>
+        /// <param name="muxer">
+        /// The <see cref="MuxerClient"/> which represents the connection to the iOS USB Multiplexor.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="DeviceContext"/> which contains information about the device with which
+        /// we are interacting.
+        /// </param>
+        /// <param name="logger">
+        /// A <see cref="ILogger"/> which can be used when logging.
+        /// </param>
+        public ClientFactory(MuxerClient muxer, DeviceContext context, ILogger<T> logger)
+        {
+            this.Muxer = muxer ?? throw new ArgumentNullException(nameof(muxer));
+            this.Context = context ?? throw new ArgumentNullException(nameof(context));
+            this.Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="MuxerClient"/> which represents the connection to the iOS USB Multiplexor.
+        /// </summary>
+        public MuxerClient Muxer { get; }
+
+        /// <summary>
+        /// Gets the <see cref="DeviceContext"/> which contains information about the device with which
+        /// we are interacting.
+        /// </summary>
+        public DeviceContext Context { get; }
+
+        /// <summary>
+        /// Gets a <see cref="ILogger"/> which can be used when logging.
+        /// </summary>
+        public ILogger<T> Logger { get; }
+
+        /// <summary>
+        /// Asynchronously creates a new instance of the <typeparamref name="T"/> client.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous
+        /// operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns the
+        /// newly created <typeparamref name="T"/> service client when completed.
+        /// </returns>
+        public abstract Task<T> CreateAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Kaponata.iOS/DeviceContext.cs
+++ b/src/Kaponata.iOS/DeviceContext.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="DeviceContext.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+
+namespace Kaponata.iOS
+{
+    /// <summary>
+    /// The <see cref="DeviceContext"/> represents a single connection to an iOS device.
+    /// It can be used in session scopes to inject information about the current iOS device
+    /// to via the constructor.
+    /// </summary>
+    public class DeviceContext
+    {
+        /// <summary>
+        /// Gets or sets the device to which the session is scoped.
+        /// </summary>
+        public MuxerDevice Device { get; set; }
+    }
+}

--- a/src/Kaponata.iOS/Lockdown/LockdownProtocol.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownProtocol.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Kaponata.iOS.PropertyLists;
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading;
@@ -24,8 +25,11 @@ namespace Kaponata.iOS.Lockdown
         /// <param name="ownsStream">
         /// A value indicating whether this <see cref="LockdownProtocol"/> instance owns the <paramref name="stream"/> or not.
         /// </param>
-        public LockdownProtocol(Stream stream, bool ownsStream)
-            : base(stream, ownsStream)
+        /// <param name="logger">
+        /// A <see cref="ILogger"/> which can be used when logging.
+        /// </param>
+        public LockdownProtocol(Stream stream, bool ownsStream, ILogger logger)
+            : base(stream, ownsStream, logger)
         {
         }
 

--- a/src/Kaponata.iOS/NotificationProxy/NotificationProxyClient.cs
+++ b/src/Kaponata.iOS/NotificationProxy/NotificationProxyClient.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Kaponata.iOS.PropertyLists;
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading;
@@ -18,7 +19,12 @@ namespace Kaponata.iOS.NotificationProxy
         /// <summary>
         /// Gets the name of the notification proxy service on the device.
         /// </summary>
-        private const string ServiceName = "com.apple.mobile.notification_proxy";
+        public const string ServiceName = "com.apple.mobile.notification_proxy";
+
+        /// <summary>
+        /// Gets the name of the insecure notification proxy service on the device.
+        /// </summary>
+        public const string InsecureServiceName = "com.apple.mobile.insecure_notification_proxy";
 
         private readonly PropertyListProtocol protocol;
 
@@ -28,9 +34,12 @@ namespace Kaponata.iOS.NotificationProxy
         /// <param name="stream">
         /// A <see cref="Stream"/> which represents a connection to the notification proxy running on the device.
         /// </param>
-        public NotificationProxyClient(Stream stream)
+        /// <param name="logger">
+        /// A <see cref="ILogger"/> which can be used when logging.
+        /// </param>
+        public NotificationProxyClient(Stream stream, ILogger logger)
         {
-            this.protocol = new PropertyListProtocol(stream, ownsStream: true);
+            this.protocol = new PropertyListProtocol(stream, ownsStream: true, logger: logger);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR:

- Moves the `static LockdownClient.ConnectAsync` method to a `LockdownClientFactory` class. This should make it easier to mock this method in unit tests.
- Add trace logging to `PropertyListProtocol`, `LockdownClient`.