### PR TITLE
Various fixes

### DIFF
--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Pair.cs
@@ -345,7 +345,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Returns(false);
 
             var dict = new NSDictionary();
-            dict.Add("Error", "InvalidHostBuid");
+            dict.Add("Error", "InvalidHostID");
 
             protocol
                 .Setup(p => p.ReadMessageAsync(default))

--- a/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/LockdownClientTests.Session.cs
@@ -99,7 +99,7 @@ namespace Kaponata.iOS.Tests.Lockdown
                 .Returns(Task.CompletedTask);
 
             var response = new NSDictionary();
-            response.Add("Error", nameof(LockdownError.InvalidHostBuid));
+            response.Add("Error", nameof(LockdownError.InvalidHostID));
             protocol
                 .Setup(p => p.ReadMessageAsync(default))
                 .ReturnsAsync(response);

--- a/src/Kaponata.iOS.Tests/Lockdown/PairingRecordTests.cs
+++ b/src/Kaponata.iOS.Tests/Lockdown/PairingRecordTests.cs
@@ -140,5 +140,29 @@ namespace Kaponata.iOS.Tests.Lockdown
 
             Assert.Equal(sameHashCode, record.GetHashCode() == other.GetHashCode());
         }
+
+        /// <summary>
+        /// <see cref="PairingRecord.ToString"/> works for a pairing record which is empty.
+        /// </summary>
+        [Fact]
+        public void ToString_EmptyPairingRecord()
+        {
+            var record = new PairingRecord();
+            Assert.Equal("HostId: , SystemBUID: , Host certificate:  (expires: )", record.ToString());
+        }
+
+        /// <summary>
+        /// <see cref="PairingRecord.ToString"/> works for a regular pairing record.
+        /// </summary>
+        [Fact]
+        public void ToString_ValidPairingRecord()
+        {
+            var raw = File.ReadAllText("Lockdown/0123456789abcdef0123456789abcdef01234567.plist");
+            var dict = (NSDictionary)XmlPropertyListParser.ParseString(raw);
+
+            var pairingRecord = PairingRecord.Read(dict);
+
+            Assert.Equal("HostId: 01234567-012345678901234567, SystemBUID: 01234567890123456789012345, Host certificate: EE63391AA1FBA937E2784CC7DAAA9C22BA223B54 (expires: 2026-11-28 11:20:17Z)", pairingRecord.ToString());
+        }
     }
 }

--- a/src/Kaponata.iOS/Lockdown/LockdownError.cs
+++ b/src/Kaponata.iOS/Lockdown/LockdownError.cs
@@ -25,9 +25,9 @@ namespace Kaponata.iOS.Lockdown
         GetProhibited,
 
         /// <summary>
-        /// The host BUID is invalid.
+        /// The host ID is invalid.
         /// </summary>
-        InvalidHostBuid,
+        InvalidHostID,
 
         /// <summary>
         /// The user denied the pairing request.

--- a/src/Kaponata.iOS/Lockdown/PairingRecord.cs
+++ b/src/Kaponata.iOS/Lockdown/PairingRecord.cs
@@ -159,7 +159,7 @@ namespace Kaponata.iOS.Lockdown
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"HostId: {this.HostId}, SystemBUID: {this.SystemBUID}, Host certificate: {this.HostCertificate?.Thumbprint} (expires: {this.HostCertificate?.NotAfter.ToUniversalTime():u})";
+            return $"HostId: {this.HostId}, SystemBUID: {this.SystemBUID}, Host certificate: {this.HostCertificate?.Thumbprint} (expires: {this.HostCertificate?.NotAfter:u})";
         }
 
         /// <inheritdoc/>

--- a/src/Kaponata.iOS/Lockdown/PairingRecord.cs
+++ b/src/Kaponata.iOS/Lockdown/PairingRecord.cs
@@ -157,6 +157,12 @@ namespace Kaponata.iOS.Lockdown
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"HostId: {this.HostId}, SystemBUID: {this.SystemBUID}, Host certificate: {this.HostCertificate?.Thumbprint} (expires: {this.HostCertificate?.NotAfter.ToUniversalTime():u})";
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             var other = obj as PairingRecord;


### PR DESCRIPTION
- `LockdownError`: Fix `InvalidHostID` spelling
- `PairingRecord`: Implement `.ToString()`
- `PairingRecordProvisioner`: Additional logging