### PR TITLE
XZ fixes: fix struct layout, spanify code

### DIFF
--- a/src/Kaponata.FileFormats.Tests/Kaponata.FileFormats.Tests.csproj
+++ b/src/Kaponata.FileFormats.Tests/Kaponata.FileFormats.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kaponata.FileFormats.Tests/Lzma/LzmaStreamTests.cs
+++ b/src/Kaponata.FileFormats.Tests/Lzma/LzmaStreamTests.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="LzmaStreamTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.FileFormats.Lzma;
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Kaponata.FileFormats.Tests.Lzma
+{
+    /// <summary>
+    /// Tests the <see cref="LzmaStream"/> struct.
+    /// </summary>
+    public class LzmaStreamTests
+    {
+        /// <summary>
+        /// Tests the layout of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        [Fact]
+        public unsafe void LayoutTest()
+        {
+            switch (sizeof(nint))
+            {
+                case 8:
+                    Assert.Equal(0x0, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.NextIn)).ToInt32());
+                    Assert.Equal(0x8, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.AvailIn)).ToInt32());
+                    Assert.Equal(0x10, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.TotalIn)).ToInt32());
+                    Assert.Equal(0x18, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.NextOut)).ToInt32());
+                    Assert.Equal(0x20, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.AvailOut)).ToInt32());
+                    Assert.Equal(0x28, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.TotalOut)).ToInt32());
+                    Assert.Equal(0x30, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.Allocator)).ToInt32());
+                    Assert.Equal(0x38, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.InternalState)).ToInt32());
+                    Assert.Equal(0x40, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr1)).ToInt32());
+                    Assert.Equal(0x48, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr2)).ToInt32());
+                    Assert.Equal(0x50, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr3)).ToInt32());
+                    Assert.Equal(0x58, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr4)).ToInt32());
+                    Assert.Equal(0x60, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.SeekPos)).ToInt32());
+                    Assert.Equal(0x68, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedInt2)).ToInt32());
+                    Assert.Equal(0x70, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedInt3)).ToInt32());
+                    Assert.Equal(0x78, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedInt4)).ToInt32());
+                    Assert.Equal(0x80, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedEnum1)).ToInt32());
+                    Assert.Equal(0x84, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedEnum2)).ToInt32());
+
+                    Assert.Equal(0x88, Marshal.SizeOf<LzmaStream>());
+                    break;
+
+                case 4:
+                    Assert.Equal(0x0, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.NextIn)).ToInt32());
+                    Assert.Equal(0x4, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.AvailIn)).ToInt32());
+                    Assert.Equal(0x8, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.TotalIn)).ToInt32());
+                    Assert.Equal(0x10, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.NextOut)).ToInt32());
+                    Assert.Equal(0x14, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.AvailOut)).ToInt32());
+                    Assert.Equal(0x18, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.TotalOut)).ToInt32());
+                    Assert.Equal(0x20, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.Allocator)).ToInt32());
+                    Assert.Equal(0x24, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.InternalState)).ToInt32());
+                    Assert.Equal(0x28, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr1)).ToInt32());
+                    Assert.Equal(0x2c, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr2)).ToInt32());
+                    Assert.Equal(0x30, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr3)).ToInt32());
+                    Assert.Equal(0x34, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedPtr4)).ToInt32());
+                    Assert.Equal(0x38, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.SeekPos)).ToInt32());
+                    Assert.Equal(0x40, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedInt2)).ToInt32());
+                    Assert.Equal(0x48, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedInt3)).ToInt32());
+                    Assert.Equal(0x4c, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedInt4)).ToInt32());
+                    Assert.Equal(0x50, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedEnum1)).ToInt32());
+                    Assert.Equal(0x54, Marshal.OffsetOf<LzmaStream>(nameof(LzmaStream.ReservedEnum2)).ToInt32());
+
+                    Assert.Equal(0x58, Marshal.SizeOf<LzmaStream>());
+                    break;
+
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/Kaponata.FileFormats/Lzma/LzmaResult.cs
+++ b/src/Kaponata.FileFormats/Lzma/LzmaResult.cs
@@ -230,5 +230,27 @@ namespace Kaponata.FileFormats.Lzma
         /// </para>
         /// </remarks>
         ProgError = 11,
