### PR TITLE
usbmuxd pod: set USBMUXD_SOCKET_ADDRESS

### DIFF
--- a/src/chart/charts/usbmuxd/templates/daemonset.yaml
+++ b/src/chart/charts/usbmuxd/templates/daemonset.yaml
@@ -51,6 +51,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: USBMUXD_SOCKET_ADDRESS
+          value: 127.0.0.1:27015
 
       # Required volumes
       volumes:


### PR DESCRIPTION
We force the usbmudx pod to listen on a TCP socket. This means that the muxer client should also connect to this TCP address. Set the `USBMUXD_SOCKET_ADDRESS` environment variable to achieve that.