### PR TITLE
UsbmuxdSidecar: Use the UDID of the device as a unique identifier

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,6 +28,7 @@
     <PackageProjectUrl>https://www.kaponata.io</PackageProjectUrl>
     <Copyright>Quamotion bv</Copyright>
     <Authors>Quamotion bv</Authors>
+    <Product>Kaponata</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Kaponata.Sidecars.Tests/UsbmuxdSidecarTests.cs
+++ b/src/Kaponata.Sidecars.Tests/UsbmuxdSidecarTests.cs
@@ -79,7 +79,7 @@ namespace Kaponata.Sidecars.Tests
 
             var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
             deviceClient
-                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar,app.kubernetes.io/instance=my-pod", null, default))
+                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar", null, default))
                 .ReturnsAsync(
                     new ItemList<MobileDevice>()
                     {
@@ -143,7 +143,7 @@ namespace Kaponata.Sidecars.Tests
 
             var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
             deviceClient
-                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar,app.kubernetes.io/instance=my-pod", null, default))
+                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar", null, default))
                 .ReturnsAsync(
                     new ItemList<MobileDevice>()
                     {
@@ -258,7 +258,7 @@ namespace Kaponata.Sidecars.Tests
 
             var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
             deviceClient
-                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar,app.kubernetes.io/instance=my-pod", null, default))
+                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar", null, default))
                 .ReturnsAsync(
                     new ItemList<MobileDevice>()
                     {
@@ -349,7 +349,7 @@ namespace Kaponata.Sidecars.Tests
 
             var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
             deviceClient
-                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar,app.kubernetes.io/instance=my-pod", null, default))
+                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar", null, default))
                 .ReturnsAsync(
                     new ItemList<MobileDevice>()
                     {
@@ -433,7 +433,7 @@ namespace Kaponata.Sidecars.Tests
             var deviceClient = new Mock<NamespacedKubernetesClient<MobileDevice>>(MockBehavior.Strict);
             deviceClient.Setup(p => p.PatchStatusAsync(kubernetesDevice, It.IsAny<JsonPatchDocument<MobileDevice>>(), default)).ReturnsAsync(kubernetesDevice);
             deviceClient
-                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar,app.kubernetes.io/instance=my-pod", null, default))
+                .Setup(d => d.ListAsync(null, null, "kubernetes.io/os=ios,app.kubernetes.io/managed-by=UsbmuxdSidecar", null, default))
                 .ReturnsAsync(
                     new ItemList<MobileDevice>()
                     {

--- a/src/Kaponata.Sidecars/Makefile
+++ b/src/Kaponata.Sidecars/Makefile
@@ -16,7 +16,10 @@ deploy: all
 	docker tag $(registry)/$(image):$(version)-amd64 $(registry)/$(image):latest-amd64
 # As an exception to the general rule, delete all usbmuxd pods since they rely on the sidecar image.
 	kubectl delete pod -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd
-  
+
+logs:
+	kubectl logs -l app.kubernetes.io/component=usbmuxd,app.kubernetes.io/name=usbmuxd --all-containers --tail=-1 --timestamps
+
 push: all
 	docker push $(registry)/$(image):$(version)-amd64
 	docker push $(registry)/$(image):$(version)-arm64


### PR DESCRIPTION
The sidecar currently selects iOS devices based on the OS, the UDID and the "owner" (= the name of the usbmuxd pod to which the device is attached).

That doesn't work well for devices which were previously attached to a pod with a different name. This can happen when the pod is re-created, or when the device is physically moved from one node to another.

Only use the OS + the UDID of the device to uniquely identifier a device.

This commit also adds more logging.