+
+        /// <summary>
+        /// Request to change the input file position.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Some coders can do random access in the input file. The
+        /// initialization functions of these coders take the file size
+        /// as an argument. No other coders can return <see cref="SeekNeeded"/>.
+        /// </para>
+        /// <para>
+        /// When this value is returned, the application must seek to
+        /// the file position given in <see cref="LzmaStream.SeekPos"/>. This value
+        /// is guaranteed to never exceed the file size that was
+        /// specified at the coder initialization.
+        /// </para>
+        /// <para>
+        /// After seeking the application should read new input and
+        /// pass it normally via <see cref="LzmaStream.NextIn"/> and <see cref="LzmaStream.AvailIn"/>.
+        /// </para>
+        /// </remarks>
+        SeekNeeded = 12,
     }
 }

--- a/src/Kaponata.FileFormats/Lzma/LzmaStream.cs
+++ b/src/Kaponata.FileFormats/Lzma/LzmaStream.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Kaponata.FileFormats.Lzma
@@ -57,17 +56,17 @@ namespace Kaponata.FileFormats.Lzma
     /// </para>
     /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
-    internal struct LzmaStream
+    public unsafe struct LzmaStream
     {
         /// <summary>
         /// Pointer to the next input byte.
         /// </summary>
-        public IntPtr NextIn;
+        public byte* NextIn;
 
         /// <summary>
         /// Number of available input bytes in next_in.
         /// </summary>
-        public uint AvailIn;
+        public nuint AvailIn;
 
         /// <summary>
         /// Total number of bytes read by liblzma.
@@ -77,12 +76,12 @@ namespace Kaponata.FileFormats.Lzma
         /// <summary>
         /// Pointer to the next output position.
         /// </summary>
-        public IntPtr NextOut;
+        public byte* NextOut;
 
         /// <summary>
         /// Amount of free space in next_out.
         /// </summary>
-        public uint AvailOut;
+        public nuint AvailOut;
 
         /// <summary>
         /// Total number of bytes written by liblzma.
@@ -96,30 +95,62 @@ namespace Kaponata.FileFormats.Lzma
         /// In most cases this is NULL which makes liblzma use
         /// the standard malloc() and free().
         /// </remarks>
-        public IntPtr Allocator;
+        public void* Allocator;
 
         /// <summary>
         /// Internal state is not visible to applications.
         /// </summary>
 #pragma warning disable SA1214 // Readonly fields must appear before non-readonly fields
-        public readonly IntPtr InternalState;
-#pragma warning restore SA1214 // Readonly fields must appear before non-readonly fields
+        public readonly void* InternalState;
 
         /// <summary>
-        /// Reserved space to allow possible future extensions without
-        /// breaking the ABI. Excluding the initialization of this structure,
-        /// you should not touch these, because the names of these variables
-        /// may change.
+        /// This is the first pointer field of the reserved space of the <see cref="LzmaStream"/> struct.
         /// </summary>
-        private readonly IntPtr reservedPtr1;
-        private readonly IntPtr reservedPtr2;
-        private readonly IntPtr reservedPtr3;
-        private readonly IntPtr reservedPtr4;
-        private readonly ulong reservedInt1;
-        private readonly ulong reservedInt2;
-        private readonly uint reservedInt3;
-        private readonly uint reservedInt4;
-        private readonly uint reservedEnum1;
-        private readonly uint reservedEnum2;
+        public readonly void* ReservedPtr1;
+
+        /// <summary>
+        /// This is the second pointer field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly void* ReservedPtr2;
+
+        /// <summary>
+        /// This is the third pointer field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly void* ReservedPtr3;
+
+        /// <summary>
+        /// This is the fourth pointer field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly void* ReservedPtr4;
+
+        /// <summary>
+        /// New seek input position for <see cref="LzmaResult.SeekNeeded"/>.
+        /// </summary>
+        public ulong SeekPos;
+
+        /// <summary>
+        /// This is the second integer field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly ulong ReservedInt2;
+
+        /// <summary>
+        /// This is the third integer field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly nuint ReservedInt3;
+
+        /// <summary>
+        /// This is the fourth integer field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly nuint ReservedInt4;
+
+        /// <summary>
+        /// This is the first enum field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly uint ReservedEnum1;
+
+        /// <summary>
+        /// This is the second enum field of the reserved space of the <see cref="LzmaStream"/> struct.
+        /// </summary>
+        public readonly uint ReservedEnum2;
     }
 }

