### PR TITLE
Support storing developer disk images in a Kubernetes registry

### DIFF
--- a/src/Kaponata.Api.Tests/DeveloperDiskControllerTests.cs
+++ b/src/Kaponata.Api.Tests/DeveloperDiskControllerTests.cs
@@ -1,0 +1,357 @@
+﻿// <copyright file="DeveloperDiskControllerTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DeveloperDisks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Api.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="DeveloperDiskController"/> class.
+    /// </summary>
+    public class DeveloperDiskControllerTests
+    {
+        /// <summary>
+        /// Returns tests data for the <see cref="ImportDeveloperDiskAsync_ValidatesFiles_Async"/> theory.
+        /// </summary>
+        /// <returns>
+        /// Test data for the <see cref="ImportDeveloperDiskAsync_ValidatesFiles_Async"/> theory.
+        /// </returns>
+        public static IEnumerable<object[]> ImportDeveloperDiskAsync_ValidatesFiles_Data()
+        {
+            // No files
+            yield return new object[]
+            {
+                new FormFileCollection(),
+            };
+
+            // Two developer disk files
+            yield return new object[]
+            {
+                new FormFileCollection()
+                {
+                    new FormFile(Stream.Null, 0, 0, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                },
+            };
+
+            // Empty files
+            yield return new object[]
+            {
+                new FormFileCollection()
+                {
+                    new FormFile(Stream.Null, 0, 0, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                },
+            };
+
+            // Empty signature
+            yield return new object[]
+            {
+                new FormFileCollection()
+                {
+                    new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                },
+            };
+
+            // Signature too large
+            yield return new object[]
+            {
+                new FormFileCollection()
+                {
+                    new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                },
+            };
+
+            // Multiple files
+            yield return new object[]
+            {
+                new FormFileCollection()
+                {
+                    new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0x10, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                },
+            };
+
+            yield return new object[]
+            {
+                new FormFileCollection()
+                {
+                    new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                    new FormFile(Stream.Null, 0, 0x10, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                    new FormFile(Stream.Null, 0, 0x10, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                },
+            };
+        }
+
+        /// <summary>
+        /// The <see cref="DeveloperDiskController"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DeveloperDiskController(null, Mock.Of<DeveloperDiskFactory>()));
+            Assert.Throws<ArgumentNullException>(() => new DeveloperDiskController(Mock.Of<DeveloperDiskStore>(), null));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.ImportDeveloperDiskAsync(CancellationToken)"/> returns 415 Unsupported Media Type
+        /// when the request does not include a form.
+        /// </summary>
+        /// <param name="contentType">
+        /// The content type of the request.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("text/json")]
+        public async Task ImportDeveloperDiskAsync_ValidatesMediaType_Async(string contentType)
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+
+            var controller = new DeveloperDiskController(store.Object, Mock.Of<DeveloperDiskFactory>())
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = new DefaultHttpContext(),
+                },
+            };
+
+            controller.Request.ContentType = contentType;
+            controller.Request.Form = null;
+
+            var result = await controller.ImportDeveloperDiskAsync(default).ConfigureAwait(false);
+            var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal((int)HttpStatusCode.UnsupportedMediaType, statusCodeResult.StatusCode);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.ImportDeveloperDiskAsync(CancellationToken)"/> validates the files which are being uploaded.
+        /// </summary>
+        /// <param name="files">
+        /// The files being uploaded.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(ImportDeveloperDiskAsync_ValidatesFiles_Data))]
+        public async Task ImportDeveloperDiskAsync_ValidatesFiles_Async(FormFileCollection files)
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+
+            var controller = new DeveloperDiskController(store.Object, Mock.Of<DeveloperDiskFactory>())
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = new DefaultHttpContext(),
+                },
+            };
+
+            controller.Request.ContentType = "multipart/form-data";
+            controller.Request.Form =
+                    new FormCollection(
+                        null,
+                        files);
+
+            var result = await controller.ImportDeveloperDiskAsync(default).ConfigureAwait(false);
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.ImportDeveloperDiskAsync(CancellationToken)"/> correctly adds the disk to the store.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ImportDeveloperDiskAsync_ImportsFiles_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+
+            var disk = new DeveloperDisk();
+            factory.Setup(f => f
+                .FromFileAsync(It.IsAny<TempFileStream>(), It.IsAny<Stream>(), default))
+                .ReturnsAsync(disk)
+                .Verifiable();
+
+            store.Setup(s => s.AddAsync(disk, default)).Returns(Task.CompletedTask);
+
+            var controller = new DeveloperDiskController(store.Object, factory.Object)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = new DefaultHttpContext(),
+                },
+            };
+
+            controller.Request.ContentType = "multipart/form-data";
+            controller.Request.Form =
+                    new FormCollection(
+                        null,
+                        new FormFileCollection()
+                        {
+                            new FormFile(Stream.Null, 0, 0x400_000, "DeveloperDiskImage.dmg", "DeveloperDiskImage.dmg"),
+                            new FormFile(Stream.Null, 0, 0x10, "DeveloperDiskImage.dmg.signature", "DeveloperDiskImage.dmg.signature"),
+                        });
+
+            var result = await controller.ImportDeveloperDiskAsync(default).ConfigureAwait(false);
+
+            factory.Verify();
+            store.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.ListDeveloperDisksAsync(CancellationToken)"/> returns the correct values.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ListAsync_Works_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            store.Setup(s => s.ListAsync(default))
+                .ReturnsAsync(new List<Version>() { new Version(10, 1), new Version(14, 0) });
+
+            var result = await controller.ListDeveloperDisksAsync(default);
+            Assert.Collection(
+                Assert.IsType<List<string>>(result.Value),
+                r => Assert.Equal("10.1", r),
+                r => Assert.Equal("14.0", r));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.DownloadDeveloperDiskAsync(string, CancellationToken)"/> returns 404 Not Found
+        /// when passed an invalid version number.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DownloadDeveloperDiskAsync_NotAVersion_ReturnsNotFound_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            var result = await controller.DownloadDeveloperDiskAsync("abc", default);
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.DownloadDeveloperDiskAsync(string, CancellationToken)"/> returns 404 Not Found
+        /// when passed a version number of a disk which does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DownloadDeveloperDiskAsync_NoSuchVersion_ReturnsNotFound_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            store.Setup(s => s.GetAsync(new Version(14, 0), default)).ReturnsAsync((DeveloperDisk)null);
+
+            var result = await controller.DownloadDeveloperDiskAsync("14.0", default);
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.DownloadDeveloperDiskAsync(string, CancellationToken)"/> returns the
+        /// disk contents.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DownloadDeveloperDiskAsync_ReturnsDisk_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            var disk = new DeveloperDisk()
+            {
+                Image = Stream.Null,
+            };
+
+            store.Setup(s => s.GetAsync(new Version(14, 0), default)).ReturnsAsync(disk);
+
+            var result = await controller.DownloadDeveloperDiskAsync("14.0", default);
+            var fileStreamResult = Assert.IsType<FileStreamResult>(result);
+
+            Assert.NotNull(fileStreamResult.FileStream);
+            Assert.Equal("application/octet-stream", fileStreamResult.ContentType);
+            Assert.Equal("DeveloperDiskImage.dmg", fileStreamResult.FileDownloadName);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.DownloadDeveloperDiskSignatureAsync(string, CancellationToken)"/> returns 404 Not Found
+        /// when passed an invalid version number.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DownloadDeveloperDiskSignatureAsync_NotAVersion_ReturnsNotFound_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            var result = await controller.DownloadDeveloperDiskSignatureAsync("abc", default);
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.DownloadDeveloperDiskSignatureAsync(string, CancellationToken)"/> returns 404 Not Found
+        /// when passed a version number of a disk which does not exist.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DownloadDeveloperDiskSignatureAsync_NoSuchVersion_ReturnsNotFound_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            store.Setup(s => s.GetAsync(new Version(14, 0), default)).ReturnsAsync((DeveloperDisk)null);
+
+            var result = await controller.DownloadDeveloperDiskSignatureAsync("14.0", default);
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskController.DownloadDeveloperDiskSignatureAsync(string, CancellationToken)"/> returns the developer
+        /// disk signature.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DownloadDeveloperDiskSignatureAsync_ReturnsDisk_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var factory = new Mock<DeveloperDiskFactory>(MockBehavior.Strict);
+            var controller = new DeveloperDiskController(store.Object, factory.Object);
+
+            var disk = new DeveloperDisk()
+            {
+                Signature = Array.Empty<byte>(),
+            };
+
+            store.Setup(s => s.GetAsync(new Version(14, 0), default)).ReturnsAsync(disk);
+
+            var result = await controller.DownloadDeveloperDiskSignatureAsync("14.0", default);
+            var fileStreamResult = Assert.IsType<FileContentResult>(result);
+
+            Assert.NotNull(fileStreamResult.FileContents);
+            Assert.Equal("application/octet-stream", fileStreamResult.ContentType);
+            Assert.Equal("DeveloperDiskImage.dmg.signature", fileStreamResult.FileDownloadName);
+        }
+    }
+}

