### PR TITLE
Bump KubernetesClient to 5.0.10

### DIFF
--- a/src/Kaponata.Kubernetes/Kaponata.Kubernetes.csproj
+++ b/src/Kaponata.Kubernetes/Kaponata.Kubernetes.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="5.0.2" />
+    <PackageReference Include="KubernetesClient" Version="5.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.5" />
   </ItemGroup>
 

--- a/src/Kaponata.Kubernetes/KubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.cs
@@ -169,8 +169,7 @@ namespace Kaponata.Kubernetes
                     throw;
                 }
 
-                // Once https://github.com/kubernetes-client/csharp/pull/553 is merged, we can pass the inner exception, too.
-                throw new KubernetesException(status);
+                throw new KubernetesException(status, ex);
             }
         }
     }


### PR DESCRIPTION
This contains a small fix which allows us to propagate the underlying exception when throwing a KubernetesException