--- a/src/Kaponata.FileFormats/Lzma/XZInputStream.cs
+++ b/src/Kaponata.FileFormats/Lzma/XZInputStream.cs
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -38,10 +37,13 @@ namespace Kaponata.FileFormats.Lzma
         /// </summary>
         private const int BufSize = 512;
 
-        private readonly List<byte> internalBuffer = new List<byte>();
         private readonly Stream innerStream;
+        private readonly Ownership ownership;
+
         private readonly IntPtr inbuf;
         private readonly IntPtr outbuf;
+        private int outbufProcessed;
+
         private LzmaStream lzmaStream;
         private long length;
         private long position;
@@ -87,6 +89,7 @@ namespace Kaponata.FileFormats.Lzma
             this.outbuf = Marshal.AllocHGlobal(BufSize);
 
             this.lzmaStream.AvailIn = 0;
+            this.lzmaStream.NextIn = this.inbuf;
             this.lzmaStream.NextOut = this.outbuf;
             this.lzmaStream.AvailOut = BufSize;
 
@@ -225,21 +228,26 @@ namespace Kaponata.FileFormats.Lzma
         /// The number of bytes to read.
         /// </param>
         /// <returns>byte read or -1 on end of stream.</returns>
-        public override int Read(byte[] buffer, int offset, int count)
+        public unsafe override int Read(byte[] buffer, int offset, int count)
         {
             this.EnsureNotDisposed();
 
-            var action = LzmaAction.Run;
-
-            var readBuf = new byte[BufSize];
-            var outManagedBuf = new byte[BufSize];
-
-            while (this.internalBuffer.Count < count)
+            // Make sure data is available in the output buffer.
+            while (this.lzmaStream.AvailOut == BufSize - this.outbufProcessed)
             {
+                LzmaAction action = LzmaAction.Run;
+
+                if (this.lzmaStream.AvailOut == 0)
+                {
+                    this.lzmaStream.AvailOut = BufSize;
+                    this.lzmaStream.NextOut = (byte*)this.outbuf;
+                    this.outbufProcessed = 0;
+                }
+
                 if (this.lzmaStream.AvailIn == 0)
                 {
-                    this.lzmaStream.AvailIn = (uint)this.innerStream.Read(readBuf, 0, readBuf.Length);
-                    Marshal.Copy(readBuf, 0, this.inbuf, (int)this.lzmaStream.AvailIn);
+                    Span<byte> inputBuffer = new Span<byte>((void*)this.inbuf, BufSize);
+                    this.lzmaStream.AvailIn = (uint)this.innerStream.Read(inputBuffer);
                     this.lzmaStream.NextIn = this.inbuf;
 
                     if (this.lzmaStream.AvailIn == 0)
@@ -248,49 +256,33 @@ namespace Kaponata.FileFormats.Lzma
                     }
                 }
 
+                // Decode the data.
                 var ret = NativeMethods.lzma_code(ref this.lzmaStream, action);
 
-                if (this.lzmaStream.AvailOut == 0 || ret == LzmaResult.StreamEnd)
+                if (ret == LzmaResult.StreamEnd)
                 {
-                    var writeSize = BufSize - (int)this.lzmaStream.AvailOut;
-                    Marshal.Copy(this.outbuf, outManagedBuf, 0, writeSize);
-
-                    this.internalBuffer.AddRange(outManagedBuf);
-                    var tail = outManagedBuf.Length - writeSize;
-                    this.internalBuffer.RemoveRange(this.internalBuffer.Count - tail, tail);
-
-                    this.lzmaStream.NextOut = this.outbuf;
-                    this.lzmaStream.AvailOut = BufSize;
+                    break;
                 }
-
-                if (ret != LzmaResult.OK)
+                else if (ret != LzmaResult.OK)
                 {
-                    if (ret == LzmaResult.StreamEnd)
-                    {
-                        break;
-                    }
-
                     NativeMethods.lzma_end(ref this.lzmaStream);
-
                     LzmaException.ThrowOnError(ret);
                 }
             }
 
