### PR TITLE
Introducing the DeviceServiceProvider

### DIFF
--- a/src/Kaponata.Sidecars.Tests/PairingRecordProvisionerTests.cs
+++ b/src/Kaponata.Sidecars.Tests/PairingRecordProvisionerTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Kaponata.iOS;
+using Kaponata.iOS.DependencyInjection;
 using Kaponata.iOS.Lockdown;
 using Kaponata.iOS.Muxer;
 using Kaponata.iOS.Workers;
@@ -58,6 +59,7 @@ namespace Kaponata.Sidecars.Tests
                 .AddSingleton(lockdownFactoryMock.Object)
                 .AddSingleton<PairingRecordProvisioner>()
                 .AddSingleton<DeviceContext>()
+                .AddSingleton<DeviceServiceProvider>()
                 .BuildServiceProvider();
         }
 
@@ -67,10 +69,10 @@ namespace Kaponata.Sidecars.Tests
         [Fact]
         public void Constructor_ValidatesArguments()
         {
-            Assert.Throws<ArgumentNullException>("muxerClient", () => new PairingRecordProvisioner(null, Mock.Of<KubernetesPairingRecordStore>(), Mock.Of<IServiceProvider>(), NullLogger<PairingRecordProvisioner>.Instance));
-            Assert.Throws<ArgumentNullException>("kubernetesPairingRecordStore", () => new PairingRecordProvisioner(Mock.Of<MuxerClient>(), null, Mock.Of<IServiceProvider>(), NullLogger<PairingRecordProvisioner>.Instance));
+            Assert.Throws<ArgumentNullException>("muxerClient", () => new PairingRecordProvisioner(null, Mock.Of<KubernetesPairingRecordStore>(), Mock.Of<DeviceServiceProvider>(), NullLogger<PairingRecordProvisioner>.Instance));
+            Assert.Throws<ArgumentNullException>("kubernetesPairingRecordStore", () => new PairingRecordProvisioner(Mock.Of<MuxerClient>(), null, Mock.Of<DeviceServiceProvider>(), NullLogger<PairingRecordProvisioner>.Instance));
             Assert.Throws<ArgumentNullException>("serviceProvider", () => new PairingRecordProvisioner(Mock.Of<MuxerClient>(), Mock.Of<KubernetesPairingRecordStore>(), null, NullLogger<PairingRecordProvisioner>.Instance));
-            Assert.Throws<ArgumentNullException>("logger", () => new PairingRecordProvisioner(Mock.Of<MuxerClient>(), Mock.Of<KubernetesPairingRecordStore>(), Mock.Of<IServiceProvider>(), null));
+            Assert.Throws<ArgumentNullException>("logger", () => new PairingRecordProvisioner(Mock.Of<MuxerClient>(), Mock.Of<KubernetesPairingRecordStore>(), Mock.Of<DeviceServiceProvider>(), null));
         }
 
         /// <summary>

--- a/src/Kaponata.Sidecars/PairingRecordProvisioner.cs
+++ b/src/Kaponata.Sidecars/PairingRecordProvisioner.cs
@@ -25,7 +25,7 @@ namespace Kaponata.Sidecars
         private readonly MuxerClient muxerClient;
         private readonly ILogger<PairingRecordProvisioner> logger;
         private readonly KubernetesPairingRecordStore kubernetesPairingRecordStore;
-        private readonly IServiceProvider serviceProvider;
+        private readonly DeviceServiceProvider serviceProvider;
         private readonly Dictionary<string, Task> pairingTasks = new Dictionary<string, Task>();
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Kaponata.Sidecars
         /// <param name="logger">
         /// A logger which can be used when logging.
         /// </param>
