### PR TITLE
Add MobileImageMounterClient

### DIFF
--- a/src/Kaponata.iOS.Tests/GlobalSuppressions.cs
+++ b/src/Kaponata.iOS.Tests/GlobalSuppressions.cs
@@ -15,3 +15,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.SpringBoardServices")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.DiagnosticsRelay")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.DeveloperDisks")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.Tests.MobileImageMounter")]

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
@@ -47,6 +47,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -85,6 +86,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -124,6 +126,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -167,6 +170,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<byte[]>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -204,6 +208,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
@@ -270,6 +270,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -330,6 +331,8 @@ namespace Kaponata.iOS.Tests.Lockdown
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
+
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -141,6 +141,8 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await client.StartSessionAsync(pairingRecord, default).ConfigureAwait(false);
@@ -226,6 +228,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(response);
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.SetValue.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.SetValue.cs
@@ -49,6 +49,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Verifiable();
 
             protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/HangupRequestTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/HangupRequestTests.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="HangupRequestTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.MobileImageMounter;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="HangupRequest"/> class.
+    /// </summary>
+    public class HangupRequestTests
+    {
+        /// <summary>
+        /// <see cref="HangupRequest.ToDictionary"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToDictionary_Works()
+        {
+            var dict = new HangupRequest().ToDictionary();
+
+            Assert.Equal("Hangup", Assert.Contains("Command", dict).ToObject());
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/HangupResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/HangupResponseTests.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="HangupResponseTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.MobileImageMounter;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="HangupResponse"/> class.
+    /// </summary>
+    public class HangupResponseTests
+    {
+        /// <summary>
+        /// <see cref="HangupResponse.FromDictionary(NSDictionary)"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void FromDictionary_Works()
+        {
+            var dict = new NSDictionary();
+            dict.Add("Goodbye", true);
+
+            var response = new HangupResponse();
+            response.FromDictionary(dict);
+
+            Assert.Null(response.DetailedError);
+            Assert.Null(response.Error);
+            Assert.Null(response.Status);
+            Assert.True(response.Goodbye);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/LookupImageRequestTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/LookupImageRequestTests.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="LookupImageRequestTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.MobileImageMounter;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="LookupImageRequest"/> class.
+    /// </summary>
+    public class LookupImageRequestTests
+    {
+        /// <summary>
+        /// <see cref="LookupImageRequest.ToDictionary"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToDictionary_Works()
+        {
+            var dict = new LookupImageRequest()
+            {
+                ImageType = "Developer",
+            }.ToDictionary();
+
+            Assert.Equal("LookupImage", Assert.Contains("Command", dict).ToObject());
+            Assert.Equal("Developer", Assert.Contains("ImageType", dict).ToObject());
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/LookupImageResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/LookupImageResponseTests.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="LookupImageResponseTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.MobileImageMounter;
+using System.IO;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="LookupImageResponse"/> class.
+    /// </summary>
+    public class LookupImageResponseTests
+    {
+        /// <summary>
+        /// <see cref="LookupImageResponse.FromDictionary(NSDictionary)"/> works correctly.
+        /// </summary>
+        /// <param name="path">
+        /// The path to the file which contains the serialized response.
+        /// </param>
+        /// <param name="hasImage">
+        /// A value indicating whether the response indicates the image is mounted.
+        /// </param>
+        [Theory]
+        [InlineData("MobileImageMounter/noImagesResponse.bin", false)]
+        [InlineData("MobileImageMounter/imageLookupResponse.bin", true)]
+        public void FromDictionary(string path, bool hasImage)
+        {
+            var response = new LookupImageResponse();
+
+            NSDictionary dictionary = (NSDictionary)XmlPropertyListParser.Parse(File.ReadAllBytes(path));
+            response.FromDictionary(dictionary);
+            Assert.Null(response.DetailedError);
+            Assert.Null(response.Error);
+            Assert.Equal(hasImage, response.ImageSignature != null);
+            Assert.Equal("Complete", response.Status);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterClientFactoryTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterClientFactoryTests.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="MobileImageMounterClientFactoryTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.MobileImageMounter;
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="MobileImageMounterClient"/> class.
+    /// </summary>
+    public class MobileImageMounterClientFactoryTests
+    {
+        /// <summary>
+        /// The <see cref="MobileImageMounterClientFactory"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClientFactory(null, new DeviceContext(), Mock.Of<LockdownClientFactory>(), NullLogger<MobileImageMounterClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClientFactory(Mock.Of<MuxerClient>(), null, Mock.Of<LockdownClientFactory>(), NullLogger<MobileImageMounterClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClientFactory(Mock.Of<MuxerClient>(), new DeviceContext(), null, NullLogger<MobileImageMounterClient>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClientFactory(Mock.Of<MuxerClient>(), new DeviceContext(), Mock.Of<LockdownClientFactory>(), null));
+        }
+
+        /// <summary>
+        /// The <see cref="MobileImageMounterClientFactory.CreateAsync(CancellationToken)"/> method returns a properly
+        /// configured <see cref="MobileImageMounterClient"/>.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateAsync_Works_Async()
+        {
+            var lockdownClientFactory = new Mock<LockdownClientFactory>(MockBehavior.Strict);
+            var muxerClient = new Mock<MuxerClient>(MockBehavior.Strict);
+            var context = new DeviceContext() { Device = new MuxerDevice() };
+
+            var lockdownClient = new Mock<LockdownClient>(MockBehavior.Strict);
+            lockdownClientFactory
+                .Setup(l => l.CreateAsync(default))
+                .ReturnsAsync(lockdownClient.Object)
+                .Verifiable();
+
+            lockdownClient
+                .Setup(l => l.StartServiceAsync(MobileImageMounterClient.ServiceName, default))
+                .ReturnsAsync(new ServiceDescriptor() { Port = 1234 })
+                .Verifiable();
+
+            muxerClient
+                .Setup(m => m.ConnectAsync(context.Device, 1234, default))
+                .ReturnsAsync(Stream.Null)
+                .Verifiable();
+
+            var factory = new MobileImageMounterClientFactory(muxerClient.Object, context, lockdownClientFactory.Object, NullLogger<MobileImageMounterClient>.Instance);
+
+            await using (var client = await factory.CreateAsync(default).ConfigureAwait(false))
+            {
+            }
+
+            lockdownClientFactory.Verify();
+            lockdownClient.Verify();
+            muxerClient.Verify();
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterClientTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterClientTests.cs
@@ -1,0 +1,371 @@
+﻿// <copyright file="MobileImageMounterClientTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.MobileImageMounter;
+using Kaponata.iOS.PropertyLists;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="MobileImageMounterClient"/> class.
+    /// </summary>
+    public class MobileImageMounterClientTests
+    {
+        /// <summary>
+        /// The <see cref="MobileImageMounterClient"/> cosntructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClient(null));
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClient(null, NullLogger.Instance));
+            Assert.Throws<ArgumentNullException>(() => new MobileImageMounterClient(Stream.Null, null));
+        }
+
+        /// <summary>
+        /// The <see cref="MobileImageMounterClient"/> methods throw when the instance has been disposed of.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task Methods_ThrowWhenAsyncDisposed_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            var client = new MobileImageMounterClient(protocol.Object);
+            await client.DisposeAsync();
+
+            Assert.True(client.IsDisposed);
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.HangupAsync(default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.LookupImageAsync(null, default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.MountImageAsync(null, null, default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.UploadImageAsync(null, null, null, default)).ConfigureAwait(false);
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// The <see cref="MobileImageMounterClient"/> methods throw when the instance has been disposed of.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [SuppressMessage("Usage", "VSTHRD103:Call async methods when in an async method", Justification = "Testing the .Dispose method")]
+        public async Task Methods_ThrowWhenDisposed_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.Dispose()).Verifiable();
+
+            var client = new MobileImageMounterClient(protocol.Object);
+            client.Dispose();
+
+            Assert.True(client.IsDisposed);
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.HangupAsync(default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.LookupImageAsync(null, default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.MountImageAsync(null, null, default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.UploadImageAsync(null, null, null, default)).ConfigureAwait(false);
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.LookupImageAsync(string, CancellationToken)"/> validates it arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task LookupImageAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.LookupImageAsync(null, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.LookupImageAsync(string, CancellationToken)"/> works correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task LookupImageAsync_Works_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<LookupImageRequest>(), default))
+                .Callback<IPropertyList, CancellationToken>((request, ct) =>
+                {
+                    var lookupImageRequest = Assert.IsType<LookupImageRequest>(request);
+                    Assert.Equal("LookupImage", lookupImageRequest.Command);
+                    Assert.Equal("Developer", lookupImageRequest.ImageType);
+                })
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var response = new LookupImageResponse();
+
+            protocol
+                .Setup(p => p.ReadMessageAsync<LookupImageResponse>(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                Assert.Same(response, await client.LookupImageAsync("Developer", default).ConfigureAwait(false));
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.MountImageAsync(byte[], string, CancellationToken)"/> validates it arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task MountImageAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MountImageAsync(null, string.Empty, default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MountImageAsync(Array.Empty<byte>(), null, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.MountImageAsync(byte[], string, CancellationToken)"/> works correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task MountImageAsync_Works_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<MountImageRequest>(), default))
+                .Callback<IPropertyList, CancellationToken>((request, ct) =>
+                {
+                    var mountImageRequest = Assert.IsType<MountImageRequest>(request);
+                    Assert.Equal("MountImage", mountImageRequest.Command);
+                    Assert.Equal("Developer", mountImageRequest.ImageType);
+                    Assert.Equal(new byte[] { 1, 2, 3, 4 }, mountImageRequest.ImageSignature);
+                })
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var response = new MobileImageMounterResponse() { Status = "Complete" };
+
+            protocol
+                .Setup(p => p.ReadMessageAsync<MobileImageMounterResponse>(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                await client.MountImageAsync(new byte[] { 1, 2, 3, 4 }, "Developer", default).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.MountImageAsync(byte[], string, CancellationToken)"/> works correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task MountImageAsync_HandlesError_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<MountImageRequest>(), default))
+                .Callback<IPropertyList, CancellationToken>((request, ct) =>
+                {
+                    var mountImageRequest = Assert.IsType<MountImageRequest>(request);
+                    Assert.Equal("MountImage", mountImageRequest.Command);
+                    Assert.Equal("Developer", mountImageRequest.ImageType);
+                    Assert.Equal(new byte[] { 1, 2, 3, 4 }, mountImageRequest.ImageSignature);
+                })
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var response = new MobileImageMounterResponse() { Status = "Error" };
+
+            protocol
+                .Setup(p => p.ReadMessageAsync<MobileImageMounterResponse>(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                var ex = await Assert.ThrowsAsync<MobileImageMounterException>(() => client.MountImageAsync(new byte[] { 1, 2, 3, 4 }, "Developer", default));
+                Assert.Equal("Invalid image mounter response. Expected Complete but received the Error status.", ex.Message);
+                Assert.Equal("Error", ex.Status);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.HangupAsync(CancellationToken)"/> works correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task HangupAsync_Works_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<HangupRequest>(), default))
+                .Callback<IPropertyList, CancellationToken>((request, ct) =>
+                {
+                    var hangupRequest = Assert.IsType<HangupRequest>(request);
+                    Assert.Equal("Hangup", hangupRequest.Command);
+                })
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var response = new HangupResponse() { Status = "Complete" };
+
+            protocol
+                .Setup(p => p.ReadMessageAsync<HangupResponse>(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                await client.HangupAsync(default).ConfigureAwait(false);
+            }
+
+            protocol.Verify();
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.UploadImageAsync(Stream, string, byte[], CancellationToken)"/> validates it arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task UploadImageAsync_ValidatesArguments_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UploadImageAsync(null, string.Empty, Array.Empty<byte>(), default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UploadImageAsync(Stream.Null, null, Array.Empty<byte>(), default)).ConfigureAwait(false);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UploadImageAsync(Stream.Null, string.Empty, null, default)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.UploadImageAsync(Stream, string, byte[], CancellationToken)"/> works correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task UploadImageAsync_Works_Async()
+        {
+            using (MemoryStream imageStream = new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!")))
+            using (MemoryStream protocolStream = new MemoryStream())
+            {
+                var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+                protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+                protocol
+                    .Setup(p => p.WriteMessageAsync(It.IsAny<UploadImageRequest>(), default))
+                    .Callback<IPropertyList, CancellationToken>((request, ct) =>
+                    {
+                        var uploadImageRequest = Assert.IsType<UploadImageRequest>(request);
+                        Assert.Equal("ReceiveBytes", uploadImageRequest.Command);
+                        Assert.Equal("Developer", uploadImageRequest.ImageType);
+                        Assert.Equal(13, uploadImageRequest.ImageSize);
+                        Assert.Equal(new byte[] { 1, 2, 3, 4 }, uploadImageRequest.ImageSignature);
+                    })
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                Queue<MobileImageMounterResponse> responses = new Queue<MobileImageMounterResponse>(
+                    new List<MobileImageMounterResponse>()
+                    {
+                        new MobileImageMounterResponse() { Status = "ReceiveBytesAck" },
+                        new MobileImageMounterResponse() { Status = "Complete" },
+                    });
+
+                protocol
+                    .Setup(p => p.ReadMessageAsync<MobileImageMounterResponse>(default))
+                    .ReturnsAsync(responses.Dequeue);
+
+                protocol.Setup(p => p.Stream).Returns(protocolStream);
+
+                await using (var client = new MobileImageMounterClient(protocol.Object))
+                {
+                    await client.UploadImageAsync(imageStream, "Developer", new byte[] { 1, 2, 3, 4 }, default).ConfigureAwait(false);
+                }
+
+                protocol.Verify();
+
+                Assert.Equal("Hello, World!", Encoding.UTF8.GetString(protocolStream.ToArray()));
+                Assert.Empty(responses);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="MobileImageMounterClient.UploadImageAsync(Stream, string, byte[], CancellationToken)"/> handles errors correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task UploadImageAsync_HandlesError_Async()
+        {
+            var protocol = new Mock<PropertyListProtocol>(MockBehavior.Strict);
+            protocol.Setup(p => p.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
+
+            protocol
+                .Setup(p => p.WriteMessageAsync(It.IsAny<UploadImageRequest>(), default))
+                .Callback<IPropertyList, CancellationToken>((request, ct) =>
+                {
+                    var uploadImageRequest = Assert.IsType<UploadImageRequest>(request);
+                    Assert.Equal("ReceiveBytes", uploadImageRequest.Command);
+                    Assert.Equal("Developer", uploadImageRequest.ImageType);
+                    Assert.Equal(0, uploadImageRequest.ImageSize);
+                    Assert.Equal(new byte[] { 1, 2, 3, 4 }, uploadImageRequest.ImageSignature);
+                })
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var response = new MobileImageMounterResponse();
+            response.FromDictionary((NSDictionary)XmlPropertyListParser.Parse(File.ReadAllBytes("MobileImageMounter/mountImageAlreadyMountedResponse.bin")));
+
+            protocol
+                .Setup(p => p.ReadMessageAsync<MobileImageMounterResponse>(default))
+                .ReturnsAsync(response);
+
+            await using (var client = new MobileImageMounterClient(protocol.Object))
+            {
+                var exception = await Assert.ThrowsAsync<MobileImageMounterException>(() => client.UploadImageAsync(Stream.Null, "Developer", new byte[] { 1, 2, 3, 4 }, default)).ConfigureAwait(false);
+                Assert.Equal("Invalid image mounter response: : ImageMountFailed", exception.Message);
+                Assert.Equal("ImageMountFailed", exception.Error);
+                Assert.Null(exception.Status);
+                Assert.NotNull(exception.DetailedError);
+            }
+
+            protocol.Verify();
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterResponseTests.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="MobileImageMounterResponseTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.MobileImageMounter;
+using System.IO;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="MobileImageMounterResponse"/> class.
+    /// </summary>
+    public class MobileImageMounterResponseTests
+    {
+        /// <summary>
+        /// <see cref="MobileImageMounterResponse.FromDictionary(NSDictionary)"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ReadError_Works()
+        {
+            var dict = (NSDictionary)XmlPropertyListParser.Parse(File.ReadAllBytes("MobileImageMounter/mountImageAlreadyMountedResponse.bin"));
+            MobileImageMounterResponse response = new MobileImageMounterResponse();
+            response.FromDictionary(dict);
+
+            Assert.NotNull(response.DetailedError);
+            Assert.Equal("ImageMountFailed", response.Error);
+            Assert.Null(response.Status);
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/MountImageRequestTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/MountImageRequestTests.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="MountImageRequestTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.MobileImageMounter;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="MountImageRequest"/> class.
+    /// </summary>
+    public class MountImageRequestTests
+    {
+        /// <summary>
+        /// <see cref="MountImageRequest.ToDictionary"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToDictionary_Works()
+        {
+            var request = new MountImageRequest()
+            {
+                ImagePath = "/private/var/mobile/Media/PublicStaging/staging.dimage",
+                ImageType = "Developer",
+                ImageSignature = new byte[] { 1, 2, 3, 4 },
+            }.ToDictionary();
+
+            Assert.Equal("MountImage", Assert.Contains<string, NSObject>("Command", request).ToObject());
+            Assert.Equal("/private/var/mobile/Media/PublicStaging/staging.dimage", Assert.Contains<string, NSObject>("ImagePath", request).ToObject());
+            Assert.Equal("Developer", Assert.Contains<string, NSObject>("ImageType", request).ToObject());
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, Assert.Contains<string, NSObject>("ImageSignature", request).ToObject());
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/UploadImageRequestTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/UploadImageRequestTests.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="UploadImageRequestTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.MobileImageMounter;
+using Xunit;
+
+namespace Kaponata.iOS.Tests.MobileImageMounter
+{
+    /// <summary>
+    /// Tests the <see cref="UploadImageRequest"/> class.
+    /// </summary>
+    public class UploadImageRequestTests
+    {
+        /// <summary>
+        /// <see cref="UploadImageRequest.ToDictionary"/> works correctly.
+        /// </summary>
+        [Fact]
+        public void ToDictionary_Works()
+        {
+            var request = new UploadImageRequest()
+            {
+                ImageSignature = new byte[] { 1, 2, 3, 4 },
+                ImageSize = 4,
+                ImageType = "Developer",
+            }.ToDictionary();
+
+            Assert.Equal("ReceiveBytes", Assert.Contains("Command", request).ToObject());
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, Assert.Contains("ImageSignature", request).ToObject());
+            Assert.Equal(4, Assert.Contains("ImageSize", request).ToObject());
+            Assert.Equal("Developer", Assert.Contains("ImageType", request).ToString());
+        }
+    }
+}

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/imageLookupResponse.bin
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/imageLookupResponse.bin
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ImageSignature</key>
+	<array>
+		<data>
+		k4Eo+ylEi5pRJsfvB7rNpeT0tTkZnlskCptZYppzHXtIzkjJE8p/uRhVIYaL
+		dm+84y1kskPkwKbG9AEX/KlWlJBkKVsgvSC1VwpVk1bi4doUKsszWDb/RTwG
+		yPdGDf7sbEgN0seFeBoEsKhcMw3sX922k2XcgN+rlswiCe8V39Q=
+		</data>
+	</array>
+	<key>Status</key>
+	<string>Complete</string>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/mountImageAlreadyMountedResponse.bin
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/mountImageAlreadyMountedResponse.bin
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DetailedError</key>
+	<string>Error Domain=com.apple.MobileStorage.ErrorDomain Code=-2 "Failed to mount /private/var/run/mobile_image_mounter/938128FB29448B9A5126C7EF07BACDA5E4F4B539199E5B240A9B59629A731D7B48CE48C913CA7FB9185521868B766FBCE32D64B243E4C0A6C6F40117FCA95694/9064295B20BD20B5570A559356E2E1DA142ACB335836FF453C06C8F7460DFEEC6C480DD2C785781A04B0A85C330DEC5FDDB69365DC80DFAB96CC2209EF15DFD4/UyDcHL.dmg." UserInfo={NSLocalizedDescription=Failed to mount /private/var/run/mobile_image_mounter/938128FB29448B9A5126C7EF07BACDA5E4F4B539199E5B240A9B59629A731D7B48CE48C913CA7FB9185521868B766FBCE32D64B243E4C0A6C6F40117FCA95694/9064295B20BD20B5570A559356E2E1DA142ACB335836FF453C06C8F7460DFEEC6C480DD2C785781A04B0A85C330DEC5FDDB69365DC80DFAB96CC2209EF15DFD4/UyDcHL.dmg., NSUnderlyingError=0x104609f90 {Error Domain=com.apple.MobileStorage.ErrorDomain Code=-2 "Invalid value for MountPath: Error Domain=com.apple.MobileStorage.ErrorDomain Code=-3 "A disk image of type Developer/(null) is already mounted at /Developer." UserInfo={NSLocalizedDescription=A disk image of type Developer/(null) is already mounted at /Developer.}" UserInfo={NSLocalizedDescription=Invalid value for MountPath: Error Domain=com.apple.MobileStorage.ErrorDomain Code=-3 "A disk image of type Developer/(null) is already mounted at /Developer." UserInfo={NSLocalizedDescription=A disk image of type Developer/(null) is already mounted at /Developer.}}}}</string>
+	<key>Error</key>
+	<string>ImageMountFailed</string>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/noImagesResponse.bin
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/noImagesResponse.bin
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Status</key>
+	<string>Complete</string>
+</dict>
+</plist>

--- a/src/Kaponata.iOS.Tests/NSDictionaryExtensionsTests.cs
+++ b/src/Kaponata.iOS.Tests/NSDictionaryExtensionsTests.cs
@@ -4,6 +4,7 @@
 
 using Claunia.PropertyList;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Kaponata.iOS.Tests
@@ -117,6 +118,30 @@ namespace Kaponata.iOS.Tests
             dict.Add("key", new NSNumber(true));
 
             Assert.True(dict.GetNullableBoolean("key"));
+        }
+
+        /// <summary>
+        /// <see cref="NSDictionaryExtensions.GetBoolean(NSDictionary, string)"/> throws an excpetion
+        /// if the key is not present in the dictionary.
+        /// </summary>
+        [Fact]
+        public void GetBoolean_MissingKey_Throws()
+        {
+            var dict = new NSDictionary();
+            Assert.Throws<KeyNotFoundException>(() => dict.GetBoolean("missing"));
+        }
+
+        /// <summary>
+        /// <see cref="NSDictionaryExtensions.GetBoolean(NSDictionary, string)"/> returns the correct value
+        /// if the entry is a single <see cref="NSNumber"/> object.
+        /// </summary>
+        [Fact]
+        public void GetBoolean_ReturnsValue()
+        {
+            var dict = new NSDictionary();
+            dict.Add("key", new NSNumber(true));
+
+            Assert.True(dict.GetBoolean("key"));
         }
 
         /// <summary>

--- a/src/Kaponata.iOS/GlobalSuppressions.cs
+++ b/src/Kaponata.iOS/GlobalSuppressions.cs
@@ -15,3 +15,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.SpingBoardServices")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.DiagnosticsRelay")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.DeveloperDisks")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Standard iOS spelling", Scope = "namespace", Target = "~N:Kaponata.iOS.MobileImageMounter")]

--- a/src/Kaponata.iOS/MobileImageMounter/HangupRequest.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/HangupRequest.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="HangupRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.PropertyLists;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// A request to the remote end to terminate the connection.
+    /// </summary>
+    public class HangupRequest : IPropertyList
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the command type.
+        /// </summary>
+        public string Command { get; set; } = "Hangup";
+
+        /// <inheritdoc/>
+        public NSDictionary ToDictionary()
+        {
+            var dict = new NSDictionary();
+            dict.Add(nameof(this.Command), this.Command);
+            return dict;
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/HangupResponse.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/HangupResponse.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="HangupResponse.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// A response from the remote end, confirming the connection has been terminated.
+    /// </summary>
+    public class HangupResponse : MobileImageMounterResponse
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the remote end has acknowledged the terminate request.
+        /// </summary>
+        public bool Goodbye { get; set; }
+
+        /// <inheritdoc/>
+        public override void FromDictionary(NSDictionary dictionary)
+        {
+            base.FromDictionary(dictionary);
+            this.Goodbye = dictionary.GetBoolean(nameof(this.Goodbye));
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/LookupImageRequest.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/LookupImageRequest.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="LookupImageRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.PropertyLists;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Represents a request which is sent to the mobile image mounter service running on the device.
+    /// </summary>
+    public class LookupImageRequest : IPropertyList
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the command type.
+        /// </summary>
+        public string Command { get; set; } = "LookupImage";
+
+        /// <summary>
+        /// Gets or sets a value indicating the image type.
+        /// </summary>
+        public string ImageType
+        {
+            get; set;
+        }
+
+        /// <inheritdoc/>
+        public NSDictionary ToDictionary()
+        {
+            var dict = new NSDictionary();
+            dict.Add(nameof(this.Command), this.Command);
+            dict.Add(nameof(this.ImageType), this.ImageType);
+            return dict;
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/LookupImageResponse.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/LookupImageResponse.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="LookupImageResponse.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using System.Collections.Generic;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Respresents the response of a LookupImage request.
+    /// </summary>
+    public class LookupImageResponse : MobileImageMounterResponse
+    {
+        /// <summary>
+        /// Gets or sets the signature object as retrieved from the device.
+        /// </summary>
+        public IList<byte[]> ImageSignature { get; set; }
+
+        /// <inheritdoc/>
+        public override void FromDictionary(NSDictionary dictionary)
+        {
+            base.FromDictionary(dictionary);
+
+            this.ImageSignature = dictionary.GetDataArray(nameof(this.ImageSignature));
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClient.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClient.cs
@@ -1,0 +1,219 @@
+﻿// <copyright file="MobileImageMounterClient.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.PropertyLists;
+using Microsoft;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// The <see cref="MobileImageMounterClient"/> provides access to the mobile image mounter services running on the device.
+    /// </summary>
+    public class MobileImageMounterClient : IAsyncDisposable, IDisposableObservable
+    {
+        /// <summary>
+        /// Gets the name of the mobile image mounter service on the device.
+        /// </summary>
+        public const string ServiceName = "com.apple.mobile.mobile_image_mounter";
+
+        private readonly PropertyListProtocol protocol;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterClient"/> class.
+        /// </summary>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> which represents a connection to the mobile image mounter services running on the device.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which can be used when logging.
+        /// </param>
+        public MobileImageMounterClient(Stream stream, ILogger logger)
+        {
+            this.protocol = new PropertyListProtocol(stream, ownsStream: true, logger);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterClient"/> class.
+        /// </summary>
+        /// <param name="protocol">
+        /// A <see cref="PropertyListProtocol"/> which represents a connection to the mobile image mounter services running on the device.
+        /// </param>
+        public MobileImageMounterClient(PropertyListProtocol protocol)
+        {
+            this.protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
+        }
+
+        /// <inheritdoc/>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
+        /// Gets the image status of the device.
+        /// </summary>
+        /// <param name="imageType">
+        /// The image type to lookup.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A image status of the device.
+        /// </returns>
+        public async Task<LookupImageResponse> LookupImageAsync(string imageType, CancellationToken cancellationToken)
+        {
+            Verify.NotDisposed(this);
+            Requires.NotNull(imageType, nameof(imageType));
+
+            await this.protocol.WriteMessageAsync(
+                new LookupImageRequest()
+                {
+                    ImageType = imageType,
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            var response = await this.protocol.ReadMessageAsync<LookupImageResponse>(cancellationToken).ConfigureAwait(false);
+            this.EnsureValidResponse(response);
+
+            return response;
+        }
+
+        /// <summary>
+        /// Uploads the image to the device.
+        /// </summary>
+        /// <param name="image">
+        /// The image to be uploaded.
+        /// </param>
+        /// <param name="imageType">
+        /// The type of the image. e.g. "Developer".
+        /// </param>
+        /// <param name="signature">
+        /// The signature of the image.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public async Task UploadImageAsync(Stream image, string imageType, byte[] signature, CancellationToken cancellationToken)
+        {
+            Verify.NotDisposed(this);
+
+            Requires.NotNull(image, nameof(image));
+            Requires.NotNull(imageType, nameof(imageType));
+            Requires.NotNull(signature, nameof(signature));
+
+            await this.protocol.WriteMessageAsync(
+                new UploadImageRequest()
+                {
+                    ImageType = imageType,
+                    ImageSignature = signature,
+                    ImageSize = (int)image.Length,
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            var response = await this.protocol.ReadMessageAsync<MobileImageMounterResponse>(cancellationToken).ConfigureAwait(false);
+            this.EnsureValidResponse(response, "ReceiveBytesAck");
+
+            image.Seek(0, SeekOrigin.Begin);
+            await image.CopyToAsync(this.protocol.Stream, bufferSize: 0x10_000, cancellationToken).ConfigureAwait(false);
+
+            response = await this.protocol.ReadMessageAsync<MobileImageMounterResponse>(cancellationToken).ConfigureAwait(false);
+            this.EnsureValidResponse(response, "Complete");
+        }
+
+        /// <summary>
+        /// Mounts the uploaded image to the device.
+        /// </summary>
+        /// <param name="signature">
+        /// The signature of the image.
+        /// </param>
+        /// <param name="imageType">
+        /// The image type.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        public async Task MountImageAsync(byte[] signature, string imageType, CancellationToken cancellationToken)
+        {
+            Verify.NotDisposed(this);
+
+            Requires.NotNull(signature, nameof(signature));
+            Requires.NotNull(imageType, nameof(imageType));
+
+            await this.protocol.WriteMessageAsync(
+                new MountImageRequest()
+                {
+                    ImageType = imageType,
+                    ImageSignature = signature,
+                    ImagePath = "/private/var/mobile/Media/PublicStaging/staging.dimage",
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            var response = await this.protocol.ReadMessageAsync<MobileImageMounterResponse>(cancellationToken).ConfigureAwait(false);
+            this.EnsureValidResponse(response, "Complete");
+        }
+
+        /// <summary>
+        /// Sends the hangup command.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task HangupAsync(CancellationToken cancellationToken)
+        {
+            Verify.NotDisposed(this);
+
+            await this.protocol.WriteMessageAsync(
+                new HangupRequest(),
+                cancellationToken).ConfigureAwait(false);
+
+            var response = this.protocol.ReadMessageAsync<HangupResponse>(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            this.IsDisposed = true;
+
+            return this.protocol.DisposeAsync();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.IsDisposed = true;
+
+            this.protocol.Dispose();
+        }
+
+        private void EnsureValidResponse(MobileImageMounterResponse response)
+        {
+            if (!string.IsNullOrEmpty(response.Error) || !string.IsNullOrEmpty(response.DetailedError))
+            {
+                throw new MobileImageMounterException($"Invalid image mounter response: {response.Status}: {response.Error}", response.Status, response.Error, response.DetailedError);
+            }
+        }
+
+        private void EnsureValidResponse(MobileImageMounterResponse response, string expectedStatus)
+        {
+            this.EnsureValidResponse(response);
+
+            if (response.Status != expectedStatus)
+            {
+                throw new MobileImageMounterException($"Invalid image mounter response. Expected {expectedStatus} but received the {response.Status} status.", response.Status, response.Error, response.DetailedError);
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClientFactory.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClientFactory.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="MobileImageMounterClientFactory.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.Muxer;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Connects to the Mobile Image Mounter service running on an iOS device, and creates a <see cref="MobileImageMounterClient"/> objects.
+    /// </summary>
+    public class MobileImageMounterClientFactory : ServiceClientFactory<MobileImageMounterClient>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterClientFactory"/> class.
+        /// </summary>
+        /// <param name="muxer">
+        /// The <see cref="MuxerClient"/> which represents the connection to the iOS USB Multiplexor.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="DeviceContext"/> which contains information about the device with which
+        /// we are interacting.
+        /// </param>
+        /// <param name="lockdownClientFactory">
+        /// A <see cref="LockdownClientFactory"/> which can create a connection to lockdown.
+        /// </param>
+        /// <param name="logger">
+        /// A <see cref="ILogger"/> which can be used when logging.
+        /// </param>
+        public MobileImageMounterClientFactory(MuxerClient muxer, DeviceContext context, LockdownClientFactory lockdownClientFactory, ILogger<MobileImageMounterClient> logger)
+            : base(muxer, context, lockdownClientFactory, logger)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override async Task<MobileImageMounterClient> CreateAsync(string serviceName, CancellationToken cancellationToken)
+        {
+            var serviceStream = await this.StartServiceAsync(serviceName, cancellationToken);
+            return new MobileImageMounterClient(serviceStream, this.Logger);
+        }
+
+        /// <inheritdoc/>
+        public override Task<MobileImageMounterClient> CreateAsync(CancellationToken cancellationToken) => this.CreateAsync(MobileImageMounterClient.ServiceName, cancellationToken);
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterException.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterException.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="MobileImageMounterException.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Represents errors when mounting iOS images.
+    /// </summary>
+    public class MobileImageMounterException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterException"/> class.
+        /// </summary>
+        /// <param name="message">
+        /// The message that describes the error.
+        /// </param>
+        /// <param name="status">
+        /// The status of the <see cref="MobileImageMounterResponse"/>.
+        /// </param>
+        /// <param name="error">
+        /// The error of the <see cref="MobileImageMounterResponse"/>.
+        /// </param>
+        /// <param name="detailedError">
+        /// The detailed error of the <see cref="MobileImageMounterResponse"/>.
+        /// </param>
+        public MobileImageMounterException(string message, string status, string error, string detailedError)
+            : base(message)
+        {
+            this.Status = status;
+            this.DetailedError = detailedError;
+            this.Error = error;
+        }
+
+        /// <summary>
+        /// Gets or sets the status of the <see cref="MobileImageMounterResponse"/>.
+        /// </summary>
+        public string Status
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the error of the <see cref="MobileImageMounterResponse"/>.
+        /// </summary>
+        public string Error
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the detailed error of the <see cref="MobileImageMounterResponse"/>.
+        /// </summary>
+        public string DetailedError
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterResponse.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterResponse.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="MobileImageMounterResponse.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.PropertyLists;
+using Microsoft;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Respresents the response of a image mounter request.
+    /// </summary>
+    public class MobileImageMounterResponse : IPropertyListDeserializable
+    {
+        /// <summary>
+        /// Gets or sets the status.
+        /// </summary>
+        public string Status
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the response error.
+        /// </summary>
+        public string Error
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the detailed error.
+        /// </summary>
+        public string DetailedError
+        {
+            get;
+            set;
+        }
+
+        /// <inheritdoc/>
+        public virtual void FromDictionary(NSDictionary dictionary)
+        {
+            Requires.NotNull(dictionary, nameof(dictionary));
+
+            this.Status = dictionary.GetString(nameof(this.Status));
+            this.Error = dictionary.GetString(nameof(this.Error));
+            this.DetailedError = dictionary.GetString(nameof(this.DetailedError));
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/MountImageRequest.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MountImageRequest.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="MountImageRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.PropertyLists;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Represents the mount image request.
+    /// </summary>
+    public class MountImageRequest : IPropertyList
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the command type.
+        /// </summary>
+        public string Command { get; set; } = "MountImage";
+
+        /// <summary>
+        /// Gets or sets the path to the image (on the device).
+        /// </summary>
+        public string ImagePath
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets or sets the image signature.
+        /// </summary>
+        public byte[] ImageSignature
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the image type.
+        /// </summary>
+        public string ImageType
+        {
+            get; set;
+        }
+
+        /// <inheritdoc/>
+        public NSDictionary ToDictionary()
+        {
+            var dict = new NSDictionary();
+            dict.Add(nameof(this.Command), this.Command);
+            dict.Add(nameof(this.ImagePath), this.ImagePath);
+            dict.Add(nameof(this.ImageSignature), this.ImageSignature);
+            dict.Add(nameof(this.ImageType), this.ImageType);
+            return dict;
+        }
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/UploadImageRequest.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/UploadImageRequest.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="UploadImageRequest.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Claunia.PropertyList;
+using Kaponata.iOS.PropertyLists;
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Represents the upload image request.
+    /// </summary>
+    public class UploadImageRequest : IPropertyList
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the command type.
+        /// </summary>
+        public string Command { get; set; } = "ReceiveBytes";
+
+        /// <summary>
+        /// Gets or sets the image signature.
+        /// </summary>
+        public byte[] ImageSignature
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the image size.
+        /// </summary>
+        public int ImageSize
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the image type.
+        /// </summary>
+        public string ImageType
+        {
+            get; set;
+        }
+
+        /// <inheritdoc/>
+        public NSDictionary ToDictionary()
+        {
+            var dict = new NSDictionary();
+            dict.Add(nameof(this.Command), this.Command);
+            dict.Add(nameof(this.ImageSignature), this.ImageSignature);
+            dict.Add(nameof(this.ImageSize), this.ImageSize);
+            dict.Add(nameof(this.ImageType), this.ImageType);
+            return dict;
+        }
+    }
+}

--- a/src/Kaponata.iOS/NSDictionaryExtensions.cs
+++ b/src/Kaponata.iOS/NSDictionaryExtensions.cs
@@ -101,6 +101,23 @@ namespace Kaponata.iOS
         }
 
         /// <summary>
+        /// Gets the value associated with the specified <paramref name="key"/>, as a <see langword="bool"/> value.
+        /// </summary>
+        /// <param name="dict">
+        /// The dictionary in which to search for the value associated with the specified <paramref name="key"/>.
+        /// </param>
+        /// <param name="key">
+        /// The key of the value to get.
+        /// </param>
+        /// <returns>
+        /// The value associated with the specified key.
+        /// </returns>
+        public static bool GetBoolean(this NSDictionary dict, string key)
+        {
+            return ((NSNumber)dict[key]).ToBool();
+        }
+
+        /// <summary>
         /// Gets the value associated with the specified <paramref name="key"/>, as a <see cref="DateTime"/> value.
         /// </summary>
         /// <param name="dict">

--- a/src/Kaponata.iOS/PropertyLists/PropertyListProtocol.cs
+++ b/src/Kaponata.iOS/PropertyLists/PropertyListProtocol.cs
@@ -62,7 +62,7 @@ namespace Kaponata.iOS.PropertyLists
         /// <summary>
         /// Gets the <see cref="Stream"/> which is used to communicate with the device.
         /// </summary>
-        public Stream Stream => this.stream;
+        public virtual Stream Stream => this.stream;
 
         /// <summary>
         /// Asynchronously sends a message to the remote lockdown client.
@@ -211,7 +211,7 @@ namespace Kaponata.iOS.PropertyLists
         }
 
         /// <inheritdoc/>
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
             if (this.stream != this.rawStream)
             {
@@ -227,7 +227,7 @@ namespace Kaponata.iOS.PropertyLists
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (this.stream != this.rawStream)
             {


### PR DESCRIPTION
The `MobileImageMounterClient` can be used to mount developer disk images on iOS devices.

The sidecar will use this client to ensure the developer disk image is mounted on any device attached to the cluster.