### PR TITLE
Bump DiscUtils to 0.16.6

### DIFF
--- a/src/Kaponata.FileFormats.Tests/Kaponata.FileFormats.Tests.csproj
+++ b/src/Kaponata.FileFormats.Tests/Kaponata.FileFormats.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Kaponata.FileFormats\Kaponata.FileFormats.csproj" />
     <PackageReference Include="Kaponata.FileFormats.TestAssets" Version="0.3.15" />
-    <PackageReference Include="DiscUtils.Fat" Version="0.16.0-alpha0051" />
+    <PackageReference Include="DiscUtils.Fat" Version="0.16.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kaponata.FileFormats/Kaponata.FileFormats.csproj
+++ b/src/Kaponata.FileFormats/Kaponata.FileFormats.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Kaponata.FileFormats.NativeDependencies" Version="0.3.12" />
-    <PackageReference Include="DiscUtils.Core" Version="0.16.0-alpha0055" />
+    <PackageReference Include="DiscUtils.Core" Version="0.16.6" />
     <PackageReference Include="plist-cil" Version="2.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The only difference is that this is a "released" version of DiscUtils, and publishing to NuGet of Kaponata.FileFormats should be unblocked.