### PR TITLE
MobileImageMounterClient: Improve error handling

### DIFF
--- a/src/Kaponata.iOS.Tests/MobileImageMounter/LookupImageResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/LookupImageResponseTests.cs
@@ -35,7 +35,7 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
             Assert.Null(response.DetailedError);
             Assert.Null(response.Error);
             Assert.Equal(hasImage, response.ImageSignature != null);
-            Assert.Equal("Complete", response.Status);
+            Assert.Equal(MobileImageMounterStatus.Complete, response.Status);
         }
     }
 }

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterClientTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterClientTests.cs
@@ -171,7 +171,7 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
-            var response = new MobileImageMounterResponse() { Status = "Complete" };
+            var response = new MobileImageMounterResponse() { Status = MobileImageMounterStatus.Complete };
 
             protocol
                 .Setup(p => p.ReadMessageAsync<MobileImageMounterResponse>(default))
@@ -207,7 +207,7 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
-            var response = new MobileImageMounterResponse() { Status = "Error" };
+            var response = new MobileImageMounterResponse() { Status = MobileImageMounterStatus.ReceiveBytesAck };
 
             protocol
                 .Setup(p => p.ReadMessageAsync<MobileImageMounterResponse>(default))
@@ -216,8 +216,8 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
             await using (var client = new MobileImageMounterClient(protocol.Object))
             {
                 var ex = await Assert.ThrowsAsync<MobileImageMounterException>(() => client.MountImageAsync(new byte[] { 1, 2, 3, 4 }, "Developer", default));
-                Assert.Equal("Invalid image mounter response. Expected Complete but received the Error status.", ex.Message);
-                Assert.Equal("Error", ex.Status);
+                Assert.Equal("Invalid image mounter response. Expected Complete but received the ReceiveBytesAck status.", ex.Message);
+                Assert.Equal(MobileImageMounterStatus.ReceiveBytesAck, ex.Status);
             }
 
             protocol.Verify();
@@ -243,7 +243,7 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
-            var response = new HangupResponse() { Status = "Complete" };
+            var response = new HangupResponse() { Status = MobileImageMounterStatus.Complete };
 
             protocol
                 .Setup(p => p.ReadMessageAsync<HangupResponse>(default))
@@ -304,8 +304,8 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
                 Queue<MobileImageMounterResponse> responses = new Queue<MobileImageMounterResponse>(
                     new List<MobileImageMounterResponse>()
                     {
-                        new MobileImageMounterResponse() { Status = "ReceiveBytesAck" },
-                        new MobileImageMounterResponse() { Status = "Complete" },
+                        new MobileImageMounterResponse() { Status = MobileImageMounterStatus.ReceiveBytesAck },
+                        new MobileImageMounterResponse() { Status = MobileImageMounterStatus.Complete },
                     });
 
                 protocol
@@ -360,7 +360,7 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
             {
                 var exception = await Assert.ThrowsAsync<MobileImageMounterException>(() => client.UploadImageAsync(Stream.Null, "Developer", new byte[] { 1, 2, 3, 4 }, default)).ConfigureAwait(false);
                 Assert.Equal("Invalid image mounter response: : ImageMountFailed", exception.Message);
-                Assert.Equal("ImageMountFailed", exception.Error);
+                Assert.Equal(MobileImageMounterError.ImageMountFailed, exception.Error);
                 Assert.Null(exception.Status);
                 Assert.NotNull(exception.DetailedError);
             }

--- a/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterResponseTests.cs
+++ b/src/Kaponata.iOS.Tests/MobileImageMounter/MobileImageMounterResponseTests.cs
@@ -25,7 +25,7 @@ namespace Kaponata.iOS.Tests.MobileImageMounter
             response.FromDictionary(dict);
 
             Assert.NotNull(response.DetailedError);
-            Assert.Equal("ImageMountFailed", response.Error);
+            Assert.Equal(MobileImageMounterError.ImageMountFailed, response.Error);
             Assert.Null(response.Status);
         }
     }

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClient.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClient.cs
@@ -118,13 +118,13 @@ namespace Kaponata.iOS.MobileImageMounter
                 cancellationToken).ConfigureAwait(false);
 
             var response = await this.protocol.ReadMessageAsync<MobileImageMounterResponse>(cancellationToken).ConfigureAwait(false);
-            this.EnsureValidResponse(response, "ReceiveBytesAck");
+            this.EnsureValidResponse(response, MobileImageMounterStatus.ReceiveBytesAck);
 
             image.Seek(0, SeekOrigin.Begin);
             await image.CopyToAsync(this.protocol.Stream, bufferSize: 0x10_000, cancellationToken).ConfigureAwait(false);
 
             response = await this.protocol.ReadMessageAsync<MobileImageMounterResponse>(cancellationToken).ConfigureAwait(false);
