### PR TITLE
iOS MobileDevice resources: Use Status.Conditions

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/Models/ModelIntegrationTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/Models/ModelIntegrationTests.cs
@@ -1,0 +1,91 @@
+﻿// <copyright file="ModelIntegrationTests.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Divergic.Logging.Xunit;
+using k8s;
+using k8s.Models;
+using Kaponata.Kubernetes.Models;
+using Kaponata.Kubernetes.Polyfill;
+using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Kaponata.Kubernetes.Tests.Models
+{
+    /// <summary>
+    /// Integration tests for the <see cref="MobileDevice"/> model.
+    /// </summary>
+    public class ModelIntegrationTests
+    {
+        private readonly ITestOutputHelper output;
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelIntegrationTests"/> class.
+        /// </summary>
+        /// <param name="output">
+        /// The test output helper which will be used to log to xunit.
+        /// </param>
+        public ModelIntegrationTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            this.loggerFactory = LogFactory.Create(output);
+        }
+
+        /// <summary>
+        /// Tests updating the condition of a mobile device's status.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [Trait("TestCategory", "IntegrationTest")]
+        public async Task UpdateDeviceConditionAsync()
+        {
+            using (var client = this.CreateKubernetesClient())
+            {
+                var deviceClient = client.GetClient<MobileDevice>();
+
+                await deviceClient.TryDeleteAsync(nameof(this.UpdateDeviceConditionAsync).ToLower(), timeout: TimeSpan.FromMinutes(1), default);
+
+                var device = await deviceClient.CreateAsync(
+                    new MobileDevice()
+                    {
+                        Metadata = new V1ObjectMeta()
+                        {
+                            Name = nameof(this.UpdateDeviceConditionAsync).ToLower(),
+                            NamespaceProperty = "default",
+                        },
+                    },
+                    default);
+
+                device.Status = new MobileDeviceStatus();
+                Assert.True(device.Status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.Unknown, "NotMounted", "Not Mounted"));
+                var patch = new JsonPatchDocument<MobileDevice>();
+                patch.Add(d => d.Status, device.Status);
+
+                device = await deviceClient.PatchStatusAsync(device, patch, default).ConfigureAwait(false);
+                Assert.Equal(ConditionStatus.Unknown, device.Status.GetConditionStatus(MobileDeviceConditions.DeveloperDiskMounted));
+
+                Assert.True(device.Status.SetCondition(MobileDeviceConditions.DeveloperDiskMounted, ConditionStatus.True, "NotMounted", "Not Mounted"));
+                patch.Add(d => d.Status, device.Status);
+                device = await deviceClient.PatchStatusAsync(device, patch, default).ConfigureAwait(false);
+                Assert.Equal(ConditionStatus.True, device.Status.GetConditionStatus(MobileDeviceConditions.DeveloperDiskMounted));
+            }
+        }
+
+        private KubernetesClient CreateKubernetesClient()
+        {
+            return new KubernetesClient(
+                new KubernetesProtocol(
+                    KubernetesClientConfiguration.BuildDefaultConfig(),
+                    this.loggerFactory.CreateLogger<KubernetesProtocol>(),
+                    this.loggerFactory),
+                KubernetesOptions.Default,
+                this.loggerFactory.CreateLogger<KubernetesClient>(),
+                this.loggerFactory);
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes.Tests/NamespacedKubernetesClientExtensionsTests.MobileDevice.cs
+++ b/src/Kaponata.Kubernetes.Tests/NamespacedKubernetesClientExtensionsTests.MobileDevice.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="NamespacedKubernetesClientExtensionsTests.MobileDevice.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes.Models;
+using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.AspNetCore.JsonPatch.Operations;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kaponata.Kubernetes.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="NamespacedKubernetesClientExtensions"/> class.
+    /// </summary>
+    public class NamespacedKubernetesClientExtensionsTests
+    {
+        /// <summary>
+        /// <see cref="NamespacedKubernetesClientExtensions.SetDeviceConditionAsync(NamespacedKubernetesClient{MobileDevice}, MobileDevice, string, ConditionStatus, string, string, CancellationToken)"/>
+        /// validates its arguments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task SetDeviceConditionAsync_ValidatesArguments_Async()
+        {
+            var client = Mock.Of<NamespacedKubernetesClient<MobileDevice>>();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SetDeviceConditionAsync(null, "type", ConditionStatus.False, "reason", "message", default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SetDeviceConditionAsync(new MobileDevice(), null, ConditionStatus.False, "reason", "message", default)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <see cref="NamespacedKubernetesClientExtensions.SetDeviceConditionAsync(NamespacedKubernetesClient{MobileDevice}, MobileDevice, string, ConditionStatus, string, string, CancellationToken)"/>
+        /// updates the device condition if required.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task SetDeviceConditionAsync_UpdatesStatusIfRequired_Async()
+        {
+            var clientMock = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
+            var client = clientMock.Object;
+
+            var device = new MobileDevice();
+            JsonPatchDocument<MobileDevice> patch = null;
+
+            clientMock
+                .Setup(c => c.PatchStatusAsync(device, It.IsAny<JsonPatchDocument<MobileDevice>>(), default))
+                .Callback<MobileDevice, JsonPatchDocument<MobileDevice>, CancellationToken>((d, p, ct) => { patch = p; })
+                .Returns(Task.FromResult(device)).Verifiable();
+
+            await client.SetDeviceConditionAsync(device, MobileDeviceConditions.Paired, ConditionStatus.True, "reason", "message", default).ConfigureAwait(false);
+
+            clientMock.Verify();
+
+            Assert.NotNull(patch);
+            var patchOperation = Assert.Single(patch.Operations);
+            Assert.Equal(OperationType.Replace, patchOperation.OperationType);
+            Assert.Equal("/status/conditions", patchOperation.path);
+
+            var condition = Assert.Single(device.Status.Conditions);
+            Assert.Equal(MobileDeviceConditions.Paired, condition.Type);
+        }
+
+        /// <summary>
+        /// <see cref="NamespacedKubernetesClientExtensions.SetDeviceConditionAsync(NamespacedKubernetesClient{MobileDevice}, MobileDevice, string, ConditionStatus, string, string, CancellationToken)"/>
+        /// does not update the device condition if not required.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task SetDeviceConditionAsync_SkipsUpdatedIfNotNeeded_Async()
+        {
+            var clientMock = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
+            var client = clientMock.Object;
+
+            var device = new MobileDevice()
+            {
+                Status = new MobileDeviceStatus()
+                {
+                    Conditions = new List<MobileDeviceCondition>()
+                    {
+                        new MobileDeviceCondition()
+                        {
+                            Type = MobileDeviceConditions.Paired,
+                            Reason = "reason",
+                            Message = "message",
+                            Status = ConditionStatus.True,
+                            LastHeartbeatTime = DateTimeOffset.Now,
+                        },
+                    },
+                },
+            };
+
+            await client.SetDeviceConditionAsync(device, MobileDeviceConditions.Paired, ConditionStatus.True, "reason", "message", default).ConfigureAwait(false);
+            clientMock.Verify();
+        }
+    }
+}

--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClientExtensions.MobileDevice.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClientExtensions.MobileDevice.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="NamespacedKubernetesClientExtensions.MobileDevice.cs" company="Quamotion bv">
+// Copyright (c) Quamotion bv. All rights reserved.
+// </copyright>
+
+using Kaponata.Kubernetes.Models;
+using Microsoft;
+using Microsoft.AspNetCore.JsonPatch;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kaponata.Kubernetes
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="NamespacedKubernetesClient{T}"/> class.
+    /// </summary>
+    public static class NamespacedKubernetesClientExtensions
+    {
+        /// <summary>
+        /// Asynchronously sets a device condition.
+        /// </summary>
+        /// <param name="client">
+        /// A client which provides access to the Kubernetes cluster.
+        /// </param>
+        /// <param name="device">
+        /// The device for which to set the status.
+        /// </param>
+        /// <param name="type">
+        /// The name of the condition.
+        /// </param>
+        /// <param name="status">
+        /// The status of the condition.
+        /// </param>
+        /// <param name="reason">
+        /// A machine-readable reason for the condition status.
+        /// </param>
+        /// <param name="message">
+        /// A human-readable reason for the condition status.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public static async Task SetDeviceConditionAsync(this NamespacedKubernetesClient<MobileDevice> client, MobileDevice device, string type, ConditionStatus status, string reason, string message, CancellationToken cancellationToken)
+        {
+            Requires.NotNull(device, nameof(device));
+            Requires.NotNull(type, nameof(type));
+
+            if (device.Status == null)
+            {
+                device.Status = new MobileDeviceStatus();
+            }
+
+            if (device.Status.SetCondition(type, status, reason, message))
+            {
+                var patch = new JsonPatchDocument<MobileDevice>();
+                patch.Replace(p => p.Status.Conditions, device.Status.Conditions);
+                await client.PatchStatusAsync(device, patch, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the usbmuxd sidecar so that it uses `MobileDevice.Status.Conditions` to let users of the cluster know whether the device has paired successfully with the host or not.

This has a couple of advantages over creating the device only after the device has paired:
- It makes it easier for users to get the current device state
- It allows us to provide fine-grained status information (e.g.: did the device pair? was the developer disk mounted? ...)