-            if (this.internalBuffer.Count >= count)
-            {
-                this.internalBuffer.CopyTo(0, buffer, offset, count);
-                this.internalBuffer.RemoveRange(0, count);
-                this.position += count;
-                return count;
-            }
-            else
-            {
-                var intBufLength = this.internalBuffer.Count;
-                this.internalBuffer.CopyTo(0, buffer, offset, intBufLength);
-                this.internalBuffer.Clear();
-                this.position += intBufLength;
-                return intBufLength;
-            }
+            // Get the amount of data which can be copied
+            var canRead = Math.Min(
+                BufSize - (int)this.lzmaStream.AvailOut - this.outbufProcessed,
+                count);
+
+            var source = new Span<byte>((byte*)this.outbuf + this.outbufProcessed, canRead);
+            var target = new Span<byte>(buffer, offset, canRead);
+            source.CopyTo(target);
+
+            this.outbufProcessed += canRead;
+            this.position += canRead;
+
+            return canRead;
         }
 
         /// <inheritdoc/>

--- a/src/Kaponata.FileFormats/Lzma/XZOutputStream.cs
+++ b/src/Kaponata.FileFormats/Lzma/XZOutputStream.cs
@@ -313,10 +313,10 @@ namespace Kaponata.FileFormats.Lzma
                 LzmaResult ret;
                 fixed (byte* inbuf = &buffer[offset])
                 {
-                    this.lzmaStream.NextIn = (IntPtr)inbuf;
+                    this.lzmaStream.NextIn = inbuf;
                     fixed (byte* outbuf = &this.outbuf[BufSize - this.lzmaStream.AvailOut])
                     {
-                        this.lzmaStream.NextOut = (IntPtr)outbuf;
+                        this.lzmaStream.NextOut = outbuf;
                         ret = NativeMethods.lzma_code(ref this.lzmaStream, LzmaAction.Run);
                     }
 
@@ -342,14 +342,14 @@ namespace Kaponata.FileFormats.Lzma
         protected override void Dispose(bool disposing)
         {
             // finish encoding only if all input has been successfully processed
-            if (this.lzmaStream.InternalState != IntPtr.Zero && this.lzmaStream.AvailIn == 0)
+            if (this.lzmaStream.InternalState != null && this.lzmaStream.AvailIn == 0)
             {
                 LzmaResult ret;
                 do
                 {
                     fixed (byte* outbuf = &this.outbuf[BufSize - (int)this.lzmaStream.AvailOut])
                     {
-                        this.lzmaStream.NextOut = (IntPtr)outbuf;
+                        this.lzmaStream.NextOut = outbuf;
                         ret = NativeMethods.lzma_code(ref this.lzmaStream, LzmaAction.Finish);
                     }
 


### PR DESCRIPTION
- Fix the layout of the `LzmaStream` struct, which would cause random issues on 64-bit platforms.
- Spanify the `XZInputStream` class