-            this.EnsureValidResponse(response, "Complete");
+            this.EnsureValidResponse(response, MobileImageMounterStatus.Complete);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Kaponata.iOS.MobileImageMounter
                 cancellationToken).ConfigureAwait(false);
 
             var response = await this.protocol.ReadMessageAsync<MobileImageMounterResponse>(cancellationToken).ConfigureAwait(false);
-            this.EnsureValidResponse(response, "Complete");
+            this.EnsureValidResponse(response, MobileImageMounterStatus.Complete);
         }
 
         /// <summary>
@@ -200,13 +200,13 @@ namespace Kaponata.iOS.MobileImageMounter
 
         private void EnsureValidResponse(MobileImageMounterResponse response)
         {
-            if (!string.IsNullOrEmpty(response.Error) || !string.IsNullOrEmpty(response.DetailedError))
+            if (response.Error != null)
             {
-                throw new MobileImageMounterException($"Invalid image mounter response: {response.Status}: {response.Error}", response.Status, response.Error, response.DetailedError);
+                throw new MobileImageMounterException($"Invalid image mounter response: {response.Status}: {response.Error}", response.Status, response.Error.Value, response.DetailedError);
             }
         }
 
-        private void EnsureValidResponse(MobileImageMounterResponse response, string expectedStatus)
+        private void EnsureValidResponse(MobileImageMounterResponse response, MobileImageMounterStatus expectedStatus)
         {
             this.EnsureValidResponse(response);
 

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterError.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterError.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="MobileImageMounterError.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Represents errors returned by the mobile image mounter service running on iOS devices.
+    /// </summary>
+    public enum MobileImageMounterError
+    {
+        /// <summary>
+        /// The service did not return an error.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The client did not specify the command to execute.
+        /// </summary>
+        MissingCommand,
+
+        /// <summary>
+        /// The client requested an unknown command.
+        /// </summary>
+        UnknownCommand,
+
+        /// <summary>
+        /// The image type was missing.
+        /// </summary>
+        MissingImageType,
+
+        /// <summary>
+        /// The image could not be mounted.
+        /// </summary>
+        ImageMountFailed,
+    }
+}

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterException.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterException.cs
@@ -26,7 +26,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <param name="detailedError">
         /// The detailed error of the <see cref="MobileImageMounterResponse"/>.
         /// </param>
-        public MobileImageMounterException(string message, string status, string error, string detailedError)
+        public MobileImageMounterException(string message, MobileImageMounterStatus? status, MobileImageMounterError? error, string detailedError)
             : base(message)
         {
             this.Status = status;
@@ -37,7 +37,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <summary>
         /// Gets or sets the status of the <see cref="MobileImageMounterResponse"/>.
         /// </summary>
-        public string Status
+        public MobileImageMounterStatus? Status
         {
             get;
             set;
@@ -46,7 +46,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <summary>
         /// Gets or sets the error of the <see cref="MobileImageMounterResponse"/>.
         /// </summary>
-        public string Error
+        public MobileImageMounterError? Error
         {
             get;
             set;

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterResponse.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterResponse.cs
@@ -5,6 +5,7 @@
 using Claunia.PropertyList;
 using Kaponata.iOS.PropertyLists;
 using Microsoft;
+using System;
 
 namespace Kaponata.iOS.MobileImageMounter
 {
@@ -16,7 +17,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <summary>
         /// Gets or sets the status.
         /// </summary>
-        public string Status
+        public MobileImageMounterStatus? Status
         {
             get;
             set;
@@ -25,7 +26,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <summary>
         /// Gets or sets the response error.
         /// </summary>
-        public string Error
+        public MobileImageMounterError? Error
         {
             get;
             set;
@@ -45,8 +46,10 @@ namespace Kaponata.iOS.MobileImageMounter
         {
             Requires.NotNull(dictionary, nameof(dictionary));
 
-            this.Status = dictionary.GetString(nameof(this.Status));
-            this.Error = dictionary.GetString(nameof(this.Error));
+            var statusValue = dictionary.GetString(nameof(this.Status));
+            this.Status = statusValue == null ? null : Enum.Parse<MobileImageMounterStatus>(statusValue);
+            var errorValue = dictionary.GetString(nameof(this.Error));
+            this.Error = errorValue == null ? null : Enum.Parse<MobileImageMounterError>(errorValue);
             this.DetailedError = dictionary.GetString(nameof(this.DetailedError));
         }
     }

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterStatus.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterStatus.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="MobileImageMounterStatus.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.iOS.MobileImageMounter
+{
+    /// <summary>
+    /// Represents a status code returned by the mobile image mounter service running on a device.
+    /// </summary>
+    public enum MobileImageMounterStatus
+    {
+        /// <summary>
+        /// The operation has completed successfully.
+        /// </summary>
+        Complete,
+
+        /// <summary>
+        /// The service is ready to receive bytes (usually the contents of the developer disk).
+        /// </summary>
+        ReceiveBytesAck,
+    }
+}


### PR DESCRIPTION
Use enum values for the status and error codes returned by the client.