### PR TITLE
Support packaging the developer disk as a container image.

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/DeveloperDisks/DeveloperDiskRegistryImageFactoryTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/DeveloperDisks/DeveloperDiskRegistryImageFactoryTests.cs
@@ -1,0 +1,166 @@
+﻿// <copyright file="DeveloperDiskRegistryImageFactoryTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.FileFormats;
+using Kaponata.FileFormats.Tar;
+using Kaponata.iOS;
+using Kaponata.iOS.DeveloperDisks;
+using Kaponata.Kubernetes.DeveloperDisks;
+using Kaponata.Kubernetes.Registry;
+using Nerdbank.Streams;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.DeveloperDisks
+{
+    /// <summary>
+    /// Tests the <see cref="DeveloperDiskRegistryImageFactory"/> class.
+    /// </summary>
+    public class DeveloperDiskRegistryImageFactoryTests
+    {
+        /// <summary>
+        /// <see cref="DeveloperDiskRegistryImageFactory.CreateRegistryImageAsync(DeveloperDisk, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task Create_ValidatesArguments_Async()
+        {
+            var factory = new DeveloperDiskRegistryImageFactory();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateRegistryImageAsync(null, default));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskRegistryImageFactory.CreateRegistryImageAsync(DeveloperDisk, CancellationToken)"/> returns a proper manifest,
+        /// image configuration and RootFS layer.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task Create_Works_Async()
+        {
+            var disk = new DeveloperDisk()
+            {
+                Image = new MemoryStream(Encoding.UTF8.GetBytes("Hello, world!")),
+                Signature = new byte[] { 1, 2, 3, 4 },
+                Version = new SystemVersion()
+                {
+                    BuildID = new Guid("5abf1921-e3e3-4bfc-94c5-6c6805f23815"),
+                    ProductBuildVersion = new AppleVersion(1, 'A', 1),
+                    ProductCopyright = "Quamotion bv",
+                    ProductName = "Kaponata",
+                    ProductVersion = new Version(1, 0),
+                },
+                CreationTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            var factory = new DeveloperDiskRegistryImageFactory();
+            (var manifest, var configStream, var layerStream) = await factory.CreateRegistryImageAsync(disk, default).ConfigureAwait(false);
+
+            Assert.NotNull(manifest);
+            Assert.NotNull(configStream);
+            Assert.Equal(0, configStream.Position);
+            Assert.NotEqual(0, configStream.Length);
+
+            Assert.NotNull(layerStream);
+            Assert.Equal(0, layerStream.Position);
+            Assert.NotEqual(0, layerStream.Length);
+
+            var config = await JsonSerializer.DeserializeAsync<Image>(configStream, default).ConfigureAwait(false);
+
+            // The RootFS is a Tar archive which contains the developer disk image, signature and a copy of the SystemVersion.plist file
+            var reader = new TarReader(layerStream);
+            (TarHeader? header, Stream entryStream) = await reader.ReadAsync(default).ConfigureAwait(false);
+            Assert.Equal("SystemVersion.plist", header.Value.FileName);
+            Assert.Equal(477u, header.Value.FileSize);
+            Assert.Equal(LinuxFileMode.S_IFREG | LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR, header.Value.FileMode);
+            Assert.Equal(string.Empty, header.Value.UserName);
+            Assert.Equal(string.Empty, header.Value.GroupName);
+
+            var systemVersion = new SystemVersion();
+            systemVersion.FromDictionary((NSDictionary)PropertyListParser.Parse(entryStream));
+            Assert.Equal(new AppleVersion(1, 'A', 1), systemVersion.ProductBuildVersion);
+            Assert.Equal(new Version(1, 0), systemVersion.ProductVersion);
+
+            (header, entryStream) = await reader.ReadAsync(default).ConfigureAwait(false);
+            Assert.Equal("DeveloperDiskImage.dmg", header.Value.FileName);
+            Assert.Equal(13u, header.Value.FileSize);
+            Assert.Equal(LinuxFileMode.S_IFREG | LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR, header.Value.FileMode);
+            Assert.Equal(string.Empty, header.Value.UserName);
+            Assert.Equal(string.Empty, header.Value.GroupName);
+            byte[] buffer = new byte[header.Value.FileSize];
+            await entryStream.ReadBlockOrThrowAsync(buffer).ConfigureAwait(false);
+            Assert.Equal("Hello, world!", Encoding.UTF8.GetString(buffer));
+
+            (header, entryStream) = await reader.ReadAsync(default).ConfigureAwait(false);
+            Assert.Equal("DeveloperDiskImage.dmg.signature", header.Value.FileName);
+            Assert.Equal(4u, header.Value.FileSize);
+            Assert.Equal(LinuxFileMode.S_IFREG | LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR, header.Value.FileMode);
+            Assert.Equal(string.Empty, header.Value.UserName);
+            Assert.Equal(string.Empty, header.Value.GroupName);
+            await entryStream.ReadBlockOrThrowAsync(buffer.AsMemory(0, 4)).ConfigureAwait(false);
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, buffer.AsSpan(0, 4).ToArray());
+
+            (header, entryStream) = await reader.ReadAsync(default).ConfigureAwait(false);
+            Assert.Equal(string.Empty, header.Value.FileName);
+
+            (header, entryStream) = await reader.ReadAsync(default).ConfigureAwait(false);
+            Assert.Equal(string.Empty, header.Value.FileName);
+
+            (header, entryStream) = await reader.ReadAsync(default).ConfigureAwait(false);
+            Assert.Null(header);
+
+            // The configuration file
+            Assert.Equal("arm64", config.Architecture);
+            Assert.Null(config.Author);
+            Assert.Null(config.Config);
+            Assert.Null(config.Created);
+            Assert.Null(config.History);
+            Assert.Equal("ios", config.OS);
+            Assert.Equal("layers", config.RootFS.Type);
+            Assert.Collection(
+                config.RootFS.DiffIDs,
+                i => Assert.Equal("sha256:caad51da051d60541b2544a5984bdfc44ebceb894069007ad63b2ec073c911d0", i));
+
+            // The manifest
+            Assert.Collection(
+                manifest.Annotations,
+                a =>
+                {
+                    Assert.Equal("BuildID", a.Key);
+                    Assert.Equal("5abf1921-e3e3-4bfc-94c5-6c6805f23815", a.Value);
+                },
+                a =>
+                {
+                    Assert.Equal("ProductBuildVersion", a.Key);
+                    Assert.Equal("1A1", a.Value);
+                },
+                a =>
+                {
+                    Assert.Equal("ProductName", a.Key);
+                    Assert.Equal("Kaponata", a.Value);
+                },
+                a =>
+                {
+                    Assert.Equal("ProductVersion", a.Key);
+                    Assert.Equal("1.0", a.Value);
+                },
+                a =>
+                {
+                    Assert.Equal("DeveloperDisk.dmg.signature", a.Key);
+                    Assert.Equal("AQIDBA==", a.Value);
+                });
+            Assert.Null(manifest.Config.Annotations);
+            Assert.Equal("sha256:30c5c9a3aeb6eb237abf743b7657657580657e3548e82f6d2ce6e6e4660a9878", manifest.Config.Digest);
+            Assert.Equal("application/vnd.oci.image.config.v1+json", manifest.Config.MediaType);
+            Assert.Null(manifest.Config.Platform);
+            Assert.Equal(149, manifest.Config.Size);
+            Assert.Null(manifest.Config.URLs);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/Registry/DescriptorTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Registry/DescriptorTests.cs
@@ -41,6 +41,9 @@ namespace Kaponata.Kubernetes.Tests.Registry
                 Assert.Equal("sha256:dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f", descriptor.Digest);
                 Assert.Equal("text/plain", descriptor.MediaType);
                 Assert.Equal(13, descriptor.Size);
+
+                // The CreateAsync method will rewind the stream when done.
+                Assert.Equal(0, stream.Position);
             }
         }
     }

