### PR TITLE
Deploy a Docker registry as part of Kaponata

### DIFF
--- a/src/Kaponata.Chart.Tests/RegistryTests.cs
+++ b/src/Kaponata.Chart.Tests/RegistryTests.cs
@@ -1,0 +1,83 @@
+﻿// <copyright file="RegistryTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+using k8s;
+using Kaponata.Kubernetes;
+using Kaponata.Kubernetes.Polyfill;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Chart.Tests
+{
+    /// <summary>
+    /// Tests the Registry deployment.
+    /// </summary>
+    public class RegistryTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegistryTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// The test output helper which will be used to log to xunit.
+        /// </param>
+        public RegistryTests(ITestOutputHelper output)
+        {
+            this.loggerFactory = LogFactory.Create(output);
+            this.output = output;
+        }
+
+        /// <summary>
+        /// At least one registry pod is running and responding to HTTP requests.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task Registry_Running_Async()
+        {
+            var config = KubernetesClientConfiguration.BuildDefaultConfig();
+            if (config.Namespace == null)
+            {
+                config.Namespace = "default";
+            }
+
+            using (var kubernetes = new KubernetesProtocol(
+                config,
+                this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                this.loggerFactory))
+            using (var client = new KubernetesClient(
+                kubernetes,
+                KubernetesOptions.Default,
+                this.output.BuildLoggerFor<KubernetesClient>(),
+                this.loggerFactory))
+            {
+                // There's at least one usbmuxd pod
+                var pods = await kubernetes.ListNamespacedPodAsync(config.Namespace, labelSelector: "app.kubernetes.io/component=registry");
+                Assert.NotEmpty(pods.Items);
+                var pod = pods.Items[0];
+
+                // The pod is in the running state
+                pod = await client.WaitForPodRunningAsync(pod, TimeSpan.FromMinutes(2), default).ConfigureAwait(false);
+                Assert.Equal("Running", pod.Status.Phase);
+
+                // Try to perform a handshake
+                var httpClient = client.CreatePodHttpClient(pod, 5000);
+                httpClient.BaseAddress = new Uri($"http://{pod.Metadata.Name}:5000/v2/");
+
+                var response = await httpClient.GetAsync(string.Empty).ConfigureAwait(false);
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                var apiVersion = Assert.Single(response.Headers.GetValues("Docker-Distribution-Api-Version"));
+                Assert.Equal("registry/2.0", apiVersion);
+            }
+        }
+    }
+}

--- a/src/chart/templates/_helpers.tpl
+++ b/src/chart/templates/_helpers.tpl
@@ -155,3 +155,31 @@ app.kubernetes.io/name: {{ include "kaponata.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: "operator"
 {{- end }}
+
+{{/*
+Registry: Full Name
+*/}}
+{{- define "registry.fullname" -}}
+{{- printf "%s-registry" (include "kaponata.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Registry: Common labels
+*/}}
+{{- define "registry.labels" -}}
+helm.sh/chart: {{ include "kaponata.chart" . }}
+{{ include "registry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Registry: Selector labels
+*/}}
+{{- define "registry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kaponata.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "registry"
+{{- end }}

--- a/src/chart/templates/registry-service.yaml
+++ b/src/chart/templates/registry-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "registry.fullname" . }}
+  labels:
+    {{- include "registry.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "registry.selectorLabels" . | nindent 4 }}

--- a/src/chart/templates/registry-statefulset.yaml
+++ b/src/chart/templates/registry-statefulset.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+
+# The registry uses a StatefulSet to ensure the PVC/PV is reusable
+# when the pod is deleted / recreated
+kind: StatefulSet
+metadata:
+  name: {{ template "registry.fullname" . }}
+  labels:
+    {{- include "registry.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ template "registry.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "registry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "registry.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "operator"
+          image: "{{ .Values.registry.image.repository }}:{{ tpl .Values.registry.image.tag . }}"
+          imagePullPolicy: "{{ .Values.registry.imagePullPolicy }}"
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry/
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "local-path"
+      resources:
+        requests:
+          storage: 1Gi

--- a/src/chart/values.yaml
+++ b/src/chart/values.yaml
@@ -8,4 +8,10 @@ api:
   image:
     repository: quay.io/kaponata/api
     tag: latest-amd64
-imagePullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent
+
+registry:
+  image:
+    repository: registry
+    tag: "2.7"
+  imagePullPolicy: IfNotPresent


### PR DESCRIPTION
We will store the iOS developer disk images as container images in the Docker registry.

By default, the registry will use "local-path" storage. This is
(non-redundant) cluster-local storage and is enable by default
in k3s clusters.

The registry is deployed as a StatefulSet to ensure the PVC
can be reused after redeploying the same helm chart.

Contributes towards #220 