### PR TITLE
List & Watch operations: Support the resourceVersionMatch parameter

### DIFF
--- a/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.cs
+++ b/src/Kaponata.Kubernetes.Tests/KubernetesClientTests.cs
@@ -812,13 +812,13 @@ namespace Kaponata.Kubernetes.Tests
 
             var protocol = new Mock<IKubernetesProtocol>(MockBehavior.Strict);
             protocol
-                .Setup(p => p.WatchNamespacedObjectAsync("default", "fieldSelector", "labelSelector", "resourceVersion", protocol.Object.ListNamespacedPodWithHttpMessagesAsync, eventHandler, default))
+                .Setup(p => p.WatchNamespacedObjectAsync("default", "fieldSelector", "labelSelector", "resourceVersion", "resourceVersionMatch", protocol.Object.ListNamespacedPodWithHttpMessagesAsync, eventHandler, default))
                 .Returns(tcs.Task);
             protocol.Setup(p => p.Dispose()).Verifiable();
 
             using (var client = new KubernetesClient(protocol.Object, KubernetesOptions.Default, NullLogger<KubernetesClient>.Instance, NullLoggerFactory.Instance))
             {
-                Assert.Same(tcs.Task, client.WatchPodAsync("fieldSelector", "labelSelector", "resourceVersion", eventHandler, default));
+                Assert.Same(tcs.Task, client.WatchPodAsync("fieldSelector", "labelSelector", "resourceVersion", "resourceVersionMatch", eventHandler, default));
             }
 
             protocol.Verify();

