### PR TITLE
PropertyListProtocol improvements

### DIFF
--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.GetValue.cs
@@ -46,6 +46,8 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var value = await client.GetValueAsync("my-key", default).ConfigureAwait(false);
@@ -81,6 +83,8 @@ namespace Kaponata.iOS.Tests.Lockdown
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
+
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -118,6 +122,8 @@ namespace Kaponata.iOS.Tests.Lockdown
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
+
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
@@ -160,6 +166,8 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<byte[]>>(default)).CallBase();
+
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await client.GetPublicKeyAsync(default).ConfigureAwait(false);
@@ -194,6 +202,8 @@ namespace Kaponata.iOS.Tests.Lockdown
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
+
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
@@ -269,6 +269,8 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(dict);
 
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+
             await using (var lockdown = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 var result = await lockdown.ValidatePairAsync(pairingRecord, default).ConfigureAwait(false);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -187,6 +187,8 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);
 
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await Assert.ThrowsAsync<LockdownException>(
@@ -222,6 +224,8 @@ namespace Kaponata.iOS.Tests.Lockdown
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);
+
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
 
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.SetValue.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.SetValue.cs
@@ -48,6 +48,8 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .ReturnsAsync(dict)
                 .Verifiable();
 
+            protocol.Setup(p => p.ReadMessageAsync<LockdownResponse<string>>(default)).CallBase();
+
             await using (var client = new LockdownClient(protocol.Object, NullLogger<LockdownClient>.Instance))
             {
                 await client.SetValueAsync(domain: "my-domain", key: "my-key", value: "my-value", default).ConfigureAwait(false);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownResponseTests.cs
@@ -15,16 +15,17 @@ namespace Kaponata.iOS.Tests.Lockdown
     public class LockdownResponseTests
     {
         /// <summary>
-        /// <see cref="LockdownResponse{T}.Read(NSDictionary)"/> validates its arguments.
+        /// <see cref="LockdownResponse{T}.FromDictionary(NSDictionary)"/> validates its arguments.
         /// </summary>
         [Fact]
         public void Read_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => LockdownResponse<string>.Read(null));
+            var response = new LockdownResponse<string>();
+            Assert.Throws<ArgumentNullException>(() => response.FromDictionary(null));
         }
 
         /// <summary>
-        /// Tests the <see cref="LockdownResponse{T}.Read(NSDictionary)"/> method.
+        /// Tests the <see cref="LockdownResponse{T}.FromDictionary(NSDictionary)"/> method.
         /// </summary>
         [Fact]
         public void Read_Works()
@@ -34,7 +35,8 @@ namespace Kaponata.iOS.Tests.Lockdown
             dict.Add("Result", "Success");
             dict.Add("Type", "com.apple.mobile.lockdown");
 
-            var response = LockdownResponse<string>.Read(dict);
+            var response = new LockdownResponse<string>();
+            response.FromDictionary(dict);
 
             Assert.Equal("QueryType", response.Request);
             Assert.Equal("Success", response.Result);

--- a/src/Kaponata.iOS/Lockdown/LockdownClient.GetValue.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownClient.GetValue.cs
@@ -59,12 +59,11 @@ namespace Kaponata.iOS.Lockdown
                 },
                 cancellationToken).ConfigureAwait(false);
 
-            var response = await this.protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
-            var message = LockdownResponse<T>.Read(response);
+            var response = await this.protocol.ReadMessageAsync<LockdownResponse<T>>(cancellationToken).ConfigureAwait(false);
 
-            this.EnsureSuccess(message);
+            this.EnsureSuccess(response);
 
-            return message.Value;
+            return response.Value;
         }
 
         /// <summary>

--- a/src/Kaponata.iOS/Lockdown/LockdownClient.Session.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownClient.Session.cs
@@ -105,8 +105,7 @@ namespace Kaponata.iOS.Lockdown
                 },
                 cancellationToken).ConfigureAwait(false);
 
-            var message = await this.protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
-            var response = LockdownResponse<string>.Read(message);
+            var response = await this.protocol.ReadMessageAsync<LockdownResponse<string>>(cancellationToken).ConfigureAwait(false);
 
             if (response.Error != null)
             {

--- a/src/Kaponata.iOS/Lockdown/LockdownClient.SetValue.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownClient.SetValue.cs
@@ -42,10 +42,9 @@ namespace Kaponata.iOS.Lockdown
                 },
                 cancellationToken).ConfigureAwait(false);
 
-            var response = await this.protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
-            var message = LockdownResponse<string>.Read(response);
+            var response = await this.protocol.ReadMessageAsync<LockdownResponse<string>>(cancellationToken).ConfigureAwait(false);
 