--- a/src/Kaponata.Api.Tests/TempFileStreamTests.cs
+++ b/src/Kaponata.Api.Tests/TempFileStreamTests.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="TempFileStreamTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.IO;
+using Xunit;
+
+namespace Kaponata.Api.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="TempFileStream"/> class.
+    /// </summary>
+    public class TempFileStreamTests
+    {
+        /// <summary>
+        /// The <see cref="TempFileStream"/> creates a new file which initialized, and deletes the file when being disposed of.
+        /// </summary>
+        [Fact]
+        public void Lifecycle()
+        {
+            var stream = new TempFileStream();
+            Assert.True(File.Exists(stream.FileName));
+
+            stream.Dispose();
+            Assert.False(File.Exists(stream.FileName));
+        }
+    }
+}

--- a/src/Kaponata.Api/DeveloperDiskController.cs
+++ b/src/Kaponata.Api/DeveloperDiskController.cs
@@ -1,0 +1,187 @@
+﻿// <copyright file="DeveloperDiskController.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DeveloperDisks;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Api
+{
+    /// <summary>
+    /// Provides methods for uploading developer disk images to the cluster.
+    /// </summary>
+    public class DeveloperDiskController : Controller
+    {
+        private readonly DeveloperDiskStore store;
+        private readonly DeveloperDiskFactory factory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeveloperDiskController"/> class.
+        /// </summary>
+        /// <param name="store">
+        /// A <see cref="DeveloperDiskStore"/> which stores the developer disk images.
+        /// </param>
+        /// <param name="factory">
+        /// A <see cref="DeveloperDiskFactory"/> which can be used to read developer disk images.
+        /// </param>
+        public DeveloperDiskController(DeveloperDiskStore store, DeveloperDiskFactory factory)
+        {
+            this.store = store ?? throw new ArgumentNullException(nameof(store));
+            this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        }
+
+        /// <summary>
+        /// Imports a new developer disk, together with its signature.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        [Route("api/ios/developerDisk")]
+        [DisableRequestSizeLimit]
+        [HttpPost]
+        public async Task<ActionResult> ImportDeveloperDiskAsync(CancellationToken cancellationToken)
+        {
+            // We only accept form data.
+            if (string.IsNullOrEmpty(this.Request.ContentType) ||
+               this.Request.ContentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) != 0
+                || this.Request.Form == null)
+            {
+                return this.StatusCode((int)HttpStatusCode.UnsupportedMediaType);
+            }
+
+            // We expect a DeveloperDiskImage.dmg and DeveloperDiskImage.dmg.signature file
+            if (this.Request.Form.Files.Count(f => f.FileName == "DeveloperDiskImage.dmg") != 1)
+            {
+                return this.BadRequest("You must specify exactly one DeveloperDiskImage.dmg file");
+            }
+
+            if (this.Request.Form.Files.Count(f => f.FileName == "DeveloperDiskImage.dmg.signature") != 1)
+            {
+                return this.BadRequest("You must specify exactly one DeveloperDiskImage.dmg.signature file");
+            }
+
+            var developerDiskImageFile = this.Request.Form.Files.Single(f => f.FileName == "DeveloperDiskImage.dmg");
+            var developerDiskImageSignatureFile = this.Request.Form.Files.Single(f => f.FileName == "DeveloperDiskImage.dmg.signature");
+
+            if (developerDiskImageFile.Length < 4 * 1024 * 1024)
+            {
+                return this.BadRequest("The developer disk image is less than 4 MB in size, and is likely corrupt");
+            }
+
+            if (developerDiskImageSignatureFile.Length == 0)
+            {
+                return this.BadRequest("The developer disk image signature is an empty file, and is likely corrupt.");
+            }
+
+            if (developerDiskImageSignatureFile.Length > 0x100)
+            {
+                return this.BadRequest("The developer disk image signature is larger than 4096 bytes, and is likely corrupt.");
+            }
+
+            using (var signatureStream = developerDiskImageSignatureFile.OpenReadStream())
+            using (var developerDiskImageStream = new TempFileStream())
+            {
+                // Fetch information from the DeveloperDiskImage.dmg file (especially the target iOS version),
+                // and then copy the files to disk.
+                await developerDiskImageFile.CopyToAsync(developerDiskImageStream, cancellationToken).ConfigureAwait(false);
+                developerDiskImageStream.Position = 0;
+
+                var disk = await this.factory.FromFileAsync(developerDiskImageStream, signatureStream, cancellationToken).ConfigureAwait(false);
+                await this.store.AddAsync(disk, cancellationToken).ConfigureAwait(false);
+            }
+
+            return this.Ok();
+        }
+
+        /// <summary>
+        /// Asynchronously lists all developer disk images which are available.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Route("api/ios/developerDisk/")]
+        public async Task<JsonResult> ListDeveloperDisksAsync(CancellationToken cancellationToken)
+        {
+            var versions = await this.store.ListAsync(cancellationToken).ConfigureAwait(false);
+            return new JsonResult(versions.Select(v => v.ToString()).ToList());
+        }
+
+        /// <summary>
+        /// Downloads a developer disk image.
+        /// </summary>
+        /// <param name="version">
+        /// The iOS version for which to download the developer disk image.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// An action which allows you to download the developer disk image.
+        /// </returns>
+        [Route("api/ios/developerDisk/{version}/disk")]
+        [HttpGet]
+        public async Task<ActionResult> DownloadDeveloperDiskAsync(string version, CancellationToken cancellationToken)
+        {
+            if (!Version.TryParse(version, out Version? parsedVersion))
+            {
+                return this.NotFound();
+            }
+
+            var disk = await this.store.GetAsync(parsedVersion, cancellationToken);
+
+            if (disk == null)
+            {
+                return this.NotFound();
+            }
+
+            return new FileStreamResult(disk.Image, "application/octet-stream")
+            {
+                FileDownloadName = "DeveloperDiskImage.dmg",
+            };
+        }
+
+        /// <summary>
+        /// Downloads the signature of a developer disk image.
+        /// </summary>
+        /// <param name="version">
+        /// The iOS version for which to download the developer disk image.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// An action which allows you to download the developer disk image signature.
+        /// </returns>
+        [Route("api/ios/developerDisk/{version}/signature")]
+        [HttpGet]
+        public async Task<ActionResult> DownloadDeveloperDiskSignatureAsync(string version, CancellationToken cancellationToken)
+        {
+            if (!Version.TryParse(version, out Version? parsedVersion))
+            {
+                return this.NotFound();
+            }
+
+            var disk = await this.store.GetAsync(parsedVersion, cancellationToken);
+
+            if (disk == null)
+            {
+                return this.NotFound();
+            }
+
+            return new FileContentResult(disk.Signature, "application/octet-stream")
+            {
+                FileDownloadName = "DeveloperDiskImage.dmg.signature",
+            };
+        }
+    }
+}