-        public PairingRecordProvisioner(MuxerClient muxerClient, KubernetesPairingRecordStore kubernetesPairingRecordStore, IServiceProvider serviceProvider, ILogger<PairingRecordProvisioner> logger)
+        public PairingRecordProvisioner(MuxerClient muxerClient, KubernetesPairingRecordStore kubernetesPairingRecordStore, DeviceServiceProvider serviceProvider, ILogger<PairingRecordProvisioner> logger)
         {
             this.muxerClient = muxerClient ?? throw new ArgumentNullException(nameof(muxerClient));
             this.kubernetesPairingRecordStore = kubernetesPairingRecordStore ?? throw new ArgumentNullException(nameof(kubernetesPairingRecordStore));

--- a/src/Kaponata.iOS.Tests/DependencyInjection/DeviceServiceProviderTests.cs
+++ b/src/Kaponata.iOS.Tests/DependencyInjection/DeviceServiceProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ServiceProviderExtensionsTests.cs" company="Quamotion bv">
+﻿// <copyright file="DeviceServiceProviderTests.cs" company="Quamotion bv">
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
@@ -16,12 +16,21 @@ using Xunit;
 namespace Kaponata.iOS.Tests.DependencyInjection
 {
     /// <summary>
-    /// Tests the <see cref="ServiceProviderExtensions"/> class.
+    /// Tests the <see cref="DeviceServiceProvider"/> class.
     /// </summary>
-    public class ServiceProviderExtensionsTests
+    public class DeviceServiceProviderTests
     {
         /// <summary>
-        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// The <see cref="DeviceServiceProvider"/> construct validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DeviceServiceProvider(null));
+        }
+
+        /// <summary>
+        /// <see cref="DeviceServiceProvider.CreateDeviceScopeAsync(string, CancellationToken)"/>
         /// throws a <see cref="MuxerException"/> when no UDID is specified and a no devices are connected.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -37,11 +46,13 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 .AddSingleton<MuxerClient>(muxer.Object)
                 .BuildServiceProvider();
 
-            await Assert.ThrowsAsync<MuxerException>(() => provider.CreateDeviceScopeAsync(null, default)).ConfigureAwait(false);
+            var deviceServiceProvider = new DeviceServiceProvider(provider);
+
+            await Assert.ThrowsAsync<MuxerException>(() => deviceServiceProvider.CreateDeviceScopeAsync(null, default)).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// <see cref="DeviceServiceProvider.CreateDeviceScopeAsync(string, CancellationToken)"/>
         /// throws a <see cref="MuxerException"/> when no UDID is specified and more than one device is connected.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -62,11 +73,13 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 .AddScoped<DeviceContext>()
                 .BuildServiceProvider();
 
-            await Assert.ThrowsAsync<MuxerException>(() => provider.CreateDeviceScopeAsync(null, default)).ConfigureAwait(false);
+            var deviceServiceProvider = new DeviceServiceProvider(provider);
+
+            await Assert.ThrowsAsync<MuxerException>(() => deviceServiceProvider.CreateDeviceScopeAsync(null, default)).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// <see cref="DeviceServiceProvider.CreateDeviceScopeAsync(string, CancellationToken)"/>
         /// returns the connected device when no UDID is specified and only a single device is connected.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -92,7 +105,9 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 .AddScoped<DeviceContext>()
                 .BuildServiceProvider();
 
-            using (var scope = await provider.CreateDeviceScopeAsync(null, default).ConfigureAwait(false))
+            var deviceServiceProvider = new DeviceServiceProvider(provider);
+
+            using (var scope = await deviceServiceProvider.CreateDeviceScopeAsync(null, default).ConfigureAwait(false))
             {
                 var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
                 Assert.Same(device, context.Device);
@@ -101,7 +116,7 @@ namespace Kaponata.iOS.Tests.DependencyInjection
         }
 
         /// <summary>
-        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// <see cref="DeviceServiceProvider.CreateDeviceScopeAsync(string, CancellationToken)"/>
         /// throws an exception when the requested device is not found.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -122,11 +137,13 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 .AddScoped<DeviceContext>()
                 .BuildServiceProvider();
 
-            await Assert.ThrowsAsync<MuxerException>(() => provider.CreateDeviceScopeAsync("3", default)).ConfigureAwait(false);
+            var deviceServiceProvider = new DeviceServiceProvider(provider);
+
+            await Assert.ThrowsAsync<MuxerException>(() => deviceServiceProvider.CreateDeviceScopeAsync("3", default)).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// <see cref="ServiceProviderExtensions.CreateDeviceScopeAsync(IServiceProvider, string, CancellationToken)"/>
+        /// <see cref="DeviceServiceProvider.CreateDeviceScopeAsync(string, CancellationToken)"/>
         /// returns the requested device when available.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -153,7 +170,9 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 .AddScoped<DeviceContext>()
                 .BuildServiceProvider();
 
-            using (var scope = await provider.CreateDeviceScopeAsync("2", default).ConfigureAwait(false))
+            var deviceServiceProvider = new DeviceServiceProvider(provider);
+
+            using (var scope = await deviceServiceProvider.CreateDeviceScopeAsync("2", default).ConfigureAwait(false))
             {
                 var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();
                 Assert.Same(device, context.Device);
@@ -162,7 +181,7 @@ namespace Kaponata.iOS.Tests.DependencyInjection
         }
 
         /// <summary>
-        /// The <see cref="ServiceProviderExtensions.StartServiceAsync{T}(IServiceProvider, string, CancellationToken)"/> method works correctly.
+        /// The <see cref="DeviceServiceProvider.StartServiceAsync{T}(string, CancellationToken)"/> method works correctly.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -190,7 +209,9 @@ namespace Kaponata.iOS.Tests.DependencyInjection
                 .AddScoped<ClientFactory<LockdownClient>>((sp) => factory.Object)
                 .BuildServiceProvider();
 
-            using (var context = await provider.StartServiceAsync<LockdownClient>("2", default).ConfigureAwait(false))
+            var deviceServiceProvider = new DeviceServiceProvider(provider);
+
+            using (var context = await deviceServiceProvider.StartServiceAsync<LockdownClient>("2", default).ConfigureAwait(false))
             {
                 Assert.Same(device, context.Device);
                 Assert.NotNull(context.Scope);

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -262,7 +262,9 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .AddAppleServices()
                 .BuildServiceProvider();
 
-            using (var scope = await serviceProvider.CreateDeviceScopeAsync(null, default).ConfigureAwait(false))
+            var deviceServiceProvider = new DeviceServiceProvider(serviceProvider);
+
+            using (var scope = await deviceServiceProvider.CreateDeviceScopeAsync(null, default).ConfigureAwait(false))
             await using (var lockdown = await scope.StartServiceAsync<LockdownClient>(default).ConfigureAwait(false))
             {
                 var context = scope.ServiceProvider.GetRequiredService<DeviceContext>();

--- a/src/Kaponata.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Kaponata.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ namespace Kaponata.iOS.DependencyInjection
         {
             services.AddSingleton<MuxerClient>();
             services.AddSingleton<PairingRecordGenerator>();
+            services.AddSingleton<DeviceServiceProvider>();
 
             services.AddScoped<DeviceContext>();
 


### PR DESCRIPTION
The `DeviceServiceProvider` class is a simple class which wraps around the `IServiceProvider` and exposes methods to interact with lockdown services running on iOS devices.

The `CreateDeviceScopeAsync` and `StartServiceAsync` methods replace the extension methods on the `IServiceProvider` interface, making these methods easier to mock.

There are no function changes in this PR.