### PR TITLE
LockdownClient: Support SSL encryption

### DIFF
--- a/src/Kaponata.iOS.Tests/DependencyInjection/ServiceProviderExtensionsTests.cs
+++ b/src/Kaponata.iOS.Tests/DependencyInjection/ServiceProviderExtensionsTests.cs
@@ -73,7 +73,8 @@ namespace Kaponata.iOS.Tests.DependencyInjection
         [Fact]
         public async Task CreateDeviceScopeAsync_NoUdid_SingleDevice_WorksAsync()
         {
-            var device = new MuxerDevice();
+            var device = new MuxerDevice() { Udid = "udid" };
+            var pairingRecord = new PairingRecord();
 
             var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
             muxer
@@ -82,6 +83,9 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 {
                     device,
                 });
+            muxer
+                .Setup(m => m.ReadPairingRecordAsync("udid", default))
+                .ReturnsAsync(pairingRecord);
 
             var provider = new ServiceCollection()
                 .AddSingleton<MuxerClient>(muxer.Object)
@@ -92,6 +96,7 @@ namespace Kaponata.iOS.Tests.DependencyInjection
             {
                 var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
                 Assert.Same(device, context.Device);
+                Assert.Same(pairingRecord, context.PairingRecord);
             }
         }
 
@@ -129,6 +134,7 @@ namespace Kaponata.iOS.Tests.DependencyInjection
         public async Task CreateDeviceScopeAsync_Udid_Match_ReturnsDeviceAsync()
         {
             var device = new MuxerDevice() { Udid = "2" };
+            var pairingRecord = new PairingRecord();
 
             var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
             muxer
@@ -138,6 +144,9 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                     new MuxerDevice() { Udid = "1" },
                     device,
                 });
+            muxer
+                .Setup(m => m.ReadPairingRecordAsync("2", default))
+                .ReturnsAsync(pairingRecord);
 
             var provider = new ServiceCollection()
                 .AddSingleton<MuxerClient>(muxer.Object)
@@ -148,6 +157,7 @@ namespace Kaponata.iOS.Tests.DependencyInjection
             {
                 var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
                 Assert.Same(device, context.Device);
+                Assert.Same(pairingRecord, context.PairingRecord);
             }
         }
 