--- a/src/Kaponata.Api/TempFileStream.cs
+++ b/src/Kaponata.Api/TempFileStream.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="TempFileStream.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System.IO;
+
+namespace Kaponata.Api
+{
+    /// <summary>
+    /// A <see cref="Stream"/> backed by a temporary file.
+    /// </summary>
+    public class TempFileStream : FileStream
+    {
+        private readonly string fileName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TempFileStream"/> class.
+        /// </summary>
+        public TempFileStream()
+            : this(Path.GetTempFileName())
+        {
+        }
+
+        private TempFileStream(string fileName)
+            : base(fileName, FileMode.Create, FileAccess.ReadWrite)
+        {
+            this.fileName = fileName;
+        }
+
+        /// <summary>
+        /// Gets the name of the file which backs this <see cref="TempFileStream"/>.
+        /// </summary>
+        public string FileName => this.fileName;
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            try
+            {
+                File.Delete(this.fileName);
+            }
+            catch
+            {
+                // Don't throw when disposing.
+            }
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/LabelSelectorTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/LabelSelectorTests.cs
@@ -176,7 +176,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> validates its arguments.
+        /// <see cref="LabelSelector.Create(IDictionary{string, string})"/> validates its arguments.
         /// </summary>
         [Fact]
         public void FromDictionary_ValidatesArgument()
@@ -185,7 +185,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> returns an empty selector when passed
+        /// <see cref="LabelSelector.Create(IDictionary{string, string})"/> returns an empty selector when passed
         /// an empty dictionary.
         /// </summary>
         [Fact]
@@ -195,7 +195,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> returns a valid selector when passed
+        /// <see cref="LabelSelector.Create(IDictionary{string, string})"/> returns a valid selector when passed
         /// a single key/value pair.
         /// </summary>
         [Fact]
@@ -211,7 +211,7 @@ namespace Kaponata.Kubernetes.Tests
         }
 
         /// <summary>
-        /// <see cref="LabelSelector.Create(Dictionary{string, string})"/> returns a valid selector when passed
+        /// <see cref="LabelSelector.Create(IDictionary{string, string})"/> returns a valid selector when passed
         /// two key/value pairs.
         /// </summary>
         [Fact]

--- a/src/Kaponata.Kubernetes.Tests/Registry/ImageRegistryClientConfigurationTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Registry/ImageRegistryClientConfigurationTests.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="ImageRegistryClientConfigurationTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes.Registry;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.Registry
+{
+    /// <summary>
+    /// Tests the <see cref="ImageRegistryClientConfiguration"/> class.
+    /// </summary>
+    public class ImageRegistryClientConfigurationTests
+    {
+        /// <summary>
+        /// The <see cref="ImageRegistryClientConfiguration"/> constructor works.
+        /// </summary>
+        [Fact]
+        public void Constructor_Works()
+        {
+            var configuration = new ImageRegistryClientConfiguration("test", 1);
+            Assert.Equal("test", configuration.ServiceName);
+            Assert.Equal(1, configuration.Port);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/Registry/ImageRegistryClientFactoryTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Registry/ImageRegistryClientFactoryTests.cs
@@ -1,0 +1,166 @@
+﻿// <copyright file="ImageRegistryClientFactoryTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using Kaponata.Kubernetes.Registry;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.Registry
+{
+    /// <summary>
+    /// Tests the <see cref="ImageRegistryClientFactory"/> class.
+    /// </summary>
+    public class ImageRegistryClientFactoryTests
+    {
+        /// <summary>
+        /// The <see cref="ImageRegistryClientFactory"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ImageRegistryClientFactory(null, new ImageRegistryClientConfiguration("test", 0)));
+            Assert.Throws<ArgumentNullException>(() => new ImageRegistryClientFactory(Mock.Of<KubernetesClient>(), null));
+        }
+
+        /// <summary>
+        /// <see cref="ImageRegistryClientFactory.CreateAsync(CancellationToken)"/> returns a <see cref="HttpClient"/> which connects directly
+        /// to the service when the code is running in a pod in a Kubernetes cluster.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateAsync_InsideCluster_ConnectsDirectly_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(k => k.RunningInCluster).Returns(true);
+            var configuration = new ImageRegistryClientConfiguration("registry", 5000);
+
+            var factory = new ImageRegistryClientFactory(kubernetes.Object, configuration);
+
+            var client = await factory.CreateAsync(default).ConfigureAwait(false);
+
+            Assert.NotNull(client.HttpClient);
+            Assert.Equal(new Uri("http://registry:5000"), client.HttpClient.BaseAddress);
+        }
+
+        /// <summary>
+        /// <see cref="ImageRegistryClientFactory.CreateAsync(CancellationToken)"/> returns a <see cref="HttpClient"/> which connects
+        /// to a pod backing the service, using port forwarding, when the code is not running in a pod in a Kubernetes cluster.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateAsync_OutsideCluster_UsesPortForwarding_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(k => k.RunningInCluster).Returns(false);
+
+            var serviceClient = new Mock<NamespacedKubernetesClient<V1Service>>();
+            kubernetes.Setup(k => k.GetClient<V1Service>()).Returns(serviceClient.Object);
+
+            serviceClient
+                .Setup(s => s.TryReadAsync("registry", default))
+                .ReturnsAsync(new V1Service()
+                {
+                     Spec = new V1ServiceSpec()
+                     {
+                         Selector = new Dictionary<string, string>()
+                          {
+                              { "app", "kaponata" },
+                          },
+                     },
+                });
+
+            var pod = new V1Pod();
+
+            kubernetes.Setup(k => k.ListPodAsync(null, null, "app=kaponata", null, default))
+                .ReturnsAsync(new V1PodList()
+                {
+                    Items = new List<V1Pod>() { pod },
+                });
+
+            var httpClient = new HttpClient();
+            kubernetes
+                .Setup(k => k.CreatePodHttpClient(pod, 5000))
+                .Returns(httpClient);
+
+            var configuration = new ImageRegistryClientConfiguration("registry", 5000);
+
+            var factory = new ImageRegistryClientFactory(kubernetes.Object, configuration);
+
+            var client = await factory.CreateAsync(default).ConfigureAwait(false);
+
+            Assert.Same(httpClient, client.HttpClient);
+        }
+
+        /// <summary>
+        /// <see cref="ImageRegistryClientFactory.CreateAsync(CancellationToken)"/> throws an exception when the service
+        /// which hosts the registry cannot be found.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateAsync_OutsideCluster_ServiceMissing_Throws_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(k => k.RunningInCluster).Returns(false);
+
+            var serviceClient = new Mock<NamespacedKubernetesClient<V1Service>>();
+            kubernetes.Setup(k => k.GetClient<V1Service>()).Returns(serviceClient.Object);
+
+            serviceClient
+                .Setup(s => s.TryReadAsync("registry", default))
+                .ReturnsAsync((V1Service)null);
+
+            var configuration = new ImageRegistryClientConfiguration("registry", 5000);
+
+            var factory = new ImageRegistryClientFactory(kubernetes.Object, configuration);
+
+            await Assert.ThrowsAsync<ImageRegistryException>(() => factory.CreateAsync(default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="ImageRegistryClientFactory.CreateAsync(CancellationToken)"/> throws an exception when no pods
+        /// could be found which implement the service.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateAsync_OutsideCluster_NoPod_Throws_Async()
+        {
+            var kubernetes = new Mock<KubernetesClient>(MockBehavior.Strict);
+            kubernetes.Setup(k => k.RunningInCluster).Returns(false);
+
+            var serviceClient = new Mock<NamespacedKubernetesClient<V1Service>>();
+            kubernetes.Setup(k => k.GetClient<V1Service>()).Returns(serviceClient.Object);
+
+            serviceClient
+                .Setup(s => s.TryReadAsync("registry", default))
+                .ReturnsAsync(new V1Service()
+                {
+                    Spec = new V1ServiceSpec()
+                    {
+                        Selector = new Dictionary<string, string>()
+                          {
+                              { "app", "kaponata" },
+                          },
+                    },
+                });
+
+            kubernetes.Setup(k => k.ListPodAsync(null, null, "app=kaponata", null, default))
+                .ReturnsAsync(new V1PodList()
+                {
+                    Items = new List<V1Pod>() { },
+                });
+
+            var configuration = new ImageRegistryClientConfiguration("registry", 5000);
+
+            var factory = new ImageRegistryClientFactory(kubernetes.Object, configuration);
+
+            await Assert.ThrowsAsync<ImageRegistryException>(() => factory.CreateAsync(default)).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/Registry/ImageRegistryExceptionTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Registry/ImageRegistryExceptionTests.cs
@@ -68,5 +68,15 @@ namespace Kaponata.Kubernetes.Tests.Registry
             Assert.Single(exception.Errors);
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
+
+        /// <summary>
+        /// The <see cref="ImageRegistryException.ImageRegistryException(string)"/> constructor works correctly.
+        /// </summary>
+        [Fact]
+        public void WithMessage_Works()
+        {
+            var ex = new ImageRegistryException("this is a test");
+            Assert.Equal("this is a test", ex.Message);
+        }
     }
 }

--- a/src/Kaponata.Kubernetes/DeveloperDisks/RegistryDeveloperDiskStore.cs
+++ b/src/Kaponata.Kubernetes/DeveloperDisks/RegistryDeveloperDiskStore.cs
@@ -21,7 +21,7 @@ namespace Kaponata.Kubernetes.DeveloperDisks
     /// </summary>
     public class RegistryDeveloperDiskStore : DeveloperDiskStore
     {
-        private readonly ImageRegistryClient client;
+        private readonly ImageRegistryClientFactory clientFactory;
         private readonly string repositoryName = "devimg";
 
         /// <summary>
@@ -30,9 +30,9 @@ namespace Kaponata.Kubernetes.DeveloperDisks
         /// <param name="client">
         /// A <see cref="ImageRegistryClient"/> which provides access to the underlying registry.
         /// </param>
-        public RegistryDeveloperDiskStore(ImageRegistryClient client)
+        public RegistryDeveloperDiskStore(ImageRegistryClientFactory client)
         {
-            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.clientFactory = client ?? throw new ArgumentNullException(nameof(client));
         }
 
         /// <inheritdoc/>
@@ -49,38 +49,42 @@ namespace Kaponata.Kubernetes.DeveloperDisks
             using (layerStream)
             using (configStream)
             using (Stream manifestStream = new MemoryStream())
+            using (var client = await this.clientFactory.CreateAsync(cancellationToken).ConfigureAwait(false))
             {
                 // Send over the base layer
                 Descriptor layerDescriptor = await Descriptor.CreateAsync(layerStream, "application/vnd.oci.image.layer.nondistributable.v1.tar", cancellationToken);
-                await this.client.PushBlobAsync(this.repositoryName, layerStream, layerDescriptor.Digest, cancellationToken).ConfigureAwait(false);
+                await client.PushBlobAsync(this.repositoryName, layerStream, layerDescriptor.Digest, cancellationToken).ConfigureAwait(false);
 
                 // Prepare and send the configuration
                 var configDescriptor = await Descriptor.CreateAsync(configStream, "application/vnd.oci.image.config.v1+json", cancellationToken).ConfigureAwait(false);
-                await this.client.PushBlobAsync(this.repositoryName, configStream, configDescriptor.Digest, cancellationToken).ConfigureAwait(false);
+                await client.PushBlobAsync(this.repositoryName, configStream, configDescriptor.Digest, cancellationToken).ConfigureAwait(false);
 
                 // Prepare and send the manifest
                 manifestStream.Write(JsonSerializer.SerializeToUtf8Bytes(manifest));
 
-                await this.client.PushManifestAsync(this.repositoryName, disk.Version.ProductVersion.ToString(), manifestStream, cancellationToken);
+                await client.PushManifestAsync(this.repositoryName, disk.Version.ProductVersion.ToString(), manifestStream, cancellationToken);
             }
         }
 
         /// <inheritdoc/>
         public override async Task<List<Version>> ListAsync(CancellationToken cancellationToken)
         {
-            var tags = await this.client.ListTagsAsync(this.repositoryName, cancellationToken).ConfigureAwait(false);
-
-            var versions = new List<Version>();
-
-            foreach (var tag in tags)
+            using (var client = await this.clientFactory.CreateAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (Version.TryParse(tag, out Version? version))
-                {
-                    versions.Add(version);
-                }
-            }
+                var tags = await client.ListTagsAsync(this.repositoryName, cancellationToken).ConfigureAwait(false);
 
-            return versions;
+                var versions = new List<Version>();
+
+                foreach (var tag in tags)
+                {
+                    if (Version.TryParse(tag, out Version? version))
+                    {
+                        versions.Add(version);
+                    }
+                }
+
+                return versions;
+            }
         }
 
         /// <inheritdoc/>
@@ -91,59 +95,63 @@ namespace Kaponata.Kubernetes.DeveloperDisks
                 throw new ArgumentNullException(nameof(version));
             }
 
-            var manifest = await this.client.GetManifestAsync(this.repositoryName, version.ToString(), cancellationToken).ConfigureAwait(false);
-
-            if (manifest == null)
+            using (var client = await this.clientFactory.CreateAsync(cancellationToken).ConfigureAwait(false))
             {
-                return null;
-            }
+                var manifest = await client.GetManifestAsync(this.repositoryName, version.ToString(), cancellationToken).ConfigureAwait(false);
 
-            // We should perform some sanity checks here.
-            // Skip the config for now; although it is stored as a regular blob.
-            // var config = await this.client.GetBlobAsync
-            using (var layer = await this.client.GetBlobAsync(this.repositoryName, manifest.Layers[0].Digest, cancellationToken).ConfigureAwait(false))
-            {
-                var disk = new DeveloperDisk();
-
-                TarReader reader = new TarReader(layer);
-                TarHeader? header;
-                Stream? entryStream;
-
-                while (((header, entryStream) = await reader.ReadAsync(cancellationToken).ConfigureAwait(false)).header != null)
+                if (manifest == null)
                 {
-                    var fileName = header!.Value.FileName;
-
-                    switch (fileName)
-                    {
-                        case "DeveloperDiskImage.dmg":
-                            disk.Image = new MemoryStream();
-                            disk.CreationTime = header.Value.LastModified;
-                            await entryStream!.CopyToAsync(disk.Image, cancellationToken).ConfigureAwait(false);
-                            break;
-
-                        case "DeveloperDiskImage.dmg.signature":
-                            disk.Signature = new byte[header.Value.FileSize];
-                            await entryStream!.ReadBlockAsync(disk.Signature, cancellationToken).ConfigureAwait(false);
-                            break;
-
-                        case "SystemVersion.plist":
-                            var data = new byte[header.Value.FileSize];
-                            await entryStream!.ReadBlockAsync(data, cancellationToken).ConfigureAwait(false);
-                            var plist = (NSDictionary)PropertyListParser.Parse(data);
-
-                            disk.Version = new SystemVersion();
-                            disk.Version.FromDictionary(plist);
-                            break;
-
-                        case "":
-                            break;
-
-                        default:
-                            throw new InvalidDataException();
-                    }
+                    return null;
                 }
 
-                return disk;
+                // We should perform some sanity checks here.
+                // Skip the config for now; although it is stored as a regular blob.
+                // var config = await this.client.GetBlobAsync
+                using (var layer = await client.GetBlobAsync(this.repositoryName, manifest.Layers[0].Digest, cancellationToken).ConfigureAwait(false))
+                {
+                    var disk = new DeveloperDisk();
+
+                    TarReader reader = new TarReader(layer);
+                    TarHeader? header;
+                    Stream? entryStream;
+
+                    while (((header, entryStream) = await reader.ReadAsync(cancellationToken).ConfigureAwait(false)).header != null)
+                    {
+                        var fileName = header!.Value.FileName;
+
+                        switch (fileName)
+                        {
+                            case "DeveloperDiskImage.dmg":
+                                disk.Image = new MemoryStream();
+                                disk.CreationTime = header.Value.LastModified;
+                                await entryStream!.CopyToAsync(disk.Image, cancellationToken).ConfigureAwait(false);
+                                disk.Image.Seek(0, SeekOrigin.Begin);
+                                break;
+
+                            case "DeveloperDiskImage.dmg.signature":
+                                disk.Signature = new byte[header.Value.FileSize];
+                                await entryStream!.ReadBlockAsync(disk.Signature, cancellationToken).ConfigureAwait(false);
+                                break;
+
+                            case "SystemVersion.plist":
+                                var data = new byte[header.Value.FileSize];
+                                await entryStream!.ReadBlockAsync(data, cancellationToken).ConfigureAwait(false);
+                                var plist = (NSDictionary)PropertyListParser.Parse(data);
+
+                                disk.Version = new SystemVersion();
+                                disk.Version.FromDictionary(plist);
+                                break;
+
+                            case "":
+                                break;
+
+                            default:
+                                throw new InvalidDataException();
+                        }
+                    }
+
+                    return disk;
+                }
             }
         }
 
@@ -155,22 +163,25 @@ namespace Kaponata.Kubernetes.DeveloperDisks
                 throw new ArgumentNullException(nameof(version));
             }
 
