### PR TITLE
Dependency injection: Add convenience methods for starting iOS services.

### DIFF
--- a/src/Kaponata.iOS.Tests/DependencyInjection/DeviceServiceScopeTests.cs
+++ b/src/Kaponata.iOS.Tests/DependencyInjection/DeviceServiceScopeTests.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="DeviceServiceScopeTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DependencyInjection;
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.DependencyInjection
+{
+    /// <summary>
+    /// Tests the <see cref="DeviceServiceScope{T}"/> class.
+    /// </summary>
+    public class DeviceServiceScopeTests
+    {
+        /// <summary>
+        /// The <see cref="DeviceServiceScope{T}"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DeviceServiceScope<LockdownClient>(null, new MuxerDevice(), Mock.Of<LockdownClient>()));
+            Assert.Throws<ArgumentNullException>(() => new DeviceServiceScope<LockdownClient>(Mock.Of<IServiceScope>(), null, Mock.Of<LockdownClient>()));
+            Assert.Throws<ArgumentNullException>(() => new DeviceServiceScope<LockdownClient>(Mock.Of<IServiceScope>(), new MuxerDevice(), null));
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/DependencyInjection/ServiceScopeExtensionsTests.cs
+++ b/src/Kaponata.iOS.Tests/DependencyInjection/ServiceScopeExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="ServiceScopeExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DependencyInjection;
+using Kaponata.iOS.Lockdown;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.DependencyInjection
+{
+    /// <summary>
+    /// Tests the <see cref="ServiceScopeExtensions"/> class.
+    /// </summary>
+    public class ServiceScopeExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="ServiceScopeExtensions.StartServiceAsync{T}(IServiceScope, CancellationToken)"/> returns a service client.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task StartServiceAsync_Works_Async()
+        {
+            var lockdown = new Mock<LockdownClient>(MockBehavior.Strict);
+
+            var lockdownFactory = new Mock<ClientFactory<LockdownClient>>(MockBehavior.Strict);
+            lockdownFactory.Setup(l => l.CreateAsync(default)).ReturnsAsync(lockdown.Object);
+
+            var provider = new ServiceCollection()
+                .AddScoped<DeviceContext>()
+                .AddScoped<ClientFactory<LockdownClient>>((sp) => lockdownFactory.Object)
+                .BuildServiceProvider();
+
+            using (var scope = provider.CreateScope())
+            {
+                Assert.Equal(lockdown.Object, await scope.StartServiceAsync<LockdownClient>(default).ConfigureAwait(false));
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS/DependencyInjection/DeviceServiceScope.cs
+++ b/src/Kaponata.iOS/DependencyInjection/DeviceServiceScope.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="DeviceServiceScope.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Kaponata.iOS.DependencyInjection
+{
+    /// <summary>
+    /// Represents a connection to a service running on a device.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of the serivce running on the device.
+    /// </typeparam>
+    public struct DeviceServiceScope<T> : IDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceServiceScope{T}"/> struct.
+        /// </summary>
+        /// <param name="scope">
+        /// The service scope which represents the connection to the device.
+        /// </param>
+        /// <param name="device">
+        /// The device on which the service is running.
+        /// </param>
+        /// <param name="service">
+        /// A client for the service running on the device.
+        /// </param>
+        public DeviceServiceScope(IServiceScope scope, MuxerDevice device, T service)
+        {
+            this.Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+            this.Device = device ?? throw new ArgumentNullException(nameof(device));
+            this.Service = service ?? throw new ArgumentNullException(nameof(service));
+        }
+
+        /// <summary>
+        /// Gets the service scope which represents the connection to the device.
+        /// </summary>
+        public IServiceScope Scope { get; }
+
+        /// <summary>
+        /// Gets the device on which the service is running.
+        /// </summary>
+        public MuxerDevice Device { get; }
+
+        /// <summary>
+        /// Gets a client for the service running on the device.
+        /// </summary>
+        public T Service { get; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Scope.Dispose();
+        }
+    }
+}

--- a/src/Kaponata.iOS/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Kaponata.iOS/DependencyInjection/ServiceProviderExtensions.cs
@@ -55,5 +55,35 @@ namespace Kaponata.iOS.DependencyInjection
 
             return scope;
         }
+
+        /// <summary>
+        /// Asynchronously creates a device scope and starts a service on a device.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the service to start.
+        /// </typeparam>
+        /// <param name="provider">
+        /// A <see cref="IServiceProvider"/> from which to source the required services.
+        /// </param>
+        /// <param name="udid">
+        /// The UDID of the device to which to connect.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and, when completed,
+        /// returns a <see cref="DeviceServiceScope{T}"/> which provides access to the service running on the device.
+        /// </returns>
+        public static async Task<DeviceServiceScope<T>> StartServiceAsync<T>(this IServiceProvider provider, string udid, CancellationToken cancellationToken)
+        {
+            var scope = await provider.CreateDeviceScopeAsync(udid, cancellationToken).ConfigureAwait(false);
+            var service = await scope.StartServiceAsync<T>(cancellationToken).ConfigureAwait(false);
+
+            return new DeviceServiceScope<T>(
+                scope,
+                device: scope.ServiceProvider.GetRequiredService<DeviceContext>().Device,
+                service);
+        }
     }
 }

--- a/src/Kaponata.iOS/DependencyInjection/ServiceScopeExtensions.cs
+++ b/src/Kaponata.iOS/DependencyInjection/ServiceScopeExtensions.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ServiceScopeExtensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IServiceScope"/> class.
+    /// </summary>
+    public static class ServiceScopeExtensions
+    {
+        /// <summary>
+        /// Asynchronously starts a service on the device.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the service to start.
+        /// </typeparam>
+        /// <param name="scope">
+        /// A <see cref="IServiceScope"/> which represents a device scope.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation, which returns a <typeparamref name="T"/>
+        /// which represents a client for the service running on the device.
+        /// </returns>
+        public static Task<T> StartServiceAsync<T>(this IServiceScope scope, CancellationToken cancellationToken)
+        {
+            var factory = scope.ServiceProvider.GetRequiredService<ClientFactory<T>>();
+            return factory.CreateAsync(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the IServiceProvider.StartServiceAsync<T>(CancellationToken) method which can be used to start a service on an iOS device and connect to that service.

It abstracts away the mechanics of finding the service factory and connecting to the service using the service factory.