### PR TITLE
MuxerClient: Pass cancellation tokens to callbacks

### DIFF
--- a/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
+++ b/src/Kaponata.iOS.Tests/Muxer/MuxerClientTests.cs
@@ -386,9 +386,9 @@ namespace Kaponata.iOS.Tests.Muxer
 
             Assert.False(
                 await client.ListenAsync(
-                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onAttached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onPaired, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
                     default).ConfigureAwait(false));
 
             Assert.Empty(queue);
@@ -440,9 +440,9 @@ namespace Kaponata.iOS.Tests.Muxer
 
             Assert.True(
                 await client.ListenAsync(
-                    (onAttached) => { return Task.FromResult(onAttached.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
-                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onAttached, ct) => { return Task.FromResult(onAttached.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
+                    (onDetached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onPaired, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
                     default).ConfigureAwait(false));
 
             Assert.Equal(3, queue.Count);
@@ -494,9 +494,9 @@ namespace Kaponata.iOS.Tests.Muxer
 
             Assert.True(
                 await client.ListenAsync(
-                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onDetached) => { return Task.FromResult(onDetached.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
-                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onAttached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached, ct) => { return Task.FromResult(onDetached.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
+                    (onPaired, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
                     default).ConfigureAwait(false));
 
             Assert.Single(queue);
@@ -548,9 +548,9 @@ namespace Kaponata.iOS.Tests.Muxer
 
             Assert.True(
                 await client.ListenAsync(
-                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening);  },
-                    (onPaired) => { return Task.FromResult(onPaired.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
+                    (onAttached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening);  },
+                    (onPaired, ct) => { return Task.FromResult(onPaired.DeviceID == 1 ? MuxerListenAction.ContinueListening : MuxerListenAction.StopListening); },
                     default).ConfigureAwait(false));
 
             Assert.Equal(2, queue.Count);
@@ -597,9 +597,9 @@ namespace Kaponata.iOS.Tests.Muxer
 
             await Assert.ThrowsAsync<InvalidDataException>(
                 () => client.ListenAsync(
-                    (onAttached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onDetached) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
-                    (onPaired) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onAttached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onDetached, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
+                    (onPaired, ct) => { return Task.FromResult(MuxerListenAction.ContinueListening); },
                     default)).ConfigureAwait(false);
 
             Assert.Empty(queue);

--- a/src/Kaponata.iOS/Muxer/MuxerClient.Listen.cs
+++ b/src/Kaponata.iOS/Muxer/MuxerClient.Listen.cs
@@ -35,9 +35,9 @@ namespace Kaponata.iOS.Muxer
         /// the client aborted the listen operation, <see langword="false"/> when the server disconnected.
         /// </returns>
         public virtual async Task<bool> ListenAsync(
-            Func<DeviceAttachedMessage, Task<MuxerListenAction>> onAttached,
-            Func<DeviceDetachedMessage, Task<MuxerListenAction>> onDetached,
-            Func<DevicePairedMessage, Task<MuxerListenAction>> onPaired,
+            Func<DeviceAttachedMessage, CancellationToken, Task<MuxerListenAction>> onAttached,
+            Func<DeviceDetachedMessage, CancellationToken, Task<MuxerListenAction>> onDetached,
+            Func<DevicePairedMessage, CancellationToken, Task<MuxerListenAction>> onPaired,
             CancellationToken cancellationToken)
         {
             var protocol = await this.TryConnectToMuxerAsync(cancellationToken).ConfigureAwait(false);
@@ -81,7 +81,7 @@ namespace Kaponata.iOS.Muxer
 
                         if (onAttached != null)
                         {
-                            if (await onAttached(attachedMessage) == MuxerListenAction.StopListening)
+                            if (await onAttached(attachedMessage, cancellationToken) == MuxerListenAction.StopListening)
                             {
                                 break;
                             }
@@ -93,7 +93,7 @@ namespace Kaponata.iOS.Muxer
 
                         if (onDetached != null)
                         {
-                            if (await onDetached(detachedMessage) == MuxerListenAction.StopListening)
+                            if (await onDetached(detachedMessage, cancellationToken) == MuxerListenAction.StopListening)
                             {
                                 break;
                             }
@@ -105,7 +105,7 @@ namespace Kaponata.iOS.Muxer
 
                         if (onPaired != null)
                         {
-                            if (await onPaired(pairedMessage) == MuxerListenAction.StopListening)
+                            if (await onPaired(pairedMessage, cancellationToken) == MuxerListenAction.StopListening)
                             {
                                 break;
                             }


### PR DESCRIPTION
The callbacks are async but currently we don't provide them with a cancellation token. Let's fix that.