-            var manifest = await this.client.GetManifestAsync(this.repositoryName, version.ToString(), cancellationToken).ConfigureAwait(false);
-
-            if (manifest == null)
+            using (var client = await this.clientFactory.CreateAsync(cancellationToken).ConfigureAwait(false))
             {
-                // Nothing to do.
-                return;
-            }
+                var manifest = await client.GetManifestAsync(this.repositoryName, version.ToString(), cancellationToken).ConfigureAwait(false);
 
-            // Delete the manifest, and then the unused blob objects (configuration + RootFS layers)
-            await this.client.DeleteManifestAsync(this.repositoryName, version.ToString(), cancellationToken).ConfigureAwait(false);
-            foreach (var layer in manifest.Layers)
-            {
-                await this.client.DeleteBlobAsync(this.repositoryName, layer.Digest, cancellationToken).ConfigureAwait(false);
-            }
+                if (manifest == null)
+                {
+                    // Nothing to do.
+                    return;
+                }
 
-            await this.client.DeleteBlobAsync(this.repositoryName, manifest.Config.Digest, cancellationToken).ConfigureAwait(false);
+                // Delete the manifest, and then the unused blob objects (configuration + RootFS layers)
+                await client.DeleteManifestAsync(this.repositoryName, version.ToString(), cancellationToken).ConfigureAwait(false);
+                foreach (var layer in manifest.Layers)
+                {
+                    await client.DeleteBlobAsync(this.repositoryName, layer.Digest, cancellationToken).ConfigureAwait(false);
+                }
+
+                await client.DeleteBlobAsync(this.repositoryName, manifest.Config.Digest, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Kaponata.Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.cs
@@ -104,6 +104,11 @@ namespace Kaponata.Kubernetes
             where T : IKubernetesObject<V1ObjectMeta>;
 
         /// <summary>
+        /// Gets a value indicating whether the code is currently running inside a pod hosted in a Kubernetes cluster.
+        /// </summary>
+        public virtual bool RunningInCluster => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST"));
+
+        /// <summary>
         /// Gets the <see cref="KubernetesOptions"/> which configure this <see cref="KubernetesClient"/>.
         /// </summary>
         public KubernetesOptions Options => this.options.Value;

--- a/src/Kaponata.Kubernetes/KubernetesServiceCollectionExtensions.cs
+++ b/src/Kaponata.Kubernetes/KubernetesServiceCollectionExtensions.cs
@@ -3,8 +3,11 @@
 // </copyright>
 
 using k8s;
+using Kaponata.iOS.DeveloperDisks;
+using Kaponata.Kubernetes.DeveloperDisks;
 using Kaponata.Kubernetes.DeveloperProfiles;
 using Kaponata.Kubernetes.Polyfill;
+using Kaponata.Kubernetes.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
@@ -44,6 +47,10 @@ namespace Kaponata.Kubernetes
             services.AddSingleton<KubernetesClient>();
 
             services.AddScoped<KubernetesDeveloperProfile>();
+            services.AddSingleton(new ImageRegistryClientConfiguration("kaponata-registry", 5000));
+            services.AddScoped<ImageRegistryClientFactory>();
+            services.AddSingleton<DeveloperDiskFactory>();
+            services.AddScoped<DeveloperDiskStore, RegistryDeveloperDiskStore>();
 
             services.AddOptions<KubernetesOptions>().Configure(c => c.Namespace = @namespace);
             return services;

--- a/src/Kaponata.Kubernetes/LabelSelector.cs
+++ b/src/Kaponata.Kubernetes/LabelSelector.cs
@@ -52,7 +52,7 @@ namespace Kaponata.Kubernetes
         /// <returns>
         /// A <see cref="string"/> which represents the label selector.
         /// </returns>
-        public static string Create(Dictionary<string, string> values)
+        public static string Create(IDictionary<string, string> values)
         {
             if (values == null)
             {

--- a/src/Kaponata.Kubernetes/Registry/ImageRegistryClient.cs
+++ b/src/Kaponata.Kubernetes/Registry/ImageRegistryClient.cs
@@ -44,6 +44,11 @@ namespace Kaponata.Kubernetes.Registry
         }
 #nullable restore
 
+        /// <summary>
+        /// Gets the <see cref="HttpClient"/> which is used to connect to the image registry.
+        /// </summary>
+        public HttpClient HttpClient => this.httpClient;
+
         /// <inheritdoc/>
         public bool IsDisposed { get; private set; }
 
@@ -358,7 +363,7 @@ namespace Kaponata.Kubernetes.Registry
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.httpClient.Dispose();
+            this.httpClient?.Dispose();
             this.IsDisposed = true;
         }
     }