--- a/src/Kaponata.Kubernetes.Tests/Polyfill/KubernetesProtocolTests.Watch.cs
+++ b/src/Kaponata.Kubernetes.Tests/Polyfill/KubernetesProtocolTests.Watch.cs
@@ -66,9 +66,9 @@ namespace Kaponata.Kubernetes.Tests.Polyfill
             await Assert.ThrowsAsync<ArgumentNullException>("listOperation", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>(pod, null, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
             await Assert.ThrowsAsync<ArgumentNullException>("eventHandler", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>(pod, protocol.ListNamespacedPodWithHttpMessagesAsync, null, default)).ConfigureAwait(false);
 
-            await Assert.ThrowsAsync<ArgumentNullException>("namespace", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>(null, string.Empty, string.Empty, string.Empty, protocol.ListNamespacedPodWithHttpMessagesAsync, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
-            await Assert.ThrowsAsync<ArgumentNullException>("listOperation", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>("default", null, null, null, null, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
-            await Assert.ThrowsAsync<ArgumentNullException>("eventHandler", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>("default", null, null, null, protocol.ListNamespacedPodWithHttpMessagesAsync, null, default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ArgumentNullException>("namespace", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>(null, string.Empty, string.Empty, string.Empty, null, protocol.ListNamespacedPodWithHttpMessagesAsync, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ArgumentNullException>("listOperation", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>("default", null, null, null, null, null, (eventType, result) => Task.FromResult(WatchResult.Continue), default)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<ArgumentNullException>("eventHandler", () => protocol.WatchNamespacedObjectAsync<V1Pod, V1PodList>("default", null, null, null, null, protocol.ListNamespacedPodWithHttpMessagesAsync, null, default)).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.NamespacedObject.cs
@@ -395,6 +395,12 @@ namespace Kaponata.Kubernetes
         /// served from. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
         /// for details. Defaults to unset.
         /// </param>
+        /// <param name="resourceVersionMatch">
+        /// <paramref name="resourceVersionMatch"/> determines how <paramref name="resourceVersion"/> is applied to list calls.
+        /// It is highly recommended that <paramref name="resourceVersionMatch"/> be set for list calls where
+        /// <paramref name="resourceVersion"/> is set. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to <see langword="null"/>.
+        /// </param>
         /// <param name="listOperation">
         /// A delegate which lists all objects.
         /// </param>
@@ -416,6 +422,7 @@ namespace Kaponata.Kubernetes
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
+            string resourceVersionMatch,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
             WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
@@ -427,6 +434,7 @@ namespace Kaponata.Kubernetes
                 fieldSelector,
                 labelSelector,
                 resourceVersion,
+                resourceVersionMatch,
                 listOperation,
                 eventHandler,
                 cancellationToken);

--- a/src/Kaponata.Kubernetes/KubernetesClient.Pods.cs
+++ b/src/Kaponata.Kubernetes/KubernetesClient.Pods.cs
@@ -189,6 +189,12 @@ namespace Kaponata.Kubernetes
         /// served from. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
         /// for details. Defaults to unset.
         /// </param>
+        /// <param name="resourceVersionMatch">
+        /// <paramref name="resourceVersionMatch"/> determines how <paramref name="resourceVersion"/> is applied to list calls.
+        /// It is highly recommended that <paramref name="resourceVersionMatch"/> be set for list calls where
+        /// <paramref name="resourceVersion"/> is set. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to <see langword="null"/>.
+        /// </param>
         /// <param name="eventHandler">
         /// An handler which processes a watch event, and lets the watcher know whether
         /// to continue watching or not.
@@ -207,6 +213,7 @@ namespace Kaponata.Kubernetes
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
+            string resourceVersionMatch,
             WatchEventDelegate<V1Pod> eventHandler,
             CancellationToken cancellationToken)
         {
@@ -215,6 +222,7 @@ namespace Kaponata.Kubernetes
                 fieldSelector: fieldSelector,
                 labelSelector: labelSelector,
                 resourceVersion: resourceVersion,
+                resourceVersionMatch: resourceVersionMatch,
                 this.protocol.ListNamespacedPodWithHttpMessagesAsync,
                 eventHandler,
                 cancellationToken);

--- a/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
+++ b/src/Kaponata.Kubernetes/NamespacedKubernetesClient.cs
@@ -342,6 +342,12 @@ namespace Kaponata.Kubernetes
         /// served from. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
         /// for details. Defaults to unset.
         /// </param>
+        /// <param name="resourceVersionMatch">
+        /// <paramref name="resourceVersionMatch"/> determines how <paramref name="resourceVersion"/> is applied to list calls.
+        /// It is highly recommended that <paramref name="resourceVersionMatch"/> be set for list calls where
+        /// <paramref name="resourceVersion"/> is set. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to <see langword="null"/>.
+        /// </param>
         /// <param name="eventHandler">
         /// An handler which processes a watch event, and lets the watcher know whether
         /// to continue watching or not.
@@ -360,6 +366,7 @@ namespace Kaponata.Kubernetes
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
+            string resourceVersionMatch,
             WatchEventDelegate<T> eventHandler,
             CancellationToken cancellationToken)
         {
@@ -386,6 +393,7 @@ namespace Kaponata.Kubernetes
                     fieldSelector,
                     labelSelector,
                     currentResourceVersion,
+                    resourceVersionMatch,
                     this.ListAsync,
                     innerHandler,
                     cancellationToken).ConfigureAwait(false) != WatchExitReason.ClientDisconnected)

--- a/src/Kaponata.Kubernetes/Polyfill/IKubernetesProtocol.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/IKubernetesProtocol.cs
@@ -98,9 +98,15 @@ namespace Kaponata.Kubernetes.Polyfill
         /// to everything.
         /// </param>
         /// <param name="resourceVersion">
-        /// resourceVersion sets a constraint on what resource versions a request may be
+        /// <paramref name="resourceVersion"/> sets a constraint on what resource versions a request may be
         /// served from. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
-        /// for details. Defaults to unset.
+        /// for details. Defaults to <see langword="null"/>.
+        /// </param>
+        /// <param name="resourceVersionMatch">
+        /// <paramref name="resourceVersionMatch"/> determines how <paramref name="resourceVersion"/> is applied to list calls.
+        /// It is highly recommended that <paramref name="resourceVersionMatch"/> be set for list calls where
+        /// <paramref name="resourceVersion"/> is set. See <see href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions"/>
+        /// for details. Defaults to <see langword="null"/>.
         /// </param>
         /// <param name="listOperation">
         /// A delegate which lists all objects.
@@ -124,6 +130,7 @@ namespace Kaponata.Kubernetes.Polyfill
             string fieldSelector,
             string labelSelector,
             string resourceVersion,
+            string resourceVersionMatch,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
             WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)

--- a/src/Kaponata.Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
+++ b/src/Kaponata.Kubernetes/Polyfill/KubernetesProtocol.Watch.cs
@@ -84,6 +84,7 @@ namespace Kaponata.Kubernetes.Polyfill
                 fieldSelector: $"metadata.name={value.Metadata.Name}",
                 labelSelector: null,
                 resourceVersion: value.Metadata.ResourceVersion,
+                resourceVersionMatch: null,
                 listOperation,
                 eventHandler,
                 cancellationToken);
@@ -95,6 +96,7 @@ namespace Kaponata.Kubernetes.Polyfill
             string? fieldSelector,
             string? labelSelector,
             string? resourceVersion,
+            string? resourceVersionMatch,
             ListNamespacedObjectWithHttpMessagesAsync<TObject, TList> listOperation,
             WatchEventDelegate<TObject> eventHandler,
             CancellationToken cancellationToken)
@@ -122,6 +124,7 @@ namespace Kaponata.Kubernetes.Polyfill
                 fieldSelector: fieldSelector,
                 labelSelector: labelSelector,
                 resourceVersion: resourceVersion,
+                resourceVersionMatch: resourceVersionMatch,
                 watch: true,
                 cancellationToken: cancellationToken).ConfigureAwait(false))
             {

--- a/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/ChildOperatorIntegrationTests.cs
@@ -93,7 +93,8 @@ namespace Kaponata.Operator.Tests.Operators
                 podClient.WatchAsync(
                     fieldSelector: null,
                     labelSelector: $"{Annotations.ManagedBy}={name}",
-                    null,
+                    resourceVersion: null,
+                    resourceVersionMatch: null,
                     (eventType, pod) =>
                     {
                         logger.LogInformation($"Got an added {eventType}  event for pod {pod}", eventType, pod.Metadata.Name);

--- a/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
+++ b/src/Kaponata.Operator.Tests/Operators/FakeOperatorIntegrationTests.cs
@@ -83,7 +83,8 @@ namespace Kaponata.Operator.Tests.Operators
             var sessionWatcher = sessionClient.WatchAsync(
                 $"metadata.name={name}",
                 null,
-                null,
+                resourceVersion: null,
+                resourceVersionMatch: null,
                 (eventType, session) =>
                 {
                     if (session.Metadata.Name != name)
@@ -197,7 +198,8 @@ namespace Kaponata.Operator.Tests.Operators
             var sessionWatcher = sessionClient.WatchAsync(
                 $"metadata.name={name}",
                 null,
-                null,
+                resourceVersion: null,
+                resourceVersionMatch: null,
                 (eventType, session) =>
                 {
                     if (session.Metadata.Name != name)

--- a/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
+++ b/src/Kaponata.Operator.Tests/Operators/KubernetesClientMockExtensions.cs
@@ -104,7 +104,7 @@ namespace Kaponata.Operator.Tests.Operators
         }
 
         /// <summary>
-        /// Configures the <see cref="KubernetesClient.WatchPodAsync(string, string, string, WatchEventDelegate{V1Pod}, CancellationToken)"/> method
+        /// Configures the <see cref="KubernetesClient.WatchPodAsync(string, string, string, string, WatchEventDelegate{V1Pod}, CancellationToken)"/> method
         /// on the mock.
         /// </summary>
         /// <param name="client">
@@ -125,6 +125,7 @@ namespace Kaponata.Operator.Tests.Operators
                     null /* fieldSelector */,
                     labelSelector /* labelSelector */,
                     null /* resourceVersion */,
+                    null /* resourceVersionMatch */,
                     It.IsAny<WatchEventDelegate<V1Pod>>(),
                     It.IsAny<CancellationToken>()))
                 .Callback<string, string, string, WatchEventDelegate<V1Pod>, CancellationToken>(

--- a/src/Kaponata.Operator/Operators/ChildOperator.cs
+++ b/src/Kaponata.Operator/Operators/ChildOperator.cs
@@ -453,7 +453,8 @@ namespace Kaponata.Operator.Operators
             var sourceWatch = this.parentClient.WatchAsync(
                 fieldSelector: null,
                 this.configuration.ParentLabelSelector,
-                null,
+                resourceVersion: null,
+                resourceVersionMatch: null,
                 (eventType, value) =>
                 {
                     this.logger.LogInformation("Operator {operator} got an {eventType} event for {value}", this.configuration.OperatorName, eventType, value?.Metadata?.Name);
@@ -465,7 +466,8 @@ namespace Kaponata.Operator.Operators
             var targetWatch = this.childClient.WatchAsync(
                 fieldSelector: null,
                 Selector.Create(this.configuration.ChildLabels),
-                null,
+                resourceVersion: null,
+                resourceVersionMatch: null,
                 (eventType, value) =>
                 {
                     this.logger.LogInformation("Operator {operator} got an {eventType} event for {value}", this.configuration.OperatorName, eventType, value?.Metadata?.Name);

--- a/src/Kaponata.Tests.Shared/NamespacedKubernetesClientExtensions.cs
+++ b/src/Kaponata.Tests.Shared/NamespacedKubernetesClientExtensions.cs
@@ -133,7 +133,7 @@ namespace Kaponata.Tests.Shared
         }
 
         /// <summary>
-        /// Configures the <see cref="NamespacedKubernetesClient{T}.WatchAsync(string, string, string, WatchEventDelegate{T}, CancellationToken)"/> method
+        /// Configures the <see cref="NamespacedKubernetesClient{T}.WatchAsync(string, string, string, string, WatchEventDelegate{T}, CancellationToken)"/> method
         /// on the mock.
         /// </summary>
         /// <param name="client">
@@ -161,10 +161,11 @@ namespace Kaponata.Tests.Shared
                     fieldSelector /* fieldSelector */,
                     labelSelector /* labelSelector */,
                     null /* resourceVersion */,
+                    null /* resourceVersionMatch */,
                     It.IsAny<WatchEventDelegate<T>>(),
                     It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, WatchEventDelegate<T>, CancellationToken>(
-                (fieldSelector, labelSelector, resourceVersion, eventHandler, cancellationToken) =>
+                .Callback<string, string, string, string, WatchEventDelegate<T>, CancellationToken>(
+                (fieldSelector, labelSelector, resourceVersion, resourceVersionMatch, eventHandler, cancellationToken) =>
                 {
                     cancellationToken.Register(watchClient.TaskCompletionSource.SetCanceled);
                     watchClient.ClientRegistered.SetResult(eventHandler);


### PR DESCRIPTION
Various operations (such as the list and watch operations) take a `resourceVersion` argument, which allows you to specify which version of a resource you want to retrieve.

It is possible for exact resource versions of objects the be unavailable, when these objects are not updated frequently.

In that case, we can pass `resourceVersionMatch =NotOlderThan`, allowing the cluster to return newer versions of that object.