### PR TITLE
iOS: Support registering clients via dependency injection

### DIFF
--- a/src/Kaponata.iOS.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/Kaponata.iOS.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ServiceCollectionExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DependencyInjection;
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Kaponata.iOS.NotificationProxy;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.DependencyInjection
+{
+    /// <summary>
+    /// Tests the <see cref="ServiceCollectionExtensions"/> class.
+    /// </summary>
+    public class ServiceCollectionExtensionsTests
+    {
+        /// <summary>
+        /// The <see cref="ServiceCollectionExtensions.AddAppleServices(IServiceCollection)"/> method properly configures
+        /// the service collection.
+        /// </summary>
+        [Fact]
+        public void AddAppleServices_Works()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddLogging()
+                .AddAppleServices()
+                .BuildServiceProvider();
+
+            // Make sure we can get the most common types
+            var muxer = serviceProvider.GetRequiredService<MuxerClient>();
+            var lockdownFactory = serviceProvider.GetRequiredService<ClientFactory<LockdownClient>>();
+            var notificationProxyClientFactory = serviceProvider.GetRequiredService<ClientFactory<NotificationProxyClient>>();
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/DependencyInjection/ServiceProviderExtensionsTests.cs
+++ b/src/Kaponata.iOS.Tests/DependencyInjection/ServiceProviderExtensionsTests.cs
@@ -1,0 +1,153 @@
+﻿// <copyright file="ServiceProviderExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DependencyInjection;
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.DependencyInjection
+{
+    /// <summary>
+    /// Tests the <see cref="ServiceProviderExtensions"/> class.
+    /// </summary>
+    public class ServiceProviderExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// throws a <see cref="MuxerException"/> when no UDID is specified and a no devices are connected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateDeviceScopeAsync_NoUdid_NoDevice_ThrowsAsync()
+        {
+            var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxer
+                .Setup(m => m.ListDevicesAsync(default))
+                .ReturnsAsync(new Collection<MuxerDevice>() { });
+
+            var provider = new ServiceCollection()
+                .AddSingleton<MuxerClient>(muxer.Object)
+                .BuildServiceProvider();
+
+            await Assert.ThrowsAsync<MuxerException>(() => provider.CreateDeviceScopeAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// throws a <see cref="MuxerException"/> when no UDID is specified and more than one device is connected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateDeviceScopeAsync_NoUdid_TwoDevices_ThrowsAsync()
+        {
+            var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxer
+                .Setup(m => m.ListDevicesAsync(default))
+                .ReturnsAsync(new Collection<MuxerDevice>()
+                {
+                    new MuxerDevice(),
+                    new MuxerDevice(),
+                });
+
+            var provider = new ServiceCollection()
+                .AddSingleton<MuxerClient>(muxer.Object)
+                .AddScoped<DeviceContext>()
+                .BuildServiceProvider();
+
+            await Assert.ThrowsAsync<MuxerException>(() => provider.CreateDeviceScopeAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// returns the connected device when no UDID is specified and only a single device is connected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateDeviceScopeAsync_NoUdid_SingleDevice_WorksAsync()
+        {
+            var device = new MuxerDevice();
+
+            var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxer
+                .Setup(m => m.ListDevicesAsync(default))
+                .ReturnsAsync(new Collection<MuxerDevice>()
+                {
+                    device,
+                });
+
+            var provider = new ServiceCollection()
+                .AddSingleton<MuxerClient>(muxer.Object)
+                .AddScoped<DeviceContext>()
+                .BuildServiceProvider();
+
+            using (var scope = await provider.CreateDeviceScopeAsync(null, default).ConfigureAwait(false))
+            {
+                var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
+                Assert.Same(device, context.Device);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// throws an exception when the requested device is not found.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateDeviceScopeAsync_Udid_NoMatch_ThrowsAsync()
+        {
+            var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxer
+                .Setup(m => m.ListDevicesAsync(default))
+                .ReturnsAsync(new Collection<MuxerDevice>()
+                {
+                    new MuxerDevice() { Udid = "1" },
+                    new MuxerDevice() { Udid = "2" },
+                });
+
+            var provider = new ServiceCollection()
+                .AddSingleton<MuxerClient>(muxer.Object)
+                .AddScoped<DeviceContext>()
+                .BuildServiceProvider();
+
+            await Assert.ThrowsAsync<MuxerException>(() => provider.CreateDeviceScopeAsync("3", default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// returns the requested device when available.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateDeviceScopeAsync_Udid_Match_ReturnsDeviceAsync()
+        {
+            var device = new MuxerDevice() { Udid = "2" };
+
+            var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
+            muxer
+                .Setup(m => m.ListDevicesAsync(default))
+                .ReturnsAsync(new Collection<MuxerDevice>()
+                {
+                    new MuxerDevice() { Udid = "1" },
+                    device,
+                });
+
+            var provider = new ServiceCollection()
+                .AddSingleton<MuxerClient>(muxer.Object)
+                .AddScoped<DeviceContext>()
+                .BuildServiceProvider();
+
+            using (var scope = await provider.CreateDeviceScopeAsync("2", default).ConfigureAwait(false))
+            {
+                var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
+                Assert.Same(device, context.Device);
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/GlobalSuppressions.cs
+++ b/src/Kaponata.iOS.Tests/GlobalSuppressions.cs
@@ -10,3 +10,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.PropertyLists")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.NotificationProxy")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.Lockdown")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.DependencyInjection")]

--- a/src/Kaponata.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Kaponata.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ServiceCollectionExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Kaponata.iOS.NotificationProxy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kaponata.iOS.DependencyInjection
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="IServiceCollection"/> interface.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds iOS-related functionality to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The <see cref="IServiceCollection"/> to add services to.
+        /// </param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> so that additional calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddAppleServices(this IServiceCollection services)
+        {
+            services.AddSingleton<MuxerClient>();
+
+            services.AddScoped<DeviceContext>();
+
+            services.AddTransient<ClientFactory<LockdownClient>, LockdownClientFactory>();
+            services.AddTransient<ClientFactory<NotificationProxyClient>, NotificationProxyClientFactory>();
+
+            return services;
+        }
+    }
+}

--- a/src/Kaponata.iOS/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Kaponata.iOS/DependencyInjection/ServiceProviderExtensions.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="ServiceProviderExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.DependencyInjection
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="IServiceProvider"/> interface.
+    /// </summary>
+    public static class ServiceProviderExtensions
+    {
+        /// <summary>
+        /// Asynchronously create a device scope, which can be used to interact with services running on the iOS device.
+        /// </summary>
+        /// <param name="provider">
+        /// The <see cref="IServiceProvider"/> which provides the required services.
+        /// </param>
+        /// <param name="udid">
+        /// The UDID of the device to which to connect.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a <see cref="IServiceScope"/>
+        /// from which device services (such as lockdown service clients) can be sourced.
+        /// </returns>
+        public static async Task<IServiceScope> CreateDeviceScopeAsync(this IServiceProvider provider, string udid, CancellationToken cancellationToken)
+        {
+            var muxer = provider.GetRequiredService<MuxerClient>();
+            var allDevices = await muxer.ListDevicesAsync(cancellationToken).ConfigureAwait(false);
+
+            // The UDID can be null, in which case we select the first device.
+            var devices = allDevices.Where(
+                d => udid == null
+                || string.Equals(d.Udid, udid, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            if (devices.Length != 1)
+            {
+                throw new MuxerException($"Could not find the device with udid '{udid}'.");
+            }
+
+            var scope = provider.CreateScope();
+
+            var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
+            context.Device = devices[0];
+
+            return scope;
+        }
+    }
+}

--- a/src/Kaponata.iOS/GlobalSuppressions.cs
+++ b/src/Kaponata.iOS/GlobalSuppressions.cs
@@ -10,3 +10,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.PropertyLists")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.NotificationProxy")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Lockdown")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.DependencyInjection")]

--- a/src/Kaponata.iOS/Kaponata.iOS.csproj
+++ b/src/Kaponata.iOS/Kaponata.iOS.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="plist-cil" Version="2.1.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.1" />
   </ItemGroup>

--- a/src/Kaponata.iOS/NotificationProxy/NotificationProxyClientFactory.cs
+++ b/src/Kaponata.iOS/NotificationProxy/NotificationProxyClientFactory.cs
@@ -31,7 +31,7 @@ namespace Kaponata.iOS.NotificationProxy
         /// <param name="logger">
         /// A <see cref="ILogger"/> which can be used when logging.
         /// </param>
-        public NotificationProxyClientFactory(MuxerClient muxer, DeviceContext context, LockdownClientFactory lockdownClientFactory, ILogger<NotificationProxyClient> logger)
+        public NotificationProxyClientFactory(MuxerClient muxer, DeviceContext context, ClientFactory<LockdownClient> lockdownClientFactory, ILogger<NotificationProxyClient> logger)
             : base(muxer, context, lockdownClientFactory, logger)
         {
         }

--- a/src/Kaponata.iOS/ServiceClientFactory.cs
+++ b/src/Kaponata.iOS/ServiceClientFactory.cs
@@ -20,7 +20,7 @@ namespace Kaponata.iOS
     /// </typeparam>
     public abstract class ServiceClientFactory<T> : ClientFactory<T>
     {
-        private readonly LockdownClientFactory factory;
+        private readonly ClientFactory<LockdownClient> factory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceClientFactory{T}"/> class.
@@ -38,7 +38,7 @@ namespace Kaponata.iOS
         /// <param name="logger">
         /// A <see cref="ILogger"/> which can be used when logging.
         /// </param>
-        public ServiceClientFactory(MuxerClient muxer, DeviceContext context, LockdownClientFactory lockdownClientFactory, ILogger<T> logger)
+        public ServiceClientFactory(MuxerClient muxer, DeviceContext context, ClientFactory<LockdownClient> lockdownClientFactory, ILogger<T> logger)
             : base(muxer, context, logger)
         {
             this.factory = lockdownClientFactory ?? throw new ArgumentNullException(nameof(lockdownClientFactory));


### PR DESCRIPTION
This commit adds the ability to register services which interact with devices via dependency injection. It introduces the concept of a "device scope".

A device scope is a scope in which the DeviceContext service is registered. This service contains the information about the device on which the scope interacts.

You can configure a service collection by calling the `AddAppleServices` method. Once the service provider has been built, you can create a device scope by calling the `CreateDeviceScopeAsync` method.

This method takes a `udid` as a parameter (which can be `null` or a specific UDID).