### PR TITLE
Support device conditions.

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/Models/MobileDeviceConditionTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Models/MobileDeviceConditionTests.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="MobileDeviceConditionTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes.Models;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.Models
+{
+    /// <summary>
+    /// Tests the <see cref="MobileDeviceCondition"/> class.
+    /// </summary>
+    public class MobileDeviceConditionTests
+    {
+        /// <summary>
+        /// The <see cref="MobileDeviceCondition.ToString"/> method works correctly.
+        /// </summary>
+        [Fact]
+        public void ToString_Works()
+        {
+            Assert.Equal(
+                "Paired: True (Reason)",
+                new MobileDeviceCondition()
+                {
+                    Type = MobileDeviceConditions.Paired,
+                    Status = ConditionStatus.True,
+                    Reason = "Reason",
+                }.ToString());
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/Models/MobileDeviceStatusTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Models/MobileDeviceStatusTests.cs
@@ -19,7 +19,7 @@ namespace Kaponata.Kubernetes.Tests.Models
         /// properties that property is <see langword="null"/>.
         /// </summary>
         [Fact]
-        public void ConditionsNull_AddsCondition()
+        public void SetCondition_ConditionsNull_AddsCondition()
         {
             var status = new MobileDeviceStatus();
             Assert.True(status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.True, "Reason", "Message"));
@@ -36,7 +36,7 @@ namespace Kaponata.Kubernetes.Tests.Models
         /// if the status has changed.
         /// </summary>
         [Fact]
-        public void Conditions_UpdatesCondition()
+        public void SetCondition_UpdatesCondition()
         {
             var status = new MobileDeviceStatus()
             {
@@ -64,7 +64,7 @@ namespace Kaponata.Kubernetes.Tests.Models
         /// condition is renewed with the same status.
         /// </summary>
         [Fact]
-        public void Conditions_UpdatesTimestamp()
+        public void SetCondition_UpdatesTimestamp()
         {
             var status = new MobileDeviceStatus()
             {
@@ -96,7 +96,7 @@ namespace Kaponata.Kubernetes.Tests.Models
         /// did not change and the heartbeat is recent.
         /// </summary>
         [Fact]
-        public void Conditions_RecentTimestamp_DoesNothing()
+        public void SetCondition_RecentTimestamp_DoesNothing()
         {
             var status = new MobileDeviceStatus()
             {
@@ -121,6 +121,51 @@ namespace Kaponata.Kubernetes.Tests.Models
             Assert.Equal("Reason", condition.Reason);
             Assert.Equal("Message", condition.Message);
             Assert.True(condition.LastHeartbeatTime > DateTimeOffset.Now.AddMinutes(-5));
+        }
+
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.GetConditionStatus(string)"/> returns <see cref="ConditionStatus.Unknown"/>
+        /// when the <see cref="MobileDeviceStatus.Conditions"/> is <see langword="null"/>.
+        /// </summary>
+        [Fact]
+        public void GetCondition_ConditionsNull_ReturnsUnknown()
+        {
+            var status = new MobileDeviceStatus();
+            Assert.Equal(ConditionStatus.Unknown, status.GetConditionStatus(MobileDeviceConditions.DeveloperDiskMounted));
+        }
+
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.GetConditionStatus(string)"/> returns <see cref="ConditionStatus.Unknown"/>
+        /// when the <see cref="MobileDeviceStatus.Conditions"/> is not <see langword="null"/> but does not contain
+        /// the requested condition.
+        /// </summary>
+        [Fact]
+        public void GetCondition_MissingCondition_ReturnsUnknown()
+        {
+            var status = new MobileDeviceStatus() { Conditions = new List<MobileDeviceCondition>() };
+            Assert.Equal(ConditionStatus.Unknown, status.GetConditionStatus(MobileDeviceConditions.DeveloperDiskMounted));
+        }
+
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.GetConditionStatus(string)"/> returns the condition status
+        /// when the <see cref="MobileDeviceStatus.Conditions"/> contains the requested condition.
+        /// </summary>
+        [Fact]
+        public void GetCondition_HasCondition_ReturnsConditionValue()
+        {
+            var status = new MobileDeviceStatus()
+            {
+                Conditions = new List<MobileDeviceCondition>()
+                {
+                    new MobileDeviceCondition()
+                    {
+                        Type = MobileDeviceConditions.DeveloperDiskMounted,
+                        Status = ConditionStatus.True,
+                    },
+                },
+            };
+
+            Assert.Equal(ConditionStatus.True, status.GetConditionStatus(MobileDeviceConditions.DeveloperDiskMounted));
         }
     }
 }

--- a/src/Kaponata.Kubernetes.Tests/Models/MobileDeviceStatusTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Models/MobileDeviceStatusTests.cs
@@ -1,0 +1,126 @@
+﻿// <copyright file="MobileDeviceStatusTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes.Models;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests.Models
+{
+    /// <summary>
+    /// Tests the <see cref="MobileDeviceStatus"/> class.
+    /// </summary>
+    public class MobileDeviceStatusTests
+    {
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.SetCondition(string, ConditionStatus, string, string)"/> initializes the <see cref="MobileDeviceStatus.Conditions"/>
+        /// properties that property is <see langword="null"/>.
+        /// </summary>
+        [Fact]
+        public void ConditionsNull_AddsCondition()
+        {
+            var status = new MobileDeviceStatus();
+            Assert.True(status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.True, "Reason", "Message"));
+            Assert.NotNull(status.Conditions);
+            var condition = Assert.Single(status.Conditions);
+            Assert.Equal(MobileDeviceConditions.DeveloperDiskMounted, condition.Type);
+            Assert.Equal(ConditionStatus.True, condition.Status);
+            Assert.Equal("Reason", condition.Reason);
+            Assert.Equal("Message", condition.Message);
+        }
+
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.SetCondition(string, ConditionStatus, string, string)"/> updates an existing condition
+        /// if the status has changed.
+        /// </summary>
+        [Fact]
+        public void Conditions_UpdatesCondition()
+        {
+            var status = new MobileDeviceStatus()
+            {
+                Conditions = new List<MobileDeviceCondition>()
+                {
+                    new MobileDeviceCondition()
+                    {
+                         Type = MobileDeviceConditions.DeveloperDiskMounted,
+                         Status = ConditionStatus.False,
+                    },
+                },
+            };
+
+            Assert.True(status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.True, "Reason", "Message"));
+
+            var condition = Assert.Single(status.Conditions);
+            Assert.Equal(MobileDeviceConditions.DeveloperDiskMounted, condition.Type);
+            Assert.Equal(ConditionStatus.True, condition.Status);
+            Assert.Equal("Reason", condition.Reason);
+            Assert.Equal("Message", condition.Message);
+        }
+
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.SetCondition(string, ConditionStatus, string, string)"/> updates the timestamp if an existing
+        /// condition is renewed with the same status.
+        /// </summary>
+        [Fact]
+        public void Conditions_UpdatesTimestamp()
+        {
+            var status = new MobileDeviceStatus()
+            {
+                Conditions = new List<MobileDeviceCondition>()
+                {
+                    new MobileDeviceCondition()
+                    {
+                         Type = MobileDeviceConditions.DeveloperDiskMounted,
+                         Status = ConditionStatus.True,
+                         Reason = "Reason",
+                         Message = "Message",
+                         LastHeartbeatTime = DateTimeOffset.Now.AddDays(-1),
+                    },
+                },
+            };
+
+            Assert.True(status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.True, "Reason", "Message"));
+
+            var condition = Assert.Single(status.Conditions);
+            Assert.Equal(MobileDeviceConditions.DeveloperDiskMounted, condition.Type);
+            Assert.Equal(ConditionStatus.True, condition.Status);
+            Assert.Equal("Reason", condition.Reason);
+            Assert.Equal("Message", condition.Message);
+            Assert.True(condition.LastHeartbeatTime > DateTimeOffset.Now.AddMinutes(-5));
+        }
+
+        /// <summary>
+        /// <see cref="MobileDeviceStatus.SetCondition(string, ConditionStatus, string, string)"/> does nothing if the status
+        /// did not change and the heartbeat is recent.
+        /// </summary>
+        [Fact]
+        public void Conditions_RecentTimestamp_DoesNothing()
+        {
+            var status = new MobileDeviceStatus()
+            {
+                Conditions = new List<MobileDeviceCondition>()
+                {
+                    new MobileDeviceCondition()
+                    {
+                         Type = MobileDeviceConditions.DeveloperDiskMounted,
+                         Status = ConditionStatus.True,
+                         Reason = "Reason",
+                         Message = "Message",
+                         LastHeartbeatTime = DateTimeOffset.Now,
+                    },
+                },
+            };
+
+            Assert.False(status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.True, "Reason", "Message"));
+
+            var condition = Assert.Single(status.Conditions);
+            Assert.Equal(MobileDeviceConditions.DeveloperDiskMounted, condition.Type);
+            Assert.Equal(ConditionStatus.True, condition.Status);
+            Assert.Equal("Reason", condition.Reason);
+            Assert.Equal("Message", condition.Message);
+            Assert.True(condition.LastHeartbeatTime > DateTimeOffset.Now.AddMinutes(-5));
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/Models/ConditionStatus.cs
+++ b/src/Kaponata.Kubernetes/Models/ConditionStatus.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="ConditionStatus.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Kubernetes.Models
+{
+    /// <summary>
+    /// Describes the status of a individual condition.
+    /// </summary>
+    public enum ConditionStatus
+    {
+        /// <summary>
+        /// The condition is met.
+        /// </summary>
+        True,
+
+        /// <summary>
+        /// The condition is not met.
+        /// </summary>
+        False,
+
+        /// <summary>
+        /// The status of the condition is unknown.
+        /// </summary>
+        Unknown,
+    }
+}

--- a/src/Kaponata.Kubernetes/Models/MobileDevice.yaml
+++ b/src/Kaponata.Kubernetes/Models/MobileDevice.yaml
@@ -9,7 +9,7 @@ metadata:
     # operator to determine whether the CRD should be reinstalled or not.
     # Use the following command to determine that version:
     # nbgv get-version $(git rev-list -1 HEAD) -v NuGetPackageVersion
-    app.kubernetes.io/version: "0.3.52"
+    app.kubernetes.io/version: "0.3.346"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kaponata.io
@@ -50,8 +50,64 @@ spec:
                     which allows users to remotely control this device.
                 vncPassword:
                   type: string
+                  format: password
                   description: |
                     When available, a password which can be used to connect to the VNC server at vncHost.
+                conditions:
+                  description: |
+                    Conditions is a list of all conditions this MobileDevice is in.
+                  items:
+                    description: |
+                      MobileDeviceCondition contains details for the current condition of this MobileDevice.
+                    properties:
+                      type:
+                        description: Type of the condition.  The condition type uniquely identifies the condition.
+                        type: string
+                      status:
+                        description: |
+                          Status of the condition, one of ('True', 'False', 'Unknown').
+                        type: string
+                        enum:
+                        - 'True'
+                        - 'False'
+                        - 'Unknown'
+                      reason:
+                        description: |
+                          Reason is the (brief) reason for the condition's last transition.
+                        type: string
+                      message:
+                        description: |
+                          Message is the human readable message indicating details about last transition.
+                        type: string
+                      lastHeartbeatTime:
+                        description: |
+                          LastHeartbeatTime is the timestamp corresponding to the last update of this condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |
+                          LastTransitionTime is the last time the device condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+
+                  # These properties are used by Kubernetes strategic merge operations.  They should allows us to
+                  # patch lists (such as status.conditions) by specifying a 'key' (type in this case).
+                  # Unfortunately, Kubernetes does not currently support strategy merges for custom resources:
+                  # 
+                  "x-kubernetes-list-map-keys":
+                    - "type"
+                  "x-kubernetes-list-type": "map"
+            
+          # This section enables the 'status' subresource.  It allows controllers to only patch the status stanza
+          # by posting to /status.
+          subresources:
+            status: {}
+
       # Shown in kubectl get
       additionalPrinterColumns:
       - name: Labels

--- a/src/Kaponata.Kubernetes/Models/MobileDevice.yaml
+++ b/src/Kaponata.Kubernetes/Models/MobileDevice.yaml
@@ -9,7 +9,7 @@ metadata:
     # operator to determine whether the CRD should be reinstalled or not.
     # Use the following command to determine that version:
     # nbgv get-version $(git rev-list -1 HEAD) -v NuGetPackageVersion
-    app.kubernetes.io/version: "0.3.346"
+    app.kubernetes.io/version: "0.3.348"
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kaponata.io
@@ -103,10 +103,10 @@ spec:
                     - "type"
                   "x-kubernetes-list-type": "map"
             
-          # This section enables the 'status' subresource.  It allows controllers to only patch the status stanza
-          # by posting to /status.
-          subresources:
-            status: {}
+      # This section enables the 'status' subresource.  It allows controllers to only patch the status stanza
+      # by posting to /status.
+      subresources:
+        status: {}
 
       # Shown in kubectl get
       additionalPrinterColumns:

--- a/src/Kaponata.Kubernetes/Models/MobileDeviceCondition.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDeviceCondition.cs
@@ -52,5 +52,11 @@ namespace Kaponata.Kubernetes.Models
         /// </summary>
         [JsonProperty("lastTransitionTime")]
         public DateTimeOffset LastTransitionTime { get; set; }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{this.Type}: {this.Status} ({this.Reason})";
+        }
     }
 }

--- a/src/Kaponata.Kubernetes/Models/MobileDeviceCondition.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDeviceCondition.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="MobileDeviceCondition.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+#nullable disable
+
+namespace Kaponata.Kubernetes.Models
+{
+    /// <summary>
+    /// <see cref="MobileDeviceCondition"/> contains details for the current condition of this <see cref="MobileDevice"/>.
+    /// </summary>
+    /// <seealso href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties"/>
+    public class MobileDeviceCondition
+    {
+        /// <summary>
+        /// Gets or sets the type of the condition. The condition type uniquely identifies the condition.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the status of the condition.
+        /// </summary>
+        [JsonProperty("status")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ConditionStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets a (brief) reason for the condition's last transition.
+        /// </summary>
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        /// <summary>
+        /// Gets or sets human readable message indicating details about last transition.
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last time the condition was probed.
+        /// </summary>
+        [JsonProperty("lastHeartbeatTime")]
+        public DateTimeOffset LastHeartbeatTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last time the device condition transitioned from one status to another.
+        /// </summary>
+        [JsonProperty("lastTransitionTime")]
+        public DateTimeOffset LastTransitionTime { get; set; }
+    }
+}

--- a/src/Kaponata.Kubernetes/Models/MobileDeviceConditions.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDeviceConditions.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="MobileDeviceConditions.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+namespace Kaponata.Kubernetes.Models
+{
+    /// <summary>
+    /// Contains the names of well-known device conditions.
+    /// </summary>
+    public class MobileDeviceConditions
+    {
+        /// <summary>
+        /// The name of the condition which indicates whether the device is ready.
+        /// </summary>
+        public const string Ready = nameof(Ready);
+
+        /// <summary>
+        /// The name of the condition which indicates whether the device has paired successfully with the host.
+        /// </summary>
+        public const string Paired = nameof(Paired);
+
+        /// <summary>
+        /// The name of the condition which indicates whether the developer disk has mounted successfully on the devie.
+        /// </summary>
+        public const string DeveloperDiskMounted = nameof(DeveloperDiskMounted);
+    }
+}

--- a/src/Kaponata.Kubernetes/Models/MobileDeviceStatus.cs
+++ b/src/Kaponata.Kubernetes/Models/MobileDeviceStatus.cs
@@ -2,7 +2,11 @@
 // Copyright (c) Quamotion bv. All rights reserved.
 // </copyright>
 
+using Microsoft.AspNetCore.JsonPatch;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 #nullable disable
 
@@ -26,5 +30,71 @@ namespace Kaponata.Kubernetes.Models
         /// </summary>
         [JsonProperty(PropertyName = "vncPassword")]
         public string VncPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of all conditions currently known for this device.
+        /// </summary>
+        [JsonProperty(PropertyName = "conditions")]
+        public IList<MobileDeviceCondition> Conditions { get; set; }
+
+        /// <summary>
+        /// Updates a condition.
+        /// </summary>
+        /// <param name="type">
+        /// The name of the condition to update.
+        /// </param>
+        /// <param name="status">
+        /// The current status of the condition.
+        /// </param>
+        /// <param name="reason">
+        /// A machine-readable status code which describes the reason for the condition.
+        /// </param>
+        /// <param name="message">
+        /// A human-readable message which describes the reason for the condition.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the condition has been updated; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        public bool UpdateCondition(string type, ConditionStatus status, string reason, string message)
+        {
+            var currentCondition = this.Conditions.SingleOrDefault(c => c.Type == type);
+
+            if (currentCondition == null)
+            {
+                this.Conditions.Add(
+                    new MobileDeviceCondition()
+                    {
+                        Type = type,
+                        Status = status,
+                        Reason = reason,
+                        Message = message,
+                        LastHeartbeatTime = DateTimeOffset.Now,
+                        LastTransitionTime = DateTimeOffset.Now,
+                    });
+
+                return true;
+            }
+            else if (currentCondition.Status != status)
+            {
+                currentCondition.LastHeartbeatTime = DateTimeOffset.Now;
+                currentCondition.LastTransitionTime = DateTimeOffset.Now;
+                currentCondition.Status = status;
+                currentCondition.Reason = reason;
+                currentCondition.Message = message;
+
+                return true;
+            }
+            else if (currentCondition.LastHeartbeatTime.AddMinutes(5) > DateTimeOffset.Now)
+            {
+                currentCondition.LastHeartbeatTime = DateTimeOffset.Now;
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/kaponata-ui/package.json
+++ b/src/kaponata-ui/package.json
@@ -46,7 +46,7 @@
     "protractor-backend-mock-plugin": "^1.0.3",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "^4.2.3",
+    "typescript": "~4.2.3",
     "selenium-webdriver": "~4.0.0-beta.3"
   }
 }


### PR DESCRIPTION
For a device to work properly with Kaponata, multiple conditions must be met. For example:

- The device must pair with the host
- The developer disk image must be mounted on the device.
- A provisioning profile and developer certificate which allow installing applications on the device must be available.
- ...

This PR adds a conditions list to the MobileDevice CRD, which allows storing these conditions. Conditions are described in the [Kubernetes API conventions](https://github.com/zecke/Kubernetes/blob/master/docs/devel/api-conventions.md#typical-status-properties) document.

This PR needs unit tests/integration tests before merging.