--- a/src/Kaponata.Kubernetes/DeveloperDisks/DeveloperDiskRegistryImageFactory.cs
+++ b/src/Kaponata.Kubernetes/DeveloperDisks/DeveloperDiskRegistryImageFactory.cs
@@ -1,0 +1,116 @@
+﻿// <copyright file="DeveloperDiskRegistryImageFactory.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.FileFormats;
+using Kaponata.FileFormats.Tar;
+using Kaponata.iOS.DeveloperDisks;
+using Kaponata.Kubernetes.Registry;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Kubernetes.DeveloperDisks
+{
+    /// <summary>
+    /// Provides methods for creating container images which represent developer disks.
+    /// </summary>
+    public class DeveloperDiskRegistryImageFactory
+    {
+        /// <summary>
+        /// Asynchronously creates a registry image which contains a <see cref="DeveloperDisk"/>.
+        /// </summary>
+        /// <param name="developerDisk">
+        /// The <see cref="DeveloperDisk"/> for which to create the image.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and, when completed, returns the image manifest,
+        /// image configuration and RootFS layer for the registry image containing the devleoper disk image.
+        /// </returns>
+        public async Task<(Manifest manifest, Stream configStream, Stream layer)> CreateRegistryImageAsync(DeveloperDisk developerDisk, CancellationToken cancellationToken)
+        {
+            if (developerDisk == null)
+            {
+                throw new ArgumentNullException(nameof(developerDisk));
+            }
+
+            var layer = await CreateLayerAsync(developerDisk, cancellationToken);
+            var layerDescriptor = await Descriptor.CreateAsync(layer, "application/vnd.oci.image.layer.nondistributable.v1.tar", cancellationToken).ConfigureAwait(false);
+
+            var config = CreateConfig(layerDescriptor.Digest);
+            Stream configStream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(configStream, config, cancellationToken: cancellationToken).ConfigureAwait(false);
+            configStream.Seek(0, SeekOrigin.Begin);
+
+            var configDescriptor = await Descriptor.CreateAsync(configStream, "application/vnd.oci.image.config.v1+json", cancellationToken).ConfigureAwait(false);
+            var manifest = CreateManifest(configDescriptor, layerDescriptor, developerDisk);
+
+            return (manifest, configStream, layer);
+        }
+
+        private static async Task<Stream> CreateLayerAsync(DeveloperDisk developerDisk, CancellationToken cancellationToken)
+        {
+            MemoryStream stream = new MemoryStream();
+            var writer = new TarWriter(stream);
+
+            var versionBytes = Encoding.UTF8.GetBytes(developerDisk.Version.ToDictionary().ToXmlPropertyList());
+
+            var fileMode = LinuxFileMode.S_IFREG | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IROTH;
+
+            await writer.AddFileAsync("SystemVersion.plist", fileMode, developerDisk.CreationTime, new MemoryStream(versionBytes), cancellationToken).ConfigureAwait(false);
+            await writer.AddFileAsync("DeveloperDiskImage.dmg", fileMode, developerDisk.CreationTime, developerDisk.Image, cancellationToken).ConfigureAwait(false);
+            await writer.AddFileAsync("DeveloperDiskImage.dmg.signature", fileMode, developerDisk.CreationTime, new MemoryStream(developerDisk.Signature), cancellationToken).ConfigureAwait(false);
+            await writer.WriteTrailerAsync(cancellationToken).ConfigureAwait(false);
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            return stream;
+        }
+
+        private static Image CreateConfig(string layerDiffId)
+        {
+            return new Image()
+            {
+                Architecture = Annotations.Architecture.Arm64,
+                OS = Annotations.OperatingSystem.iOS,
+                RootFS = new RootFS()
+                {
+                    Type = "layers",
+                    DiffIDs = new string[]
+                    {
+                        /* digest over the layer's uncompressed tar archive */
+                        layerDiffId,
+                    },
+                },
+            };
+        }
+
+        private static Manifest CreateManifest(Descriptor configDescriptor, Descriptor layerDescriptor, DeveloperDisk developerDisk)
+        {
+            return new Manifest()
+            {
+                SchemaVersion = 2,
+                Config = configDescriptor,
+                Layers = new Descriptor[]
+                {
+                    layerDescriptor,
+                },
+                Annotations = new Dictionary<string, string>()
+                {
+                    { nameof(SystemVersion.BuildID), developerDisk.Version.BuildID!.ToString() },
+                    { nameof(SystemVersion.ProductBuildVersion), developerDisk.Version.ProductBuildVersion!.ToString() },
+                    { nameof(SystemVersion.ProductName), developerDisk.Version.ProductName! },
+                    { nameof(SystemVersion.ProductVersion), developerDisk.Version.ProductVersion!.ToString() },
+                    { "DeveloperDisk.dmg.signature", Convert.ToBase64String(developerDisk.Signature) },
+                },
+            };
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/Registry/Descriptor.cs
+++ b/src/Kaponata.Kubernetes/Registry/Descriptor.cs
@@ -99,6 +99,8 @@ namespace Kaponata.Kubernetes.Registry
 
             descriptor.MediaType = mediaType;
 
+            content.Seek(0, SeekOrigin.Begin);
+
             return descriptor;
         }
     }

--- a/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskReaderTests.cs
+++ b/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskReaderTests.cs
@@ -47,9 +47,10 @@ namespace Kaponata.iOS.Tests.DeveloperDisks
         {
             using (Stream stream = File.OpenRead(path))
             {
-                var version = DeveloperDiskReader.GetVersionInformation(stream);
+                (var version, var creationTime) = DeveloperDiskReader.GetVersionInformation(stream);
 
                 Assert.Equal("iPhone OS", version.ProductName);
+                Assert.True(new DateTimeOffset(2010, 1, 1, 0, 0, 0, TimeSpan.Zero) < creationTime);
             }
         }
     }