-            this.EnsureSuccess(message);
+            this.EnsureSuccess(response);
         }
     }
 }

--- a/src/Kaponata.iOS/Lockdown/LockdownClient.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownClient.cs
@@ -99,10 +99,8 @@ namespace Kaponata.iOS.Lockdown
                 },
                 cancellationToken).ConfigureAwait(false);
 
-            var response = await this.protocol.ReadMessageAsync(cancellationToken).ConfigureAwait(false);
-            var message = LockdownResponse<string>.Read(response);
-
-            return message.Type;
+            var response = await this.protocol.ReadMessageAsync<LockdownResponse<string>>(cancellationToken).ConfigureAwait(false);
+            return response.Type;
         }
 
         /// <inheritdoc/>

--- a/src/Kaponata.iOS/Lockdown/LockdownResponse.Serialization.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownResponse.Serialization.cs
@@ -3,7 +3,7 @@
 // </copyright>
 
 using Claunia.PropertyList;
-using System;
+using Microsoft;
 
 namespace Kaponata.iOS.Lockdown
 {
@@ -18,32 +18,22 @@ namespace Kaponata.iOS.Lockdown
         /// <param name="data">
         /// The message data.
         /// </param>
-        /// <returns>
-        /// A <see cref="LockdownResponse{T}"/> object.
-        /// </returns>
-        public static LockdownResponse<T> Read(NSDictionary data)
+        public void FromDictionary(NSDictionary data)
         {
-            if (data == null)
+            Requires.NotNull(data, nameof(data));
+
+            this.Domain = data.GetString(nameof(this.Domain));
+            this.Key = data.GetString(nameof(this.Key));
+            this.Request = data.GetString(nameof(this.Request));
+            this.Result = data.GetString(nameof(this.Result));
+            this.Type = data.GetString(nameof(this.Type));
+
+            if (data.ContainsKey(nameof(this.Value)))
             {
-                throw new ArgumentNullException(nameof(data));
+                this.Value = (T)data.Get(nameof(this.Value)).ToObject();
             }
 
-            LockdownResponse<T> value = new LockdownResponse<T>();
-
-            value.Domain = data.GetString(nameof(Domain));
-            value.Key = data.GetString(nameof(Key));
-            value.Request = data.GetString(nameof(Request));
-            value.Result = data.GetString(nameof(Result));
-            value.Type = data.GetString(nameof(Type));
-
-            if (data.ContainsKey(nameof(Value)))
-            {
-                value.Value = (T)data.Get(nameof(Value)).ToObject();
-            }
-
-            value.Error = data.GetString(nameof(Error));
-
-            return value;
+            this.Error = data.GetString(nameof(this.Error));
         }
     }
 }

--- a/src/Kaponata.iOS/Lockdown/LockdownResponse.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownResponse.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using Kaponata.iOS.PropertyLists;
+
 namespace Kaponata.iOS.Lockdown
 {
     /// <summary>
@@ -11,7 +13,7 @@ namespace Kaponata.iOS.Lockdown
     /// <typeparam name="T">
     /// The type of the value.
     /// </typeparam>
-    public partial class LockdownResponse<T>
+    public partial class LockdownResponse<T> : IPropertyListDeserializable
     {
         /// <summary>
         /// Gets or sets the name of the domain of the value which is being returned.

--- a/src/Kaponata.iOS/PropertyLists/PropertyListProtocol.Ssl.cs
+++ b/src/Kaponata.iOS/PropertyLists/PropertyListProtocol.Ssl.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Kaponata.iOS.Lockdown;
+using Microsoft;
 using System;
 using System.Diagnostics;
 using System.Net.Security;
@@ -37,6 +38,8 @@ namespace Kaponata.iOS.PropertyLists
         /// </returns>
         public virtual async Task EnableSslAsync(PairingRecord pairingRecord, CancellationToken cancellationToken)
         {
+            Verify.NotDisposed(this);
+
             if (pairingRecord == null)
             {
                 throw new ArgumentNullException(nameof(pairingRecord));
@@ -96,6 +99,8 @@ namespace Kaponata.iOS.PropertyLists
         /// </returns>
         public virtual async Task DisableSslAsync(CancellationToken cancellationToken)
         {
+            Verify.NotDisposed(this);
+
             var sslStream = this.stream as SslStream;
 
             if (sslStream == null)


### PR DESCRIPTION
- Implement IDisposableVerifiable
- Throw when disposed
- Add convenience ReadMessageAsync<T> where T is IPropertyListDeserializable, to avoid code duplciation