@@ -159,11 +169,15 @@ namespace Kaponata.iOS.Tests.DependencyInjection
         public async Task StartServiceAsync_Works_Async()
         {
             var device = new MuxerDevice() { Udid = "2" };
+            var pairingRecord = new PairingRecord();
 
             var muxer = new Mock<MuxerClient>(MockBehavior.Strict);
             muxer
                 .Setup(m => m.ListDevicesAsync(default))
                 .ReturnsAsync(new Collection<MuxerDevice>() { device });
+            muxer
+                .Setup(m => m.ReadPairingRecordAsync("2", default))
+                .ReturnsAsync(pairingRecord);
 
             var client = new Mock<LockdownClient>(MockBehavior.Strict);
 

--- a/src/Kaponata.iOS.Tests/Kaponata.iOS.Tests.csproj
+++ b/src/Kaponata.iOS.Tests/Kaponata.iOS.Tests.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="**/*.bin" CopyToOutputDirectory="PreserveNewest" />
     <None Update="**/*.xml" CopyToOutputDirectory="PreserveNewest" />
     <None Update="**/*.cer" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.Ssl.cs
+++ b/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.Ssl.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="PropertyListProtocolTests.Ssl.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.PropertyLists;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nerdbank.Streams;
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.PropertyLists
+{
+    /// <content>
+    /// Tests the SSL-related methods in the <see cref="PropertyListProtocol"/> class.
+    /// </content>
+    public partial class PropertyListProtocolTests
+    {
+        /// <summary>
+        /// <see cref="PropertyListProtocol.EnableSslAsync(PairingRecord, CancellationToken)"/> throws when passed <see langword="null"/>
+        /// values.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task EnableSslAsync_NullValues_Throws_Async()
+        {
+            var protocol = new PropertyListProtocol(Stream.Null, ownsStream: false, NullLogger.Instance);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => protocol.EnableSslAsync(null, default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="PropertyListProtocol.DisableSslAsync(CancellationToken)"/> throws an exception when SSL is not enabled.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task DisableSslAsync_NotSsl_Throws_Async()
+        {
+            var protocol = new PropertyListProtocol(Stream.Null, ownsStream: false, NullLogger.Instance);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => protocol.DisableSslAsync(default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Tests enabling SSL over a connection with an iOS device, and then disabling that connection, where
+        /// <c>leaveInnerStreamOpen</c> is <see langword="true"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous test.
+        /// </returns>
+        [Fact]
+        public async Task EnableSslAsync_EnableAndDisable_Works_Async()
+        {
+            // Read the pairing record used to authenticate the device & client.
+            var pairingRecord = PairingRecord.Read(File.ReadAllBytes("Lockdown/0123456789abcdef0123456789abcdef01234567.plist"));
+            pairingRecord.DeviceCertificate = pairingRecord.RootCertificate;
+
+            // Set up a client/server connection
+            (var serverStream, var clientStream) = FullDuplexStream.CreatePair();
+
+            // Set up the SSL stream which will act as the server, and have that server
+            // authenticate the client.
+            var sslServer = new SslStream(serverStream, leaveInnerStreamOpen: true);
+            var authenticateSslClientTask = sslServer.AuthenticateAsServerAsync(
+                new SslServerAuthenticationOptions()
+                {
+                    ServerCertificate = pairingRecord.RootCertificate.CopyWithPrivateKeyForSsl(pairingRecord.RootPrivateKey),
+                    EncryptionPolicy = EncryptionPolicy.AllowNoEncryption,
+                    RemoteCertificateValidationCallback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+                    {
+                        return true;
+                    },
+                });
+
+            // Have the client enable SSL on the connection.
+            var protocol = new PropertyListProtocol(clientStream, ownsStream: false, NullLogger.Instance);
+            Assert.False(protocol.SslEnabled);
+
+            var enableSslTask = protocol.EnableSslAsync(pairingRecord, default);
+
+            await Task.WhenAny(
+                Task.WhenAll(authenticateSslClientTask, enableSslTask),
+                Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+
+            if (authenticateSslClientTask.IsFaulted)
+            {
+                await authenticateSslClientTask.ConfigureAwait(false);
+            }
+
+            if (enableSslTask.IsFaulted)
+            {
+                await enableSslTask.ConfigureAwait(false);
+            }
+
+            Assert.True(authenticateSslClientTask.IsCompletedSuccessfully);
+            Assert.True(enableSslTask.IsCompletedSuccessfully);
+            Assert.True(protocol.SslEnabled);
+
+            // An attempt to enable SSL a second time will fail (SSL is already enabled)
+            await Assert.ThrowsAsync<InvalidOperationException>(() => protocol.EnableSslAsync(pairingRecord, default)).ConfigureAwait(false);
+
+            // Send/receive messages in both directions over the encrypted streams
+            await this.PingTestAsync(protocol.Stream, sslServer).ConfigureAwait(false);
+            await this.PingTestAsync(sslServer, protocol.Stream).ConfigureAwait(false);
+
+            // Disable SSL
+            var disableSslTask = protocol.DisableSslAsync(default);
+            var stopSslServerTask = sslServer.ShutdownAsync();
+
+            await Task.WhenAny(
+                Task.WhenAll(
+                    disableSslTask,
+                    stopSslServerTask),
+                Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+
+            // Flush the any pending SSL packets on the SSL server side.
+            // This is simlar to what's implemented in SslFactory.DisableSessionSslCore
+            byte[] readBuffer = new byte[128];
+            await serverStream.ReadAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false);
+
+            Assert.False(protocol.SslEnabled);
+
+            // Send/receive messages in both directions over the unencrypted streams
+            await this.PingTestAsync(serverStream, clientStream).ConfigureAwait(false);
+            await this.PingTestAsync(clientStream, serverStream).ConfigureAwait(false);
+
+            await serverStream.DisposeAsync().ConfigureAwait(true);
+            await clientStream.DisposeAsync().ConfigureAwait(true);
+        }
+
+        private async Task PingTestAsync(Stream sourceStream, Stream targetStream)
+        {
+            byte[] ping = Encoding.UTF8.GetBytes("ping");
+            byte[] output = new byte[ping.Length];
+
+            var writeTask = sourceStream.WriteAsync(ping, 0, ping.Length);
+            var readTask = targetStream.ReadAsync(output, 0, output.Length);
+
+            await Task.WhenAny(
+                Task.WhenAll(
+                    writeTask,
+                    readTask),
+                Task.Delay(TimeSpan.FromSeconds(5)));
+
+            await writeTask.ConfigureAwait(false);
+            int read = await readTask.ConfigureAwait(false);
+
+            Assert.Equal(4, read);
+            Assert.Equal(ping, output);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.cs
+++ b/src/Kaponata.iOS.Tests/PropertyLists/PropertyListProtocolTests.cs
@@ -17,7 +17,7 @@ namespace Kaponata.iOS.Tests.PropertyLists
     /// <summary>
     /// Tests the <see cref="PropertyListProtocol"/> class.
     /// </summary>
-    public class PropertyListProtocolTests
+    public partial class PropertyListProtocolTests
     {
         /// <summary>
         /// The <see cref="PropertyListProtocol"/> constructor validates its arguments.

--- a/src/Kaponata.iOS.Tests/PropertyLists/X509Certificate2ExtensionsTests.cs
+++ b/src/Kaponata.iOS.Tests/PropertyLists/X509Certificate2ExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿// <copyright file="X509Certificate2ExtensionsTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.PropertyLists;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.PropertyLists
+{
+    /// <summary>
+    /// Tests the <see cref="X509Certificate2Extensions"/> class.
+    /// </summary>
+    public class X509Certificate2ExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="X509Certificate2Extensions.CopyWithPrivateKeyForSsl(X509Certificate2, RSA)"/> throws an exception
+        /// when passed <see langword="null"/> values.
+        /// </summary>
+        [Fact]
+        public void CopyWithPrivateKeyForSsl_ThrowsOnNull()
+        {
+            var pairingRecord = PairingRecord.Read(File.ReadAllBytes("Lockdown/0123456789abcdef0123456789abcdef01234567.plist"));
+
+            Assert.Throws<ArgumentNullException>(() => X509Certificate2Extensions.CopyWithPrivateKeyForSsl(pairingRecord.HostCertificate, null));
+            Assert.Throws<ArgumentNullException>(() => X509Certificate2Extensions.CopyWithPrivateKeyForSsl(null, pairingRecord.HostPrivateKey));
+        }
+
+        /// <summary>
+        /// <see cref="X509Certificate2Extensions.CopyWithPrivateKeyForSsl(X509Certificate2, RSA)"/> returns a new certificate
+        /// with a private key. On Windows, the private key is not ephemeral.
+        /// </summary>
+        [Fact]
+        public void CopyWithPrivateKeyForSsl_Works()
+        {
+            var pairingRecord = PairingRecord.Read(File.ReadAllBytes("Lockdown/0123456789abcdef0123456789abcdef01234567.plist"));
+
+            using (var certificate = pairingRecord.HostCertificate.CopyWithPrivateKeyForSsl(pairingRecord.HostPrivateKey))
+            {
+                Assert.NotNull(certificate.PrivateKey);
+
+                // On Windows, because of a SCHANNEL bug (https://github.com/dotnet/runtime/issues/23749#issuecomment-485947319), private keys
+                // for certificates cannot be marked as ephemeral because the in-memory TLS client certificate private key is not marshaled
+                // between SCHANNEL and LSASS. Make sure the private key is not ephemeral.
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var key = Assert.IsType<RSACng>(certificate.PrivateKey);
+                    Assert.False(key.Key.IsEphemeral);
+                }
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Kaponata.iOS/DependencyInjection/ServiceProviderExtensions.cs
@@ -53,6 +53,8 @@ namespace Kaponata.iOS.DependencyInjection
             var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
             context.Device = devices[0];
 
+            context.PairingRecord = await muxer.ReadPairingRecordAsync(context.Device.Udid, cancellationToken).ConfigureAwait(false);
+
             return scope;
         }
 

--- a/src/Kaponata.iOS/DeviceContext.cs
+++ b/src/Kaponata.iOS/DeviceContext.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using Kaponata.iOS.Lockdown;
 using Kaponata.iOS.Muxer;
 
 namespace Kaponata.iOS
@@ -17,5 +18,10 @@ namespace Kaponata.iOS
         /// Gets or sets the device to which the session is scoped.
         /// </summary>
         public MuxerDevice Device { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="PairingRecord"/> for this device, if available.
+        /// </summary>
+        public PairingRecord PairingRecord { get; set; }
     }
 }

--- a/src/Kaponata.iOS/PropertyLists/PropertyListProtocol.Ssl.cs
+++ b/src/Kaponata.iOS/PropertyLists/PropertyListProtocol.Ssl.cs
@@ -1,0 +1,121 @@
+﻿// <copyright file="PropertyListProtocol.Ssl.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.PropertyLists
+{
+    /// <content>
+    /// SSL-related methods for the <see cref="PropertyListProtocol"/> class.
+    /// </content>
+    public partial class PropertyListProtocol
+    {
+        /// <summary>
+        /// Gets a value indicating whether the communication with the device is secured using SSL.
+        /// </summary>
+        public virtual bool SslEnabled => this.stream != this.rawStream;
+
+        /// <summary>
+        /// Asynchronously enables SSL communications with the device.
+        /// </summary>
+        /// <param name="pairingRecord">
+        /// A <see cref="PairingRecord"/> which contains the certificates used to authenticate the host and the device.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public virtual async Task EnableSslAsync(PairingRecord pairingRecord, CancellationToken cancellationToken)
+        {
+            if (pairingRecord == null)
+            {
+                throw new ArgumentNullException(nameof(pairingRecord));
+            }
+
+            if (this.stream is SslStream)
+            {
+                throw new InvalidOperationException("This connection is already using SSL");
+            }
+
+            // This block of code constructs a TLS ("SSL") stream which enables you to connect with lockdown over an encrypted
+            // connection. It uses the built-in SslStream class.
+
+            // AllowNoEncryption will use OpenSSL security policy/level 0, see
+            // https://github.com/dotnet/runtime/blob/master/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+            // https://github.com/dotnet/runtime/blob/master/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+            // When using security policy/level 1, the root CA may be rejected on Ubuntu 20.04 (which uses OpenSSL 1.1)
+            var encryptionPolicy = EncryptionPolicy.AllowNoEncryption;
+
+            var sslStream = new SslStream(
+                innerStream: this.stream,
+                leaveInnerStreamOpen: true,
+                userCertificateSelectionCallback: (object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] acceptableIssuers) =>
+                {
+                    return localCertificates[0];
+                },
+                userCertificateValidationCallback: (sender, certificate, chain, sslPolicyErrors) =>
+                {
+                    var expectedDeviceCertHash = pairingRecord.DeviceCertificate.GetCertHashString();
+                    var actualDeviceCertHash = certificate.GetCertHashString();
+
+                    return string.Equals(expectedDeviceCertHash, actualDeviceCertHash, StringComparison.OrdinalIgnoreCase);
+                },
+                encryptionPolicy: encryptionPolicy);
+
+            X509CertificateCollection clientCertificates = new X509CertificateCollection();
+            clientCertificates.Add(pairingRecord.HostCertificate.CopyWithPrivateKeyForSsl(pairingRecord.HostPrivateKey));
+
+            await sslStream.AuthenticateAsClientAsync(
+                pairingRecord.DeviceCertificate.Subject,
+                clientCertificates,
+                SslProtocols.Tls12,
+                checkCertificateRevocation: false).ConfigureAwait(false);
+
+            this.stream = sslStream;
+        }
+
+        /// <summary>
+        /// Asynchronously terminates the secure connection between the device and the host. When this method has completes,
+        /// communication with the device will continue using plain text.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public virtual async Task DisableSslAsync(CancellationToken cancellationToken)
+        {
+            var sslStream = this.stream as SslStream;
+
+            if (sslStream == null)
+            {
+                throw new InvalidOperationException("The session is not using SSL");
+            }
+
+            // Initiate a shutdown
+            await sslStream.ShutdownAsync().ConfigureAwait(false);
+
+            // The remote end (the device) will send an alert acknowledging the shutdown. We need to manually
+            // read data to force the SslStream class to process that alert. The SslStream will process the alert
+            // and let us know that 0 bytes of data have been read.
+            byte[] readBuffer = new byte[128];
+            int bytesRead = await sslStream.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken).ConfigureAwait(false);
+            Debug.Assert(bytesRead == 0, "A SSL stream should not return data after a shutdown command.");
+
+            await sslStream.DisposeAsync();
+
+            this.stream = this.rawStream;
+        }
+    }
+}

--- a/src/Kaponata.iOS/PropertyLists/X509Certificate2Extensions.cs
+++ b/src/Kaponata.iOS/PropertyLists/X509Certificate2Extensions.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="X509Certificate2Extensions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Kaponata.iOS.PropertyLists
+{
+    /// <summary>
+    /// Extension methods for <see cref="X509Certificate2"/> certificates.
+    /// </summary>
+    public static class X509Certificate2Extensions
+    {
+        /// <summary>
+        /// Combines a private key with the public key of an <see cref="RSA"/> certificate to generate a new RSA certificate.
+        /// </summary>
+        /// <param name="certificate">
+        /// The RSA certificate.
+        /// </param>
+        /// <param name="privateKey">
+        /// The private RSA key.
+        /// </param>
+        /// <returns>
+        /// A new RSA certificate with the <see cref="X509Certificate2.HasPrivateKey"/> property set to <see langword="true"/>.
+        /// On Windows, the private key is guaranteed to not be ephemeral.
+        /// The input RSA certificate object isn't modified.
+        /// </returns>
+        public static X509Certificate2 CopyWithPrivateKeyForSsl(this X509Certificate2 certificate, RSA privateKey)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                using (var cert = certificate.CopyWithPrivateKey(privateKey))
+                {
+                    return new X509Certificate2(cert.Export(X509ContentType.Pkcs12));
+                }
+            }
+            else
+            {
+                return certificate.CopyWithPrivateKey(privateKey);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for enabling SSL encryption after staring a lockdown session.

It includes a bit of a workaround on Windows, because certificate authentication on the `SslStream` cannot use ephemeral keys: https://github.com/dotnet/runtime/issues/45680 / https://github.com/dotnet/runtime/issues/23749