--- a/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskTests.cs
+++ b/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskTests.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="DeveloperDiskTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DeveloperDisks;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.DeveloperDisks
+{
+    /// <summary>
+    /// Tests the <see cref="DeveloperDisk"/> class.
+    /// </summary>
+    public class DeveloperDiskTests
+    {
+        /// <summary>
+        /// <see cref="DeveloperDisk.FromFileAsync(Stream, Stream, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task FromFileAsync_ValidatesArguments_Async()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => DeveloperDisk.FromFileAsync(null, Stream.Null, default));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => DeveloperDisk.FromFileAsync(Stream.Null, null, default));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDisk.FromFileAsync(Stream, Stream, CancellationToken)"/> works as intended.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task FromFileAsync_Works_Async()
+        {
+            using (Stream stream = File.OpenRead("TestAssets/udro-hfsplus.dmg"))
+            using (MemoryStream signature = new MemoryStream(new byte[] { 1, 2, 3, 4 }))
+            {
+                var disk = await DeveloperDisk.FromFileAsync(stream, signature, default).ConfigureAwait(false);
+
+                Assert.Same(stream, disk.Image);
+                Assert.Equal(new byte[] { 1, 2, 3, 4 }, disk.Signature);
+                Assert.NotNull(disk.Version);
+                Assert.Equal("17E255", disk.Version.ProductBuildVersion.ToString());
+            }
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDisk.Dispose" /> works correctly.
+        /// </summary>
+        [Fact]
+        public void Dispose_Works()
+        {
+            var disk = new DeveloperDisk();
+            disk.Dispose();
+            Assert.True(disk.IsDisposed);
+
+            disk = new DeveloperDisk();
+            disk.Image = new MemoryStream();
+            disk.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => disk.Image.Length);
+        }
+    }
+}

