### PR TITLE
Add the DeveloperDiskProvisioner class

### DIFF
--- a/src/Kaponata.Sidecars.Tests/DeveloperDiskProvisionerTests.cs
+++ b/src/Kaponata.Sidecars.Tests/DeveloperDiskProvisionerTests.cs
@@ -1,0 +1,148 @@
+﻿// <copyright file="DeveloperDiskProvisionerTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DependencyInjection;
+using Kaponata.iOS.DeveloperDisks;
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.MobileImageMounter;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Sidecars.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="DeveloperDiskProvisioner"/> class.
+    /// </summary>
+    public class DeveloperDiskProvisionerTests
+    {
+        /// <summary>
+        /// The <see cref="DeveloperDiskProvisioner"/> constructor validates its arguments.
+        /// </summary>
+        [Fact]
+        public void Constructor_ValidatesArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DeveloperDiskProvisioner(null, Mock.Of<DeviceServiceProvider>(), NullLogger<DeveloperDiskProvisioner>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new DeveloperDiskProvisioner(Mock.Of<DeveloperDiskStore>(), null, NullLogger<DeveloperDiskProvisioner>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new DeveloperDiskProvisioner(Mock.Of<DeveloperDiskStore>(), Mock.Of<DeviceServiceProvider>(), null));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskProvisioner.ProvisionDeveloperDiskAsync(string, CancellationToken)"/> returns <see langword="true"/>
+        /// if a developer disk is already mounted.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ProvisionAsync_AlreadyMounted_DoesNothing_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var provider = new Mock<DeviceServiceProvider>(MockBehavior.Strict);
+            const string udid = "udid";
+
+            var scope = new Mock<DeviceServiceScope>(MockBehavior.Strict);
+            provider.Setup(p => p.CreateDeviceScopeAsync(udid, default)).ReturnsAsync(scope.Object);
+
+            var lockdown = new Mock<LockdownClient>(MockBehavior.Strict);
+            var mounter = new Mock<MobileImageMounterClient>(MockBehavior.Strict);
+            scope.Setup(s => s.StartServiceAsync<LockdownClient>(default)).ReturnsAsync(lockdown.Object);
+            scope.Setup(s => s.StartServiceAsync<MobileImageMounterClient>(default)).ReturnsAsync(mounter.Object);
+
+            var provisioner = new DeveloperDiskProvisioner(store.Object, provider.Object, NullLogger<DeveloperDiskProvisioner>.Instance);
+
+            mounter
+                .Setup(m => m.LookupImageAsync("Developer", default))
+                .ReturnsAsync(
+                new LookupImageResponse()
+                {
+                    ImageSignature = new List<byte[]>() { Array.Empty<byte>() },
+                });
+
+            Assert.True(await provisioner.ProvisionDeveloperDiskAsync(udid, default).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskProvisioner.ProvisionDeveloperDiskAsync(string, CancellationToken)"/> returns <see langword="false"/>
+        /// if a developer disk is not mounted and no developer disk is available.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ProvisionAsync_NotMounted_NotAvailable_Fails_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var provider = new Mock<DeviceServiceProvider>(MockBehavior.Strict);
+            const string udid = "udid";
+
+            var scope = new Mock<DeviceServiceScope>(MockBehavior.Strict);
+            provider.Setup(p => p.CreateDeviceScopeAsync(udid, default)).ReturnsAsync(scope.Object);
+
+            var lockdown = new Mock<LockdownClient>(MockBehavior.Strict);
+            var mounter = new Mock<MobileImageMounterClient>(MockBehavior.Strict);
+            scope.Setup(s => s.StartServiceAsync<LockdownClient>(default)).ReturnsAsync(lockdown.Object);
+            scope.Setup(s => s.StartServiceAsync<MobileImageMounterClient>(default)).ReturnsAsync(mounter.Object);
+
+            var provisioner = new DeveloperDiskProvisioner(store.Object, provider.Object, NullLogger<DeveloperDiskProvisioner>.Instance);
+
+            mounter
+                .Setup(m => m.LookupImageAsync("Developer", default))
+                .ReturnsAsync(
+                new LookupImageResponse() { ImageSignature = new List<byte[]>() });
+
+            lockdown.Setup(l => l.GetValueAsync("ProductVersion", default)).ReturnsAsync("14.1.1");
+
+            store.Setup(s => s.GetAsync(new Version(14, 1), default)).ReturnsAsync((DeveloperDisk)null);
+            store.Setup(s => s.GetAsync(new Version(14, 1, 1), default)).ReturnsAsync((DeveloperDisk)null);
+
+            Assert.False(await provisioner.ProvisionDeveloperDiskAsync(udid, default).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// <see cref="DeveloperDiskProvisioner.ProvisionDeveloperDiskAsync(string, CancellationToken)"/> returns <see langword="true"/>
+        /// if a developer disk is not mounted, but a matching developer disk can be mounted.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ProvisionAsync_NotMounted_Available_Success_Async()
+        {
+            var store = new Mock<DeveloperDiskStore>(MockBehavior.Strict);
+            var provider = new Mock<DeviceServiceProvider>(MockBehavior.Strict);
+            const string udid = "udid";
+
+            var scope = new Mock<DeviceServiceScope>(MockBehavior.Strict);
+            provider.Setup(p => p.CreateDeviceScopeAsync(udid, default)).ReturnsAsync(scope.Object);
+
+            var lockdown = new Mock<LockdownClient>(MockBehavior.Strict);
+            var mounter = new Mock<MobileImageMounterClient>(MockBehavior.Strict);
+            scope.Setup(s => s.StartServiceAsync<LockdownClient>(default)).ReturnsAsync(lockdown.Object);
+            scope.Setup(s => s.StartServiceAsync<MobileImageMounterClient>(default)).ReturnsAsync(mounter.Object);
+
+            var disk = new DeveloperDisk()
+            {
+                Image = Stream.Null,
+                Signature = Array.Empty<byte>(),
+            };
+
+            var provisioner = new DeveloperDiskProvisioner(store.Object, provider.Object, NullLogger<DeveloperDiskProvisioner>.Instance);
+
+            mounter
+                .Setup(m => m.LookupImageAsync("Developer", default))
+                .ReturnsAsync(
+                new LookupImageResponse() { ImageSignature = new List<byte[]>() });
+
+            lockdown.Setup(l => l.GetValueAsync("ProductVersion", default)).ReturnsAsync("14.1.1");
+
+            store.Setup(s => s.GetAsync(new Version(14, 1, 1), default)).ReturnsAsync((DeveloperDisk)null);
+            store.Setup(s => s.GetAsync(new Version(14, 1), default)).ReturnsAsync(disk);
+
+            mounter.Setup(s => s.UploadImageAsync(disk.Image, "Developer", disk.Signature, default)).Returns(Task.CompletedTask);
+            mounter.Setup(s => s.MountImageAsync(disk.Signature, "Developer", default)).Returns(Task.CompletedTask);
+
+            Assert.True(await provisioner.ProvisionDeveloperDiskAsync(udid, default).ConfigureAwait(false));
+        }
+    }
+}

--- a/src/Kaponata.Sidecars/DeveloperDiskProvisioner.cs
+++ b/src/Kaponata.Sidecars/DeveloperDiskProvisioner.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="DeveloperDiskProvisioner.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.iOS.DependencyInjection;
+using Kaponata.iOS.DeveloperDisks;
+using Kaponata.iOS.Lockdown;
+using Kaponata.iOS.MobileImageMounter;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Sidecars
+{
+    /// <summary>
+    /// Provisions iOS devices with developer disks.
+    /// </summary>
+    public class DeveloperDiskProvisioner
+    {
+        private readonly DeviceServiceProvider serviceProvider;
+        private readonly DeveloperDiskStore developerDiskStore;
+        private readonly ILogger<DeveloperDiskProvisioner> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeveloperDiskProvisioner"/> class.
+        /// </summary>
+        /// <param name="developerDiskStore">
+        /// A <see cref="developerDiskStore"/> which provides access to a registry of developer disk images.
+        /// </param>
+        /// <param name="serviceProvider">
+        /// A <see cref="DeviceServiceProvider"/> from which services, required to connect to iOS devices, can be sourced.
+        /// </param>
+        /// <param name="logger">
+        /// A logger which is used when logging.
+        /// </param>
+        public DeveloperDiskProvisioner(DeveloperDiskStore developerDiskStore, DeviceServiceProvider serviceProvider, ILogger<DeveloperDiskProvisioner> logger)
+        {
+            this.developerDiskStore = developerDiskStore ?? throw new ArgumentNullException(nameof(developerDiskStore));
+            this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Asynchronously mounts the developer disk on the device.
+        /// </summary>
+        /// <param name="udid">
+        /// The UDID of the device on which to mount the developer disk.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation. The task returns a value indicating whether the developer disk
+        /// is mounted on the device or not.
+        /// </returns>
+        public virtual async Task<bool> ProvisionDeveloperDiskAsync(string udid, CancellationToken cancellationToken)
+        {
+            using (var scope = await this.serviceProvider.CreateDeviceScopeAsync(udid, cancellationToken).ConfigureAwait(false))
+            await using (var lockdown = await scope.StartServiceAsync<LockdownClient>(cancellationToken).ConfigureAwait(false))
+            await using (var imageMounterClient = await scope.StartServiceAsync<MobileImageMounterClient>(cancellationToken).ConfigureAwait(false))
+            {
+                var developerDiskStatus = await imageMounterClient.LookupImageAsync("Developer", cancellationToken).ConfigureAwait(false);
+
+                // The disk is already mounted.
+                if (developerDiskStatus.ImageSignature.Count > 0)
+                {
+                    var signature = developerDiskStatus.ImageSignature.Count > 0 ? Convert.ToBase64String(developerDiskStatus.ImageSignature[0]) : string.Empty;
+
+                    this.logger.LogWarning("A developer disk has already been mounted on device {udid}: {signature}", udid, signature);
+                    return true;
+                }
+
+                // Fetch the disk from the store
+                var versionString = await lockdown.GetValueAsync("ProductVersion", cancellationToken).ConfigureAwait(false);
+                var version = Version.Parse(versionString);
+
+                var developerDisk = await this.developerDiskStore.GetAsync(version, cancellationToken).ConfigureAwait(false);
+
+                if (developerDisk == null && version.Build >= 0)
+                {
+                    var reducedVersion = new Version(version.Major, version.Minor);
+                    this.logger.LogWarning("Could not found the developer disk for version {version}. Attempting to find the developer disk for version {reducedVersion}", version, reducedVersion);
+                    developerDisk = await this.developerDiskStore.GetAsync(reducedVersion, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (developerDisk == null)
+                {
+                    this.logger.LogWarning("Could not mount the developer disk on device {udid} because no developer disk is available", udid);
+                    return false;
+                }
+
+                await imageMounterClient.UploadImageAsync(developerDisk.Image, "Developer", developerDisk.Signature, cancellationToken).ConfigureAwait(false);
+                await imageMounterClient.MountImageAsync(developerDisk.Signature, "Developer", cancellationToken).ConfigureAwait(false);
+
+                this.logger.LogInformation("Mounted the developer disk on device {udid}", udid);
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Kaponata.iOS/DependencyInjection/DeviceServiceScope.cs
+++ b/src/Kaponata.iOS/DependencyInjection/DeviceServiceScope.cs
@@ -69,7 +69,7 @@ namespace Kaponata.iOS.DependencyInjection
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.scope.Dispose();
+            this.scope?.Dispose();
         }
     }
 }

--- a/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClient.cs
+++ b/src/Kaponata.iOS/MobileImageMounter/MobileImageMounterClient.cs
@@ -49,6 +49,16 @@ namespace Kaponata.iOS.MobileImageMounter
             this.protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterClient"/> class.
+        /// </summary>
+        /// <remarks>
+        /// Intended for mocking purposes only.
+        /// </remarks>
+        protected MobileImageMounterClient()
+        {
+        }
+
         /// <inheritdoc/>
         public bool IsDisposed { get; private set; }
 
@@ -64,7 +74,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <returns>
         /// A image status of the device.
         /// </returns>
-        public async Task<LookupImageResponse> LookupImageAsync(string imageType, CancellationToken cancellationToken)
+        public virtual async Task<LookupImageResponse> LookupImageAsync(string imageType, CancellationToken cancellationToken)
         {
             Verify.NotDisposed(this);
             Requires.NotNull(imageType, nameof(imageType));
@@ -100,7 +110,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// </returns>
-        public async Task UploadImageAsync(Stream image, string imageType, byte[] signature, CancellationToken cancellationToken)
+        public virtual async Task UploadImageAsync(Stream image, string imageType, byte[] signature, CancellationToken cancellationToken)
         {
             Verify.NotDisposed(this);
 
@@ -142,7 +152,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// </returns>
-        public async Task MountImageAsync(byte[] signature, string imageType, CancellationToken cancellationToken)
+        public virtual async Task MountImageAsync(byte[] signature, string imageType, CancellationToken cancellationToken)
         {
             Verify.NotDisposed(this);
 
@@ -171,7 +181,7 @@ namespace Kaponata.iOS.MobileImageMounter
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        public async Task HangupAsync(CancellationToken cancellationToken)
+        public virtual async Task HangupAsync(CancellationToken cancellationToken)
         {
             Verify.NotDisposed(this);
 
@@ -187,7 +197,7 @@ namespace Kaponata.iOS.MobileImageMounter
         {
             this.IsDisposed = true;
 
-            return this.protocol.DisposeAsync();
+            return this.protocol == null ? ValueTask.CompletedTask : this.protocol.DisposeAsync();
         }
 
         /// <inheritdoc/>
@@ -195,7 +205,7 @@ namespace Kaponata.iOS.MobileImageMounter
         {
             this.IsDisposed = true;
 
-            this.protocol.Dispose();
+            this.protocol?.Dispose();
         }
 
         private void EnsureValidResponse(MobileImageMounterResponse response)


### PR DESCRIPTION
This provisioner is responsible for:

- Determining whether a developer disk is already mounted
- Determining whether a matching developer disk is available in the developer disk store
- Mounting the matching developer disk when required