### PR TITLE
Grant usbmuxd access to mobiledevice/patch

### DIFF
--- a/src/chart/charts/usbmuxd/templates/usbmuxd-role.yaml
+++ b/src/chart/charts/usbmuxd/templates/usbmuxd-role.yaml
@@ -13,6 +13,10 @@ rules:
   resources: [ "mobiledevices" ]
   verbs: [ "get", "list", "create", "delete", "watch", "patch" ]
 
+- apiGroups: [ "kaponata.io" ]
+  resources: [ "mobiledevices/status" ]
+  verbs: ["patch"]
+
 # pairing records are stored as secrets
 - apiGroups: [ "" ]
   resources: [ "secrets" ]


### PR DESCRIPTION
The usbmuxd sidecar will update the status of mobile device objects by patching the status. This is considered a separate resource by Kubernetes (`mobiledevices/status` vs `mobiledevices`).

This commit updates the role and grants the usbmuxd pod access to the `mobiledevice/status` resource.