### PR TITLE
Remove Redroid from CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -208,39 +208,6 @@ jobs:
           --wait
           kaponata
           ${{ github.workspace }}/bin/charts/kaponata-${{ steps.nbgv.outputs.SemVer2 }}.tgz || kubectl get pods
-      
-      - name: Redroid - Install the Android kernel modules
-        run: |
-          kernel=$(uname -r)
-
-          # install required packages
-          sudo apt-get install -y kmod make gcc linux-headers-$kernel
-
-          git clone https://github.com/remote-android/redroid-modules.git
-
-          cd redroid-modules
-          make
-          sudo make install
-
-      - name: Redroid - Check Android kernel module status
-        run: |
-          echo "Listing Android kernel modules. This should include 'ashmem_linux' and 'binder_linux'."
-          lsmod | grep -e ashmem_linux -e binder_linux
-
-          echo "Listing the binder file system. This should include 'nodev	binder'."
-          cat /proc/filesystems | grep binder
-
-          echo "Listing miscellaneous drivers registered on the miscellaneous major device. This should include '56 ashmem'."
-          cat /proc/misc | grep ashmem
-
-      - name: Redroid - Creating the Android pod
-        run: |
-          kubectl create -f ci/redroid.yaml
-          kubectl wait --for=condition=ready --timeout=180s pod redroid || kubectl describe pod redroid
-
-      - name: Redroid - Dump logcat output
-        if: always()
-        run: kubectl exec redroid -- logcat -d
 
       - name: Run chart tests and integration tests
         run: >


### PR DESCRIPTION
Redroid uses the ashmem and binder Linux kernel modules.

These modules are part of the Linux source tree, but not built for the Azure flavour of Ubuntu. We build them from source instead.

Unfortunately, the kernel modules use `kallsyms_lookup_name` which have been deprecated in newer versions of the Linux kernel: https://lwn.net/Articles/813350/.

The GitHub actions VMs recently started using a newer version of Linux, breaking the kernel modules required by Redroid.

This commit removes Redroid from CI until this issue is fixed upstream (e.g. via https://github.com/anbox/anbox-modules/pull/76).