### PR TITLE
usbmuxd role: Allow access to secrets

### DIFF
--- a/src/chart/charts/usbmuxd/templates/usbmuxd-role.yaml
+++ b/src/chart/charts/usbmuxd/templates/usbmuxd-role.yaml
@@ -8,6 +8,12 @@ rules:
 - apiGroups: [ "" ]
   resources: [ "pods" ]
   verbs: [ "get", "list" ]
+
 - apiGroups: [ "kaponata.io" ]
   resources: [ "mobiledevices" ]
-  verbs: [ "get", "list", "create", "delete" ]
+  verbs: [ "get", "list", "create", "delete", "watch", "patch" ]
+
+# pairing records are stored as secrets
+- apiGroups: [ "" ]
+  resources: [ "secrets" ]
+  verbs: [ "get", "list", "create", "delete", "watch", "patch" ]


### PR DESCRIPTION
The usbmuxd sidecar will store the pairing records for iOS devices as secrets in the cluster.

This commit grants the usbmuxd role access to cluster secrets.