### PR TITLE
Operator, API server and sidecar: print version info on startup

### DIFF
--- a/src/Kaponata.Api/Kaponata.Api.csproj
+++ b/src/Kaponata.Api/Kaponata.Api.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <AssemblyTitle>Kaponata API server</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Api/Program.cs
+++ b/src/Kaponata.Api/Program.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
@@ -42,6 +43,8 @@ namespace Kaponata.Api
         /// </returns>
         public static Task<int> Main(string[] args)
         {
+            Console.WriteLine($"{ThisAssembly.AssemblyTitle} version {ThisAssembly.AssemblyInformationalVersion}");
+
             var program = new Program();
             return program.MainAsync(args);
         }

--- a/src/Kaponata.Operator/Kaponata.Operator.csproj
+++ b/src/Kaponata.Operator/Kaponata.Operator.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <AssemblyTitle>Kaponata Operator</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Operator/Program.cs
+++ b/src/Kaponata.Operator/Program.cs
@@ -6,6 +6,7 @@ using Kaponata.Kubernetes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
@@ -45,6 +46,8 @@ namespace Kaponata.Operator
         /// </returns>
         public static Task<int> Main(string[] args)
         {
+            Console.WriteLine($"{ThisAssembly.AssemblyTitle} version {ThisAssembly.AssemblyInformationalVersion}");
+
             var program = new Program();
             return program.MainAsync(args);
         }

--- a/src/Kaponata.Sidecars/Kaponata.Sidecars.csproj
+++ b/src/Kaponata.Sidecars/Kaponata.Sidecars.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <AssemblyTitle>Kaponata Sidecar</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kaponata.Sidecars/Program.cs
+++ b/src/Kaponata.Sidecars/Program.cs
@@ -33,8 +33,13 @@ namespace Kaponata.Sidecars
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// </returns>
-        public static async Task Main(string[] args) => await BuildCommandLine()
+        public static Task Main(string[] args)
+        {
+            Console.WriteLine($"{ThisAssembly.AssemblyTitle} version {ThisAssembly.AssemblyInformationalVersion}");
+
+            return BuildCommandLine()
             .InvokeAsync(args);
+        }
 
         /// <summary>
         /// Builds the command-line interface.


### PR DESCRIPTION
Should make it a bit easier to verify the correct version is running.