### PR TITLE
ImageRegistryClient.GetManifestAsync: Return null when not found

### DIFF
--- a/src/Kaponata.Kubernetes/Registry/ImageRegistryClient.cs
+++ b/src/Kaponata.Kubernetes/Registry/ImageRegistryClient.cs
@@ -236,6 +236,11 @@ namespace Kaponata.Kubernetes.Registry
 
             var result = await this.httpClient.GetAsync($"/v2/{repository}/manifests/{reference}", cancellationToken).ConfigureAwait(false);
 
+            if (result.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
             if (result.StatusCode != HttpStatusCode.OK)
             {
                 throw await ImageRegistryException.FromResponseAsync(result, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This avoid having to catch an error to determine whether the manifest exists or not.