### PR TITLE
add debug build option to api makefile

### DIFF
--- a/src/Kaponata.Api/Dockerfile
+++ b/src/Kaponata.Api/Dockerfile
@@ -6,7 +6,7 @@ ARG GIT_REF
 ARG GIT_REMOTE
 ARG VERSION
 ARG EXPIRES
-ARG TARGET
+ARG CONFIGURATION
 
 LABEL org.opencontainers.image.title="Kaponata API Server"
 LABEL org.opencontainers.image.description=""
@@ -25,6 +25,6 @@ LABEL quay.expires-after=$EXPIRES
 
 WORKDIR /app
 
-COPY bin/$TARGET/net5.0/publish /app/
+COPY bin/$CONFIGURATION/net5.0/publish /app/
 
 ENTRYPOINT ["dotnet", "/app/Kaponata.Api.dll"]

--- a/src/Kaponata.Api/Dockerfile
+++ b/src/Kaponata.Api/Dockerfile
@@ -6,6 +6,7 @@ ARG GIT_REF
 ARG GIT_REMOTE
 ARG VERSION
 ARG EXPIRES
+ARG TARGET
 
 LABEL org.opencontainers.image.title="Kaponata API Server"
 LABEL org.opencontainers.image.description=""
@@ -24,6 +25,6 @@ LABEL quay.expires-after=$EXPIRES
 
 WORKDIR /app
 
-COPY bin/Release/net5.0/publish /app/
+COPY bin/$TARGET/net5.0/publish /app/
 
 ENTRYPOINT ["dotnet", "/app/Kaponata.Api.dll"]

--- a/src/Kaponata.Api/Makefile
+++ b/src/Kaponata.Api/Makefile
@@ -1,7 +1,7 @@
 registry=quay.io/kaponata
 image=api
 version=$(shell nbgv get-version -v SemVer2)
-TARGET := "Release"
+CONFIGURATION := "Release"
 
 # Set tags to expire in 2 weeks (duration of a sprint) in quay.io;
 # exception for tags built from release branches, which never expire.
@@ -23,15 +23,15 @@ push: all
 	docker manifest create --amend $(registry)/$(image):$(version) $(registry)/$(image):$(version)-amd64 $(registry)/$(image):$(version)-arm64
 	docker manifest push $(registry)/$(image):$(version)
 
-bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
-	dotnet publish -c $(TARGET)
+bin/$(CONFIGURATION)/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
+	dotnet publish -c $(CONFIGURATION)
 
-.amd64.docker-id: Dockerfile bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll
+.amd64.docker-id: Dockerfile bin/$(CONFIGURATION)/net5.0/publish/Kaponata.Api.dll
 	docker buildx build \
 		--platform linux/amd64 \
 		--build-arg host= \
 		--build-arg arch= \
-		--build-arg TARGET="$(TARGET)" \
+		--build-arg CONFIGURATION="$(CONFIGURATION)" \
 		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
 		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
@@ -42,11 +42,11 @@ bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune
 		-t $(registry)/$(image):$(version)-amd64
 	docker images --no-trunc --quiet $(registry)/$(image):$(version)-amd64 > .amd64.docker-id
 
-.arm64.docker-id: Dockerfile bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll
+.arm64.docker-id: Dockerfile bin/$(CONFIGURATION)/net5.0/publish/Kaponata.Api.dll
 	docker buildx build --platform linux/arm64 \
 		--build-arg host=aarch64-linux-gnu \
 		--build-arg arch=arm64 \
-		--build-arg TARGET="$(TARGET)" \
+		--build-arg CONFIGURATION="$(CONFIGURATION)" \
 		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
 		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \

--- a/src/Kaponata.Api/Makefile
+++ b/src/Kaponata.Api/Makefile
@@ -1,6 +1,7 @@
 registry=quay.io/kaponata
 image=api
 version=$(shell nbgv get-version -v SemVer2)
+TARGET := "Release"
 
 # Set tags to expire in 2 weeks (duration of a sprint) in quay.io;
 # exception for tags built from release branches, which never expire.
@@ -22,14 +23,15 @@ push: all
 	docker manifest create --amend $(registry)/$(image):$(version) $(registry)/$(image):$(version)-amd64 $(registry)/$(image):$(version)-arm64
 	docker manifest push $(registry)/$(image):$(version)
 
-bin/Release/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
-	dotnet publish -c Release
+bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -false -o -path ./obj -prune -false -o -regex '.*\.cs' -type f)
+	dotnet publish -c $(TARGET)
 
-.amd64.docker-id: Dockerfile bin/Release/net5.0/publish/Kaponata.Api.dll
+.amd64.docker-id: Dockerfile bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll
 	docker buildx build \
 		--platform linux/amd64 \
 		--build-arg host= \
 		--build-arg arch= \
+		--build-arg TARGET="$(TARGET)" \
 		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
 		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \
@@ -40,10 +42,11 @@ bin/Release/net5.0/publish/Kaponata.Api.dll: $(shell find . -path ./bin -prune -
 		-t $(registry)/$(image):$(version)-amd64
 	docker images --no-trunc --quiet $(registry)/$(image):$(version)-amd64 > .amd64.docker-id
 
-.arm64.docker-id: Dockerfile bin/Release/net5.0/publish/Kaponata.Api.dll
+.arm64.docker-id: Dockerfile bin/$(TARGET)/net5.0/publish/Kaponata.Api.dll
 	docker buildx build --platform linux/arm64 \
 		--build-arg host=aarch64-linux-gnu \
 		--build-arg arch=arm64 \
+		--build-arg TARGET="$(TARGET)" \
 		--build-arg GIT_COMMIT_DATE="$(shell nbgv get-version -v GitCommitDate)" \
 		--build-arg GIT_COMMIT_ID="$(shell nbgv get-version -v GitCommitId)" \
 		--build-arg GIT_REF="$(shell nbgv get-version -v BuildingRef)" \

--- a/src/kaponata-ui/package.json
+++ b/src/kaponata-ui/package.json
@@ -46,7 +46,7 @@
     "protractor-backend-mock-plugin": "^1.0.3",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "4.3.0",
+    "typescript": "~4.2.3",
     "selenium-webdriver": "~4.0.0-beta.3"
   }
 }

--- a/src/kaponata-ui/package.json
+++ b/src/kaponata-ui/package.json
@@ -46,7 +46,7 @@
     "protractor-backend-mock-plugin": "^1.0.3",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "^4.2.3",
+    "typescript": "4.3.0",
     "selenium-webdriver": "~4.0.0-beta.3"
   }
 }


### PR DESCRIPTION
CORS `AllowAnyOrigin()` is only set when running `Kaponata.Api` in debug mode. 

building and deploying `Kaponata.Api` can be done using:
```
make clean
make deploy TARGET=Debug
```