--- a/src/Kaponata.iOS/DeveloperDisks/DeveloperDisk.cs
+++ b/src/Kaponata.iOS/DeveloperDisks/DeveloperDisk.cs
@@ -35,6 +35,11 @@ namespace Kaponata.iOS.DeveloperDisks
         public byte[] Signature { get; set; }
 
         /// <summary>
+        /// Gets or sets the date and time at which the developer disk image was created.
+        /// </summary>
+        public DateTimeOffset CreationTime { get; set; }
+
+        /// <summary>
         /// Creates a <see cref="DeveloperDisk"/> object based on a file.
         /// </summary>
         /// <param name="image">
@@ -62,7 +67,7 @@ namespace Kaponata.iOS.DeveloperDisks
                 throw new ArgumentNullException(nameof(signature));
             }
 
-            var version = DeveloperDiskReader.GetVersionInformation(image);
+            (var version, var creationTime) = DeveloperDiskReader.GetVersionInformation(image);
             image.Seek(0, SeekOrigin.Begin);
 
             byte[] signatureBytes = new byte[signature.Length];
@@ -74,6 +79,7 @@ namespace Kaponata.iOS.DeveloperDisks
                 Image = image,
                 Signature = signatureBytes,
                 Version = version,
+                CreationTime = creationTime,
             };
         }
 