--- a/src/Kaponata.Kubernetes/Registry/ImageRegistryClientConfiguration.cs
+++ b/src/Kaponata.Kubernetes/Registry/ImageRegistryClientConfiguration.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ImageRegistryClientConfiguration.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Kubernetes.Registry
+{
+    /// <summary>
+    /// The configuration for a <see cref="ImageRegistryClientFactory"/>.
+    /// </summary>
+    public class ImageRegistryClientConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageRegistryClientConfiguration"/> class.
+        /// </summary>
+        /// <param name="serviceName">
+        /// The name of the service which hosts the image registry.
+        /// </param>
+        /// <param name="port">
+        /// The port at which the service can be reached.
+        /// </param>
+        public ImageRegistryClientConfiguration(string serviceName, int port)
+        {
+            this.ServiceName = serviceName;
+            this.Port = port;
+        }
+
+        /// <summary>
+        /// Gets the name of the service which hosts the image registry.
+        /// </summary>
+        public string ServiceName { get; private set; }
+
+        /// <summary>
+        /// Gets the port at which the service can be reached.
+        /// </summary>
+        public int Port { get; private set; }
+    }
+}

--- a/src/Kaponata.Kubernetes/Registry/ImageRegistryClientFactory.cs
+++ b/src/Kaponata.Kubernetes/Registry/ImageRegistryClientFactory.cs
@@ -1,0 +1,93 @@
+﻿// <copyright file="ImageRegistryClientFactory.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using k8s.Models;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Kubernetes.Registry
+{
+    /// <summary>
+    /// A factory class which can create <see cref="ImageRegistryClient"/> classes.
+    /// </summary>
+    public class ImageRegistryClientFactory
+    {
+        private readonly KubernetesClient client;
+        private readonly ImageRegistryClientConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageRegistryClientFactory"/> class.
+        /// </summary>
+        /// <param name="client">
+        /// A <see cref="KubernetesClient"/> which provides access to the Kubernetes cluster.
+        /// </param>
+        /// <param name="configuration">
+        /// A <see cref="ImageRegistryClientConfiguration"/> which represents the configuration for the registry.
+        /// </param>
+        public ImageRegistryClientFactory(KubernetesClient client, ImageRegistryClientConfiguration configuration)
+        {
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageRegistryClientFactory"/> class. Intended for mocking purposes only.
+        /// </summary>
+#nullable disable
+        protected ImageRegistryClientFactory()
+        {
+        }
+#nullable restore
+
+        /// <summary>
+        /// Asynchrously creates a <see cref="ImageRegistryClient"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation and which, when completed, returns a <see cref="ImageRegistryClient"/>.
+        /// </returns>
+        public virtual async Task<ImageRegistryClient> CreateAsync(CancellationToken cancellationToken)
+        {
+            if (this.client.RunningInCluster)
+            {
+                // We're running inside a Kubernetes cluster, and can directly connect to the service.
+                return new ImageRegistryClient(
+                    new HttpClient()
+                    {
+                        BaseAddress = new Uri($"http://{this.configuration.ServiceName}:{this.configuration.Port}"),
+                    });
+            }
+            else
+            {
+                // We're not running inside a Kubernetes cluster (e.g. a dev/test setup), and we can't directly connect to the service
+                // through its IP address or DNS name. Select an individual pod backing the service and use port forwarding instead.
+                var serviceClient = this.client.GetClient<V1Service>();
+                var service = await serviceClient.TryReadAsync(this.configuration.ServiceName, cancellationToken).ConfigureAwait(false);
+
+                if (service == null)
+                {
+                    throw new ImageRegistryException($"The service {this.configuration.ServiceName} does not exist");
+                }
+
+                var selector = LabelSelector.Create(service.Spec.Selector);
+
+                var pods = await this.client.ListPodAsync(labelSelector: selector, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (pods.Items.Count == 0)
+                {
+                    throw new ImageRegistryException($"No pods could be fond for service {this.configuration.ServiceName}.");
+                }
+
+                var pod = pods.Items[0];
+
+                var httpClient = this.client.CreatePodHttpClient(pod, this.configuration.Port);
+                return new ImageRegistryClient(httpClient);
+            }
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/Registry/ImageRegistryException.cs
+++ b/src/Kaponata.Kubernetes/Registry/ImageRegistryException.cs
@@ -22,6 +22,17 @@ namespace Kaponata.Kubernetes.Registry
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageRegistryException"/> class.
         /// </summary>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        public ImageRegistryException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageRegistryException"/> class.
+        /// </summary>
         /// <param name="statusCode">
         /// The HTTP status code returned by the remote server.
         /// </param>

--- a/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskFactoryTests.cs
+++ b/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskFactoryTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="DeveloperDiskFactoryTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DeveloperDisks;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.DeveloperDisks
+{
+    /// <summary>
+    /// Tests the <see cref="DeveloperDiskFactory"/> class.
+    /// </summary>
+    public class DeveloperDiskFactoryTests
+    {
+        /// <summary>
+        /// <see cref="DeveloperDiskFactory.FromFileAsync(Stream, Stream, CancellationToken)"/> validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task FromFileAsync_ValidatesArguments_Async()
+        {
+            var factory = new DeveloperDiskFactory();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => factory.FromFileAsync(null, Stream.Null, default));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => factory.FromFileAsync(Stream.Null, null, default));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskFactory.FromFileAsync(Stream, Stream, CancellationToken)"/> works as intended.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task FromFileAsync_Works_Async()
+        {
+            using (Stream stream = File.OpenRead("TestAssets/udro-hfsplus.dmg"))
+            using (MemoryStream signature = new MemoryStream(new byte[] { 1, 2, 3, 4 }))
+            {
+                var factory = new DeveloperDiskFactory();
+                var disk = await factory.FromFileAsync(stream, signature, default).ConfigureAwait(false);
+
+                Assert.Same(stream, disk.Image);
+                Assert.Equal(new byte[] { 1, 2, 3, 4 }, disk.Signature);
+                Assert.NotNull(disk.Version);
+                Assert.Equal("17E255", disk.Version.ProductBuildVersion.ToString());
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskTests.cs
+++ b/src/Kaponata.iOS.Tests/DeveloperDisks/DeveloperDiskTests.cs
@@ -17,36 +17,6 @@ namespace Kaponata.iOS.Tests.DeveloperDisks
     public class DeveloperDiskTests
     {
         /// <summary>
-        /// <see cref="DeveloperDisk.FromFileAsync(Stream, Stream, CancellationToken)"/> validates its arguments.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task FromFileAsync_ValidatesArguments_Async()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(() => DeveloperDisk.FromFileAsync(null, Stream.Null, default));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => DeveloperDisk.FromFileAsync(Stream.Null, null, default));
-        }
-
-        /// <summary>
-        /// <see cref="DeveloperDisk.FromFileAsync(Stream, Stream, CancellationToken)"/> works as intended.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task FromFileAsync_Works_Async()
-        {
-            using (Stream stream = File.OpenRead("TestAssets/udro-hfsplus.dmg"))
-            using (MemoryStream signature = new MemoryStream(new byte[] { 1, 2, 3, 4 }))
-            {
-                var disk = await DeveloperDisk.FromFileAsync(stream, signature, default).ConfigureAwait(false);
-
-                Assert.Same(stream, disk.Image);
-                Assert.Equal(new byte[] { 1, 2, 3, 4 }, disk.Signature);
-                Assert.NotNull(disk.Version);
-                Assert.Equal("17E255", disk.Version.ProductBuildVersion.ToString());
-            }
-        }
-
-        /// <summary>
         /// <see cref="DeveloperDisk.Dispose" /> works correctly.
         /// </summary>
         [Fact]

--- a/src/Kaponata.iOS/DeveloperDisks/DeveloperDisk.cs
+++ b/src/Kaponata.iOS/DeveloperDisks/DeveloperDisk.cs
@@ -39,50 +39,6 @@ namespace Kaponata.iOS.DeveloperDisks
         /// </summary>
         public DateTimeOffset CreationTime { get; set; }
 
-        /// <summary>
-        /// Creates a <see cref="DeveloperDisk"/> object based on a file.
-        /// </summary>
-        /// <param name="image">
-        /// A <see cref="Stream"/> which represents the developer disk image.
-        /// </param>
-        /// <param name="signature">
-        /// A <see cref="Stream"/> which represents the developer disk signature.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
-        /// </param>
-        /// <returns>
-        /// A <see cref="Task"/> which represents the asynchronous operation and, when completed,
-        /// returns a <see cref="DeveloperDisk"/> object which represents the developer disk.
-        /// </returns>
-        public static async Task<DeveloperDisk> FromFileAsync(Stream image, Stream signature, CancellationToken cancellationToken)
-        {
-            if (image == null)
-            {
-                throw new ArgumentNullException(nameof(image));
-            }
-
-            if (signature == null)
-            {
-                throw new ArgumentNullException(nameof(signature));
-            }
-
-            (var version, var creationTime) = DeveloperDiskReader.GetVersionInformation(image);
-            image.Seek(0, SeekOrigin.Begin);
-
-            byte[] signatureBytes = new byte[signature.Length];
-            signature.Seek(0, SeekOrigin.Begin);
-            await signature.ReadBlockOrThrowAsync(signatureBytes, cancellationToken).ConfigureAwait(false);
-
-            return new DeveloperDisk()
-            {
-                Image = image,
-                Signature = signatureBytes,
-                Version = version,
-                CreationTime = creationTime,
-            };
-        }
-
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/src/Kaponata.iOS/DeveloperDisks/DeveloperDiskFactory.cs
+++ b/src/Kaponata.iOS/DeveloperDisks/DeveloperDiskFactory.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="DeveloperDiskFactory.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Nerdbank.Streams;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.DeveloperDisks
+{
+    /// <summary>
+    /// Supports creating <see cref="DeveloperDisk"/> objects based on <see cref="Stream"/>s.
+    /// </summary>
+    public class DeveloperDiskFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="DeveloperDisk"/> object based on a file.
+        /// </summary>
+        /// <param name="image">
+        /// A <see cref="Stream"/> which represents the developer disk image.
+        /// </param>
+        /// <param name="signature">
+        /// A <see cref="Stream"/> which represents the developer disk signature.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation and, when completed,
+        /// returns a <see cref="DeveloperDisk"/> object which represents the developer disk.
+        /// </returns>
+        public virtual async Task<DeveloperDisk> FromFileAsync(Stream image, Stream signature, CancellationToken cancellationToken)
+        {
+            if (image == null)
+            {
+                throw new ArgumentNullException(nameof(image));
+            }
+
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature));
+            }
+
+            (var version, var creationTime) = DeveloperDiskReader.GetVersionInformation(image);
+            image.Seek(0, SeekOrigin.Begin);
+
+            byte[] signatureBytes = new byte[signature.Length];
+            signature.Seek(0, SeekOrigin.Begin);
+            await signature.ReadBlockOrThrowAsync(signatureBytes, cancellationToken).ConfigureAwait(false);
+
+            return new DeveloperDisk()
+            {
+                Image = image,
+                Signature = signatureBytes,
+                Version = version,
+                CreationTime = creationTime,
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following routes:

| Route | Description |
|-------|----|
| `GET api/ios/developerDisk/` | Lists all developer disks known to Kaponata |
| `POST api/ios/developerDisk/` | Uploads a new developer disk to Kaponata. You need to post a form, which contains two files: `DeveloperDiskImage.dmg` and `DeveloperDiskImage.dmg.signature` |
|  `GET api/ios/developerDisk/{version}/disk` | Dowload the developer disk image | 
| `GET api/ios/developerDisk/{version}/signature` | Download the developer disk signature | 

These routes are backed by the `DeveloperDiskController` controller. The dependencies (`RegistryDeveloperDiskStore` and `ImageRegistryClient`) are injected via dependency injection. This PR introduces a `ImageRegistryClientFactory` class which can create `ImageRegistryClient`s, by either connecting directly to a Kubernetes service (when running inside a cluster) or to a pod backing the service via port forwarding (when running outside a cluster, e.g. in dev/test scenarios).