--- a/src/Kaponata.iOS/DeveloperDisks/DeveloperDisk.cs
+++ b/src/Kaponata.iOS/DeveloperDisks/DeveloperDisk.cs
@@ -1,0 +1,87 @@
+﻿// <copyright file="DeveloperDisk.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Microsoft;
+using Nerdbank.Streams;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.DeveloperDisks
+{
+    /// <summary>
+    /// Represents an individual developer disk.
+    /// </summary>
+    public class DeveloperDisk : IDisposableObservable
+    {
+        /// <inheritdoc/>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the version information embedded in the developer disk.
+        /// </summary>
+        public SystemVersion Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a <see cref="Stream"/> which provides access to the developer disk image.
+        /// </summary>
+        public Stream Image { get; set; }
+
+        /// <summary>
+        /// Gets or sets the signature of the developer disk.
+        /// </summary>
+        public byte[] Signature { get; set; }
+
+        /// <summary>
+        /// Creates a <see cref="DeveloperDisk"/> object based on a file.
+        /// </summary>
+        /// <param name="image">
+        /// A <see cref="Stream"/> which represents the developer disk image.
+        /// </param>
+        /// <param name="signature">
+        /// A <see cref="Stream"/> which represents the developer disk signature.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation and, when completed,
+        /// returns a <see cref="DeveloperDisk"/> object which represents the developer disk.
+        /// </returns>
+        public static async Task<DeveloperDisk> FromFileAsync(Stream image, Stream signature, CancellationToken cancellationToken)
+        {
+            if (image == null)
+            {
+                throw new ArgumentNullException(nameof(image));
+            }
+
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature));
+            }
+
+            var version = DeveloperDiskReader.GetVersionInformation(image);
+            image.Seek(0, SeekOrigin.Begin);
+
+            byte[] signatureBytes = new byte[signature.Length];
+            signature.Seek(0, SeekOrigin.Begin);
+            await signature.ReadBlockOrThrowAsync(signatureBytes, cancellationToken).ConfigureAwait(false);
+
+            return new DeveloperDisk()
+            {
+                Image = image,
+                Signature = signatureBytes,
+                Version = version,
+            };
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Image?.Dispose();
+            this.IsDisposed = true;
+        }
+    }
+}

--- a/src/Kaponata.iOS/DeveloperDisks/DeveloperDiskReader.cs
+++ b/src/Kaponata.iOS/DeveloperDisks/DeveloperDiskReader.cs
@@ -7,6 +7,7 @@ using DiscUtils;
 using DiscUtils.Dmg;
 using DiscUtils.HfsPlus;
 using DiscUtils.Streams;
+using System;
 using System.IO;
 
 namespace Kaponata.iOS.DeveloperDisks
@@ -33,7 +34,7 @@ namespace Kaponata.iOS.DeveloperDisks
         /// A <see cref="SystemVersion"/> object with additional information about the developer
         /// disk image.
         /// </returns>
-        public static SystemVersion GetVersionInformation(Stream developerDiskImageStream)
+        public static (SystemVersion, DateTimeOffset) GetVersionInformation(Stream developerDiskImageStream)
         {
             using (var disk = new Disk(developerDiskImageStream, Ownership.None))
             {
@@ -61,7 +62,7 @@ namespace Kaponata.iOS.DeveloperDisks
                                 throw new InvalidDataException("The developer disk does not target iOS");
                             }
 
-                            return plist;
+                            return (plist, hfs.Root.CreationTimeUtc);
                         }
                     }
                 }


### PR DESCRIPTION
This container image has the following specifications:

- It contains a single filesystem layer, which contains:
  * The developer disk image
  * The signature of the developer disk image
  * A copy of the `SystemVersion.plist` file
- The manifest has the following annotations:
  * BuildID, ProductBuildVersion, ProductName and ProductVersion annotations: copied from SystemVersion.plist
  * DeveloperDisk.dmg.signature: The base64-encoded signature of the developer disk.